### PR TITLE
Clean up tax webhook docs

### DIFF
--- a/docs/developer/extending/apps/synchronous-webhooks/tax-webhooks.mdx
+++ b/docs/developer/extending/apps/synchronous-webhooks/tax-webhooks.mdx
@@ -211,7 +211,7 @@ For example, the amount of 12,34 USD will be sent as `"total_amount": "12.34"`
 
 3. `shipping_price_net_amount` - Net price of shipping.
 4. `lines` - List of lines tax assigned to checkout. Lines should be returned in the same order in which they were sent to the app.
-   1. `tax_rate` - Tax rate value provided as percentage. Example: provide `23` to represent `23%` tax rate.
+   1. `tax_rate` - Tax rate value provided as percentage. Example: provide `23` to represent the `23%` tax rate.
    2. `total_gross_amount` - Gross price of the line.
    3. `total_net_amount` - Net price of the line.
 
@@ -352,6 +352,6 @@ For example, the amount of 12,34 USD will be sent as `"total_amount": "12.34"`
 
 3. `shipping_price_net_amount` - Net price of shipping.
 4. `lines` - List of line taxes assigned to order. Lines should be returned in the same order in which they were sent to the app.
-   1. `tax_rate` - Tax rate value provided as percentage. Example: provide `23` to represent `23%` tax rate.
+   1. `tax_rate` - Tax rate value provided as percentage. Example: provide `23` to represent the `23%` tax rate.
    2. `total_gross_amount` - Gross price of the line.
    3. `total_net_amount` - Net price of the line.

--- a/docs/developer/extending/apps/synchronous-webhooks/tax-webhooks.mdx
+++ b/docs/developer/extending/apps/synchronous-webhooks/tax-webhooks.mdx
@@ -61,7 +61,7 @@ sequenceDiagram
 | `CHECKOUT_CALCULATE_TAXES` | Calculates taxes for checkout |
 | `ORDER_CALCULATE_TAXES`    | Calculates taxes for order    |
 
-# Checkout taxes
+## Checkout taxes
 
 Saleor Apps can subscribe to the `CHECKOUT_CALCULATE_TAXES` synchronous webhook. It is called whenever any user fetches checkout prices that are expired or not calculated yet. The response is processed and saved on checkout and checkout lines. Prices can expire or be invalidated by any change in checkout. Any tax app is treated as the source of truth about pricing.
 
@@ -76,9 +76,9 @@ For example, the amount of 12,34 USD will be sent as `"total_amount": "12.34"`
 - Shipping vouchers are included in shipping prices.
 - Vouchers for "Specific products" are included in line prices.
 - Vouchers "Apply only to a single cheapest eligible product" are included in line prices.
-  :::
+:::
 
-## Request format
+### Request format
 
 ```json
 [
@@ -153,7 +153,7 @@ For example, the amount of 12,34 USD will be sent as `"total_amount": "12.34"`
 ]
 ```
 
-### Fields:
+#### Fields:
 
 1. `id` - Id of the checkout for which the app should calculate taxes.
 2. `included_taxes_in_prices` - Flag that shows whether taxes should be included in prices.
@@ -182,7 +182,7 @@ For example, the amount of 12,34 USD will be sent as `"total_amount": "12.34"`
     11. `quantity` - Quantity of the item in the line.
     12. `total_amount` - Total price of the line.
 
-## Response format
+### Response format
 
 ```json
 {
@@ -204,18 +204,18 @@ For example, the amount of 12,34 USD will be sent as `"total_amount": "12.34"`
 }
 ```
 
-### Fields:
+#### Fields:
 
 1. `shipping_tax_rate` - Tax rate of shipping.
 2. `shipping_price_gross_amount` - The gross price of shipping.
 
 3. `shipping_price_net_amount` - Net price of shipping.
 4. `lines` - List of lines tax assigned to checkout. Lines should be returned in the same order in which they were sent to the app.
-   1. `tax_rate` - Tax rate of the line.
+   1. `tax_rate` - Tax rate value provided as percentage. Example: provide `23` to represent `23%` tax rate.
    2. `total_gross_amount` - Gross price of the line.
    3. `total_net_amount` - Net price of the line.
 
-# Order taxes
+## Order taxes
 
 Saleor Apps can subscribe to the `ORDER_CALCULATE_TAXES` synchronous webhook. It is called whenever any user fetches order prices that are expired or not calculated yet. The response from the app is processed and saved on order and order lines. Prices can expire or be invalidated by any change in order. Any tax app is treated as the source of truth about pricing.
 
@@ -230,9 +230,9 @@ For example, the amount of 12,34 USD will be sent as `"total_amount": "12.34"`
 - Shipping vouchers are included in shipping prices.
 - Vouchers for "Specific products" are included in line prices.
 - Vouchers "Apply only to a single cheapest eligible product" are included in line prices.
-  :::
+:::
 
-## Request format
+### Request format
 
 ```json
 [
@@ -294,7 +294,7 @@ For example, the amount of 12,34 USD will be sent as `"total_amount": "12.34"`
 ]
 ```
 
-### Fields:
+#### Fields:
 
 1. `id` - Id of the order for which the app should calculate taxes.
 2. `included_taxes_in_prices` - Flag that shows whether taxes should be included in prices.
@@ -323,7 +323,7 @@ For example, the amount of 12,34 USD will be sent as `"total_amount": "12.34"`
     11. `quantity` - Quantity of the item in the line.
     12. `total_amount` - Total price of the line.
 
-## Response format
+### Response format
 
 ```json
 {
@@ -345,13 +345,13 @@ For example, the amount of 12,34 USD will be sent as `"total_amount": "12.34"`
 }
 ```
 
-### Fields:
+#### Fields:
 
 1. `shipping_tax_rate` - Tax rate of shipping.
 2. `shipping_price_gross_amount` - Gross price of shipping.
 
 3. `shipping_price_net_amount` - Net price of shipping.
 4. `lines` - List of line taxes assigned to order. Lines should be returned in the same order in which they were sent to the app.
-   1. `tax_rate` - Tax rate of the line.
+   1. `tax_rate` - Tax rate value provided as percentage. Example: provide `23` to represent `23%` tax rate.
    2. `total_gross_amount` - Gross price of the line.
    3. `total_net_amount` - Net price of the line.

--- a/docs/developer/extending/apps/synchronous-webhooks/tax-webhooks.mdx
+++ b/docs/developer/extending/apps/synchronous-webhooks/tax-webhooks.mdx
@@ -54,7 +54,7 @@ sequenceDiagram
     Saleor -->>- User: Return model's prices
 ```
 
-## Available payment events are:
+## Available taxes events
 
 | Name                       | Description                   |
 | -------------------------- | ----------------------------- |


### PR DESCRIPTION
- Fix incorrect ending a warning section
- Fix incorrect header markings
- Add more context to tax_rate field
- Fix sidebar:
Was:
![image](https://user-images.githubusercontent.com/23282005/182808652-ce2eae23-037e-4e34-aee4-a8dc22b49981.png)
After PR:
![image](https://user-images.githubusercontent.com/23282005/182808723-7c232ba0-81bc-4e68-92f1-4a4d5791ebb6.png)

