### PR TITLE
Fix link to point at playground

### DIFF
--- a/docs/developer/checkout.mdx
+++ b/docs/developer/checkout.mdx
@@ -6,7 +6,7 @@ title: Cart and Checkout
 
 The below process describes the key milestones in the checkout process flow in Saleor. There are also additional steps that may occur along the way; however, the purpose of this instruction is to deliver a base reference for the user to work with. We assume that at this stage, you have already completed the steps included in the [Getting Started](getting-started/graphql.mdx) section of this chapter and that you are familiar with the basic setup of the Saleor GraphQL API.
 
-The code snippets included in this section may be run in [Playground](getting-started/graphql) or your preferred HTTP client.
+The code snippets included in this section may be run in [Playground](https://demo.saleor.io/graphql/) or your preferred HTTP client.
 
 ### Why is there no cart model?
 


### PR DESCRIPTION
I think the second link should point at the https://demo.saleor.io/graphql/, rather than the getting started docs.