### PR TITLE
fix wording in cart models explanation

### DIFF
--- a/docs/developer/checkout.mdx
+++ b/docs/developer/checkout.mdx
@@ -10,7 +10,7 @@ The code snippets included in this section may be run in [Playground](getting-st
 
 ### Why is there no cart model?
 
-Saleor has no separated object type for shopping carts and baskets. We wanted the same features—like discounts, vouchers, address-specific taxes, and shipping estimates—to be available in the cart and the checkout, so we've decided to use the same object type for both.
+Saleor has no separated object type for shopping carts and checkouts. We wanted the same features—like discounts, vouchers, address-specific taxes, and shipping estimates—to be available in the cart and the checkout, so we've decided to use the same object type for both.
 Checkout provides the interface for standard cart operations like adding products or promo codes. It can also be completed in almost any order, for example, saving a billing address before adding any items.
 
 ### Glossary


### PR DESCRIPTION
Shopping cart is a bigger basket on wheels, I think in this context the author meant `checkout`.