### PR TITLE
Fix TOC

### DIFF
--- a/docs/developer.mdx
+++ b/docs/developer.mdx
@@ -15,8 +15,8 @@ Whether you're building a custom-branded storefront or looking for ways to exten
 
 - [**Error Handling**](developer/api-conventions/error-handling.mdx): handle error conditions.
 - [**Pagination**](developer/api-conventions/pagination.mdx): learn how to traverse large datasets.
-- [**Prices**](developer/api-conventions/error-handling.mdx): models used for keeping prices.
-- [**Translations**](developer/api-conventions/error-handling.mdx): translating your shop.
+- [**Prices**](developer/api-conventions/prices.mdx): models used for keeping prices.
+- [**Translations**](developer/api-conventions/translations.mdx): translating your shop.
 
 ## Development
 


### PR DESCRIPTION
For some reason, `Prices` and `Translations` links led to the `Error Handling` page incorrectly, so this PR fixes that.