### PR TITLE
Fix environment variable used to store static files in Google Cloud Storage

### DIFF
--- a/docs/developer/running-saleor/gcs.mdx
+++ b/docs/developer/running-saleor/gcs.mdx
@@ -26,13 +26,13 @@ This integration allows you to delegate storing such files to [Google Cloud Stor
 
 "Media files" are the files uploaded through the dashboard. They include product images, category images, and non-image files.
 
-If you want to use BGC to store and serve media files, you need to configure at least the bucket name (see table above).
+If you want to use GCS to store and serve media files, you need to configure at least the media bucket name (GS_MEDIA_BUCKET_NAME).
 
 ## Serving static files from a GCS bucket
 
 "Static files" are assets required for Saleor to operate. They include assets used in default email templates.
 
-If you also intend to use GCS for your static files, you need to configure at least the bucket name (see table above).
+If you also intend to use GCS for your static files, you need to configure at least the bucket name (GS_BUCKET_NAME).
 
 ## Cross-Origin Resource Sharing
 

--- a/docs/developer/running-saleor/gcs.mdx
+++ b/docs/developer/running-saleor/gcs.mdx
@@ -13,7 +13,7 @@ This integration allows you to delegate storing such files to [Google Cloud Stor
 | `GOOGLE_APPLICATION_CREDENTIALS` | Set an environment variable to a path of the json file.                                                                   |
 | `GS_CREDENTIALS`                 | Optional. Use the OAuth 2 credentials for the connection. Default is to infer them from `GOOGLE_APPLICATION_CREDENTIALS`. |
 | `GS_MEDIA_BUCKET_NAME`           | The GCS bucket name to use for media files.                                                                               |
-| `GS_STORAGE_BUCKET_NAME`         | The GCS bucket name to use for static files.                                                                              |
+| `GS_BUCKET_NAME`                 | The GCS bucket name to use for static files.                                                                              |
 | `GS_MEDIA_CUSTOM_ENDPOINT`       | A custom endpoint to be used instead of https://storage.googleapis.com                                                    |
 | `GS_EXPIRATION`                  | The number of seconds that a generated signed URL is valid for  . Defaults to 86400 secondes (1 day)                      |
 | `GS_QUERYSTRING_AUTH`            | Setting this to `True`, enables query parameter authentication i.e, signed URLs for the static bucket. Defaults to `False`|


### PR DESCRIPTION
### Link to docs page
[https://docs.saleor.io/docs/3.x/developer/running-saleor/gcs#environment-variables](https://docs.saleor.io/docs/3.x/developer/running-saleor/gcs#environment-variables)

### Problem
Table contains entry ```GS_STORAGE_BUCKET_NAME``` as "The GCS bucket name to use for static files.".
The environment variable should be ```GS_BUCKET_NAME```.

### Proposed changes
- Changed the environment variable from ```GS_STORAGE_BUCKET_NAME``` to ```GS_BUCKET_NAME```.
- Change wording to better convey the environment variable required for either media or static file storage.