### PR TITLE
Fix incorrect field value on ShippingAddressUpdate

### DIFF
--- a/docs/developer/checkout.mdx
+++ b/docs/developer/checkout.mdx
@@ -443,7 +443,7 @@ Address can be assigned using the [`checkoutShippingAddressUpdate`](developer/ap
 ```graphql
 mutation {
   checkoutShippingAddressUpdate(
-    billingAddress: {
+    shippingAddress: {
       country: PL
       firstName: "John"
       lastName: "Smith"
@@ -454,7 +454,7 @@ mutation {
     token: "58f4ca17-9c6f-437b-8204-beb47bbee364"
   ) {
     checkout {
-      billingAddress {
+      shippingAddress {
         firstName
         lastName
         streetAddress1
@@ -477,7 +477,7 @@ Successful response:
   "data": {
     "checkoutShippingAddressUpdate": {
       "checkout": {
-        "billingAddress": {
+        "shippingAddress": {
           "firstName": "John",
           "lastName": "Smith",
           "streetAddress1": "ul. Tęczowa 7",


### PR DESCRIPTION
Currently the shown mutation is `ShippingAddressUpdate`, but the field used on the example is `billingAddress` instead of `shippingAddress`