### PR TITLE
Command for PostgresSQL should specify the user

### DIFF
--- a/versioned_docs/version-2.9.0/getting-started/installation-macos.md
+++ b/versioned_docs/version-2.9.0/getting-started/installation-macos.md
@@ -100,7 +100,7 @@ The secret key should be a unique string that only your team knows. Running the 
 Unless configured otherwise, the store will use `saleor` as both the username and password. Remember to assign your user the `SUPERUSER` privilege. This will allow you to create databases and database extensions.
 
 ```shell-session
-createuser --superuser --pwprompt saleor
+sudo -u postgres createuser --superuser --pwprompt saleor
 ```
 
 Enter `saleor` when prompted for password.
@@ -112,7 +112,7 @@ The database name is extracted from the `DATABASE_URL` environment variable. If 
 :::
 
 ```shell-session
-createdb saleor
+sudo -u postgres createdb saleor
 ```
 
 ### 7. Prepare the database


### PR DESCRIPTION
Command for PostgresSQL should specify the user of PostgresSQL. Since it default using `postgres `as username and the postgres-cli would use the username of the unix user to login (which normally won't be `postgres`) causing the command failed to execute.