### PR TITLE
Update CORS config to JSON

### DIFF
--- a/versioned_docs/version-2.11/developer/running-saleor/s3.mdx
+++ b/versioned_docs/version-2.11/developer/running-saleor/s3.mdx
@@ -39,15 +39,21 @@ Custom domain will allow you to use your CloudFront distribution or the public d
 
 You need to configure your S3 bucket to allow cross-origin requests for some files to be properly served (SVG files, Javascript files, etc.). To do this, set the below instructions in your S3 Bucket’s permissions tab, under the [CORS section](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html).
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-  <CORSRule>
-    <AllowedOrigin>*</AllowedOrigin>
-    <AllowedMethod>GET</AllowedMethod>
-    <AllowedMethod>HEAD</AllowedMethod>
-    <MaxAgeSeconds>3000</MaxAgeSeconds>
-    <AllowedHeader>*</AllowedHeader>
-  </CORSRule>
-</CORSConfiguration>
+```json
+[
+    {
+        "AllowedHeaders": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "GET",
+            "HEAD"
+        ],
+        "AllowedOrigins": [
+            "*"
+        ],
+        "ExposeHeaders": [],
+        "MaxAgeSeconds": 3000
+    }
+]
 ```


### PR DESCRIPTION
From now on, AWS S3 Buckets CORS configuration only accepts parameters as JSON.