### PR TITLE
Add reservations doc to checkout process

### DIFF
--- a/docs/developer/checkout.mdx
+++ b/docs/developer/checkout.mdx
@@ -380,6 +380,31 @@ mutation {
 }
 ```
 
+## Stock reservations
+
+While stock availability is checked on every step of the checkout process no guarantee is made to the client that stock will not be sold out before checkout completion. In case when item with limited stock was added to multiple checkouts, it will be allocated to first completed checkout causing remaining checkouts to fail to advance to the next step even if they were created before the completed one, with the `INSUFFICIENT_STOCK` error being returned by the API.
+
+Saleor implements optional stock reservations feature where stock will be eagerly allocated to the checkout for configured time.
+
+### Enabling reservations
+
+TODO after I'll learn how this will be done in dashboard
+
+### Mechanism of action
+
+If user A adds last two items to their checkout, those two items will become purchaseable only by them for given time.
+
+Those two items will also be subtracted from the available quantity displayed to other users on store, giving them immediate feedback that item they are interested in is currently not available, preventing them from adding this item to their own checkouts.
+
+If user A completes their checkout within given time, temporary allocation will be converted into permanent one. But if they don't complete their stock within the time limit, their stock reservation will expire and the two items in their checkout will become available for other users to add to their own checkouts. 
+
+If no other user will add this item to their checkout user A will still be able to complete their checkout. But if other user adds one or two items to their checkout, new reservation will be created for them, reducing quantity available to other users and preventing user A from completing their checkout.
+
+### Testing checkout for reservations
+
+`Checkout` type in GraphQL API has `stockReservationExpires` field which returns datetime of stock reservation expiration in ISO-8601 format or `null` when checkout has no active reservations.
+
+
 ## Shipping
 This step is only used if purchased items require shipping (if they are physical products). The user must select a specific shipping method to create shipping for this checkout. To signify whether shipping is required, use the `isShippingRequired` field in the [`Checkout`](developer/api-reference/objects/checkout.mdx) object.
 

--- a/docs/developer/checkout.mdx
+++ b/docs/developer/checkout.mdx
@@ -388,7 +388,9 @@ Saleor implements optional stock reservations feature where stock will be eagerl
 
 ### Enabling reservations
 
-TODO after I'll learn how this will be done in dashboard
+To enable reservations, navigate to "Site settings" page in the dashboard. Here, in the "Checkout Configuration" section you'll find controls allowing you to enable stock reservations for authenticated and anonymous checkouts.
+
+To disable stock reservations, clear both controls.
 
 ### Mechanism of action
 


### PR DESCRIPTION
This PR expands checkout documentation with description of reservations feature and their behavior.

Preview: https://saleor-docs-git-checkout-stock-reservations-saleorcommerce.vercel.app/docs/3.0/developer/checkout#stock-reservations

Related: https://github.com/mirumee/saleor/pull/7589