### PR TITLE
Fix little name errors

### DIFF
--- a/docs/developer/extending/plugins.mdx
+++ b/docs/developer/extending/plugins.mdx
@@ -100,7 +100,7 @@ Make sure that each plugin inherits from the `BasePlugin` class and that it over
 You can write your plugin as a class which has callable instances, like the one below:
 
 ```python
-# custom/plugin.py
+# custom_plugin/plugin.py
 
 from django.conf import settings
 from urllib.parse import urljoin
@@ -169,7 +169,7 @@ from django.conf import settings
 
 
 @shared_task
-def api_post_request(
+def api_post_request_task(
     url: str,
     data: Dict[str, Any],
 ):


### PR DESCRIPTION
Hi! I think I found two little name mistakes in the extending plugins page