### PR TITLE
Reordering warehouses within channel and allocation strategies

### DIFF
--- a/docs/developer/api-reference/enums/allocation-strategy-enum.mdx
+++ b/docs/developer/api-reference/enums/allocation-strategy-enum.mdx
@@ -1,0 +1,26 @@
+---
+id: allocation-strategy-enum
+title: AllocationStrategyEnum
+hide_table_of_contents: false
+---
+
+Determine the allocation strategy for the channel.
+
+    PRIORITIZE_SORTING_ORDER - the allocation is prioritized by the warehouses' sort
+    order within the channel
+
+    PRIORITIZE_HIGH_STOCK - the allocation is prioritized by the highest available
+    quantity in stocks
+
+```graphql
+enum AllocationStrategyEnum {
+  PRIORITIZE_SORTING_ORDER
+  PRIORITIZE_HIGH_STOCK
+}
+```
+
+### Values
+
+#### [`PRIORITIZE_SORTING_ORDER`](#)
+
+#### [`PRIORITIZE_HIGH_STOCK`](#)

--- a/docs/developer/api-reference/enums/allocation-strategy-enum.mdx
+++ b/docs/developer/api-reference/enums/allocation-strategy-enum.mdx
@@ -6,11 +6,10 @@ hide_table_of_contents: false
 
 Determine the allocation strategy for the channel.
 
-    PRIORITIZE_SORTING_ORDER - the allocation is prioritized by the warehouses' sort
-    order within the channel
+    PRIORITIZE_SORTING_ORDER - allocate stocks according to the warehouses' order
+    within the channel
 
-    PRIORITIZE_HIGH_STOCK - the allocation is prioritized by the highest available
-    quantity in stocks
+    PRIORITIZE_HIGH_STOCK - allocate stock in a warehouse with the most stock
 
 ```graphql
 enum AllocationStrategyEnum {

--- a/docs/developer/api-reference/inputs/channel-create-input.mdx
+++ b/docs/developer/api-reference/inputs/channel-create-input.mdx
@@ -9,6 +9,7 @@ No description
 ```graphql
 input ChannelCreateInput {
   isActive: Boolean
+  stockSettings: StockSettingsInput
   addShippingZones: [ID!]
   addWarehouses: [ID!]
   name: String!
@@ -23,6 +24,14 @@ input ChannelCreateInput {
 #### [`isActive`](#) ([`Boolean`](../../../developer/api-reference/scalars/boolean))
 
 isActive flag.
+
+#### [`stockSettings`](#) ([`StockSettingsInput`](../../../developer/api-reference/inputs/stock-settings-input))
+
+The channel stock settings.
+
+Added in Saleor 3.7.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 #### [`addShippingZones`](#) ([`[ID!]`](../../../developer/api-reference/scalars/id))
 

--- a/docs/developer/api-reference/inputs/channel-update-input.mdx
+++ b/docs/developer/api-reference/inputs/channel-update-input.mdx
@@ -9,6 +9,7 @@ No description
 ```graphql
 input ChannelUpdateInput {
   isActive: Boolean
+  stockSettings: StockSettingsInput
   addShippingZones: [ID!]
   addWarehouses: [ID!]
   name: String
@@ -24,6 +25,14 @@ input ChannelUpdateInput {
 #### [`isActive`](#) ([`Boolean`](../../../developer/api-reference/scalars/boolean))
 
 isActive flag.
+
+#### [`stockSettings`](#) ([`StockSettingsInput`](../../../developer/api-reference/inputs/stock-settings-input))
+
+The channel stock settings.
+
+Added in Saleor 3.7.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 #### [`addShippingZones`](#) ([`[ID!]`](../../../developer/api-reference/scalars/id))
 

--- a/docs/developer/api-reference/inputs/stock-settings-input.mdx
+++ b/docs/developer/api-reference/inputs/stock-settings-input.mdx
@@ -1,0 +1,19 @@
+---
+id: stock-settings-input
+title: StockSettingsInput
+hide_table_of_contents: false
+---
+
+No description
+
+```graphql
+input StockSettingsInput {
+  allocationStrategy: AllocationStrategyEnum!
+}
+```
+
+### Fields
+
+#### [`allocationStrategy`](#) ([`AllocationStrategyEnum!`](../../../developer/api-reference/enums/allocation-strategy-enum))
+
+Allocation strategy options. Strategy defines the preference of warehouses for allocations and reservations.

--- a/docs/developer/api-reference/mutations/channel-reorder-warehouses.mdx
+++ b/docs/developer/api-reference/mutations/channel-reorder-warehouses.mdx
@@ -1,0 +1,42 @@
+---
+id: channel-reorder-warehouses
+title: channelReorderWarehouses
+hide_table_of_contents: false
+---
+
+Reorder the warehouses of a channel.
+
+Added in Saleor 3.7.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
+Requires one of the following permissions: MANAGE_CHANNELS.
+
+```graphql
+channelReorderWarehouses(
+  channelId: ID!
+  moves: [ReorderInput!]!
+): ChannelReorderWarehouses
+```
+
+### Arguments
+
+#### [`channelId`](#) ([`ID!`](../../../developer/api-reference/scalars/id))
+
+ID of a channel.
+
+#### [`moves`](#) ([`[ReorderInput!]!`](../../../developer/api-reference/inputs/reorder-input))
+
+The list of reordering operations for given channel warehouses.
+
+### Type
+
+#### [`ChannelReorderWarehouses`](../../../developer/api-reference/objects/channel-reorder-warehouses)
+
+Reorder the warehouses of a channel.
+
+Added in Saleor 3.7.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
+Requires one of the following permissions: MANAGE_CHANNELS.

--- a/docs/developer/api-reference/mutations/channel-reorder-warehouses.mdx
+++ b/docs/developer/api-reference/mutations/channel-reorder-warehouses.mdx
@@ -27,7 +27,7 @@ ID of a channel.
 
 #### [`moves`](#) ([`[ReorderInput!]!`](../../../developer/api-reference/inputs/reorder-input))
 
-The list of reordering operations for given channel warehouses.
+The list of reordering operations for the given channel warehouses.
 
 ### Type
 

--- a/docs/developer/api-reference/objects/channel-reorder-warehouses.mdx
+++ b/docs/developer/api-reference/objects/channel-reorder-warehouses.mdx
@@ -1,0 +1,28 @@
+---
+id: channel-reorder-warehouses
+title: ChannelReorderWarehouses
+hide_table_of_contents: false
+---
+
+Reorder the warehouses of a channel.
+
+Added in Saleor 3.7.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
+Requires one of the following permissions: MANAGE_CHANNELS.
+
+```graphql
+type ChannelReorderWarehouses {
+  channel: Channel
+  errors: [ChannelError!]!
+}
+```
+
+### Fields
+
+#### [`channel`](#) ([`Channel`](../../../developer/api-reference/objects/channel))
+
+Channel within the warehouses are reordered.
+
+#### [`errors`](#) ([`[ChannelError!]!`](../../../developer/api-reference/objects/channel-error))

--- a/docs/developer/api-reference/objects/channel.mdx
+++ b/docs/developer/api-reference/objects/channel.mdx
@@ -20,6 +20,7 @@ type Channel implements Node {
   availableShippingMethodsPerCountry(
     countries: [CountryCode!]
   ): [ShippingMethodsPerCountry!]
+  stockSettings: StockSettings!
 }
 ```
 
@@ -90,6 +91,16 @@ Added in Saleor 3.6.
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 - ##### [`countries`](#) ([`[CountryCode!]`](../../../developer/api-reference/enums/country-code))
+
+#### [`stockSettings`](#) ([`StockSettings!`](../../../developer/api-reference/objects/stock-settings))
+
+Define the stock setting for this channel.
+
+Added in Saleor 3.7.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
+Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
 
 ### Interfaces
 

--- a/docs/developer/api-reference/objects/stock-settings.mdx
+++ b/docs/developer/api-reference/objects/stock-settings.mdx
@@ -1,0 +1,23 @@
+---
+id: stock-settings
+title: StockSettings
+hide_table_of_contents: false
+---
+
+Represents the channel stock settings.
+
+Added in Saleor 3.7.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
+```graphql
+type StockSettings {
+  allocationStrategy: AllocationStrategyEnum!
+}
+```
+
+### Fields
+
+#### [`allocationStrategy`](#) ([`AllocationStrategyEnum!`](../../../developer/api-reference/enums/allocation-strategy-enum))
+
+Allocation strategy options. Strategy defines the preference of warehouses for allocations and reservations.

--- a/docs/developer/api-reference/objects/stock-settings.mdx
+++ b/docs/developer/api-reference/objects/stock-settings.mdx
@@ -20,4 +20,4 @@ type StockSettings {
 
 #### [`allocationStrategy`](#) ([`AllocationStrategyEnum!`](../../../developer/api-reference/enums/allocation-strategy-enum))
 
-Allocation strategy options. Strategy defines the preference of warehouses for allocations and reservations.
+Allocation strategy defines the preference of warehouses for allocations and reservations.

--- a/docs/developer/channels.mdx
+++ b/docs/developer/channels.mdx
@@ -278,7 +278,7 @@ The warehouses assigned to the channel can be sorted. The provided order defines
 warehouses' order used in `PRIORITIZE_SORTING_ORDER`
 [allocation strategy](developer/stock-allocation.mdx#allocation-strategies).
 The `sort_order` in `moves` input represents the new relative position of the item.
-So when 1 is provided the item will be moved one position forward, when -1 - the one
+So when 1 is provided, the item will be moved one position forward; when -1 - one
 position backward.
 
 Let's assume that we have a `channel` with three channels in the following order.
@@ -344,7 +344,7 @@ mutation {
 }
 ```
 
-And as a response we get:
+And as a response, we get:
 
 ```json
 {

--- a/docs/developer/channels.mdx
+++ b/docs/developer/channels.mdx
@@ -47,7 +47,8 @@ Available fields:
 - `defaultCountry`: Default country for the channel. The default country will be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided, either as a query parameter or through a shipping address.
 - `hasOrders`: Returns `true` when there are already created orders using that channel. If that's the only channel using this currency, you won't be able to remove it.
 - `warehouses`: Warehouses that are available in the given channel.
-- `stockSettings`: contains all stock-related settings, f.e. the allocation strategy for the channel.
+- `stockSettings`: contains all stock-related settings,
+  f.e. the [allocation strategy](developer/stock-allocation.mdx#allocation-strategies) for the channel.
 
 Request:
 
@@ -274,7 +275,8 @@ Response:
 ## Reorder warehouses within channels
 
 The warehouses assigned to the channel can be sorted. The provided order defines the
-warehouses' order used in `PRIORITIZE_SORTING_ORDER` allocation strategy.
+warehouses' order used in `PRIORITIZE_SORTING_ORDER`
+[allocation strategy](developer/stock-allocation.mdx#allocation-strategies).
 The `sort_order` in `moves` input represents the new relative position of the item.
 So when 1 is provided the item will be moved one position forward, when -1 - the one
 position backward.

--- a/docs/developer/channels.mdx
+++ b/docs/developer/channels.mdx
@@ -314,10 +314,12 @@ mutation {
     channelId: "Q2hhbm5lbDox"
     moves: [
       {
+        # move for `americas` warehouse
         id: "V2FyZWhvdXNlOjY4M2FkMzZhLTRmNjktNDI2ZS1iYzUyLTMyZGJiZTQ2NjUyZA=="
         sortOrder: -2
       }
       {
+        # move for `europe` warehouse
         id: "V2FyZWhvdXNlOjU1NTZiOWI0LTc1ZTItNGI3YS1hZWM1LTQxOTY4NDA2OGE4OA=="
         sortOrder: 1
       }

--- a/docs/developer/channels.mdx
+++ b/docs/developer/channels.mdx
@@ -47,6 +47,7 @@ Available fields:
 - `defaultCountry`: Default country for the channel. The default country will be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided, either as a query parameter or through a shipping address.
 - `hasOrders`: Returns `true` when there are already created orders using that channel. If that's the only channel using this currency, you won't be able to remove it.
 - `warehouses`: Warehouses that are available in the given channel.
+- `stockSettings`: contains all stock-related settings, f.e. the allocation strategy for the channel.
 
 Request:
 
@@ -64,6 +65,9 @@ query {
     hasOrders
     warehouses {
       slug
+    }
+    stockSettings {
+      allocationStrategy
     }
   }
 }
@@ -93,6 +97,9 @@ Response:
           "slug": "europe"
         }
       ]
+      "stockSettings": {
+        "allocationStrategy": "PRIORITIZE_HIGH_STOCK"
+      }
     }
   }
 ```
@@ -100,6 +107,10 @@ Response:
 ## Creating a new channel
 
 You can create a new channel using [`channelCreate`](developer/api-reference/mutations/channel-create.mdx) mutation.
+During checkout creation, you can define the allocation strategy. Right now the
+two possible options are available: `PRIORITIZE_HIGH_STOCK` and `PRIORITIZE_SORTING_ORDER`,
+the `PRIORITIZE_SORTING_ORDER` strategy is used as default.
+You can read more about the allocation strategies [`here`](developer/stock-allocation.mdx#allocation-strategies).
 
 Request:
 
@@ -111,6 +122,7 @@ mutation {
       defaultCountry: US
       name: "Mobile"
       slug: "mobile"
+      stockSettings: { allocationStrategy: PRIORITIZE_HIGH_STOCK }
     }
   ) {
     channel {
@@ -122,6 +134,9 @@ mutation {
       defaultCountry {
         code
         country
+      }
+      stockSettings {
+        allocationStrategy
       }
     }
     errors {
@@ -148,6 +163,9 @@ Response:
         "defaultCountry": {
           "code": "US",
           "country": "United States of America"
+        },
+        "stockSettings": {
+          "allocationStrategy": "PRIORITIZE_HIGH_STOCK"
         }
       },
       "errors": []
@@ -248,6 +266,104 @@ Response:
         "isActive": true
       },
       "channelErrors": []
+    }
+  }
+}
+```
+
+## Reorder warehouses within channels
+
+The warehouses assigned to the channel can be sorted. The provided order defines the
+warehouses' order used in `PRIORITIZE_SORTING_ORDER` allocation strategy.
+The `sort_order` in `moves` input represents the new relative position of the item.
+So when 1 is provided the item will be moved one position forward, when -1 - the one
+position backward.
+
+Let's assume that we have a `channel` with three channels in the following order.
+
+```json
+{
+  "data": {
+    "channel": {
+      "id": "Q2hhbm5lbDox",
+      "warehouses": [
+        {
+          "id": "V2FyZWhvdXNlOjU1NTZiOWI0LTc1ZTItNGI3YS1hZWM1LTQxOTY4NDA2OGE4OA==",
+          "slug": "europe"
+        },
+        {
+          "id": "V2FyZWhvdXNlOjQwZWY1MTQwLWQ5OTYtNDVlNy04NzUzLTlkZThkMTdhMjg1Yw==",
+          "slug": "oceania"
+        },
+        {
+          "id": "V2FyZWhvdXNlOjY4M2FkMzZhLTRmNjktNDI2ZS1iYzUyLTMyZGJiZTQ2NjUyZA==",
+          "slug": "americas"
+        }
+      ]
+    }
+  }
+}
+```
+
+To move the `americas` warehouse to the first place and the `europe` warehouse to
+third, we can run the following mutation.
+
+```graphql
+mutation {
+  channelReorderWarehouses(
+    channelId: "Q2hhbm5lbDox"
+    moves: [
+      {
+        id: "V2FyZWhvdXNlOjY4M2FkMzZhLTRmNjktNDI2ZS1iYzUyLTMyZGJiZTQ2NjUyZA=="
+        sortOrder: -2
+      }
+      {
+        id: "V2FyZWhvdXNlOjU1NTZiOWI0LTc1ZTItNGI3YS1hZWM1LTQxOTY4NDA2OGE4OA=="
+        sortOrder: 1
+      }
+    ]
+  ) {
+    channel {
+      id
+      warehouses {
+        id
+        slug
+      }
+    }
+    errors {
+      field
+      code
+      message
+      warehouses
+    }
+  }
+}
+```
+
+And as a response we get:
+
+```json
+{
+  "data": {
+    "channelReorderWarehouses": {
+      "channel": {
+        "id": "Q2hhbm5lbDox",
+        "warehouses": [
+          {
+            "id": "V2FyZWhvdXNlOjY4M2FkMzZhLTRmNjktNDI2ZS1iYzUyLTMyZGJiZTQ2NjUyZA==",
+            "slug": "americas"
+          },
+          {
+            "id": "V2FyZWhvdXNlOjQwZWY1MTQwLWQ5OTYtNDVlNy04NzUzLTlkZThkMTdhMjg1Yw==",
+            "slug": "oceania"
+          },
+          {
+            "id": "V2FyZWhvdXNlOjU1NTZiOWI0LTc1ZTItNGI3YS1hZWM1LTQxOTY4NDA2OGE4OA==",
+            "slug": "europe"
+          }
+        ]
+      },
+      "errors": []
     }
   }
 }

--- a/docs/developer/stock-allocation.mdx
+++ b/docs/developer/stock-allocation.mdx
@@ -18,6 +18,8 @@ to provide the expected allocation. Below you can find the explanation of the te
   can be defined as the collection point
 - stock - corresponds to resources of specific product variant in the given warehouse
 - allocation - corresponds to the currently allocated stocks for a given order line
+- allocation strategy - defines the preferences of warehouses for stock allocation
+  and reservations
 
 The relations between the mentioned entities are shown in the chart below:
 
@@ -41,13 +43,34 @@ classDiagram
     class Warehouse{
       click_and_collect_option: String
     }
+    class Channel{
+      allocationStrategy: String
+    }
 ```
+
+### Allocation strategies
+
+The allocation strategies allow defining the rule that is used during the stock
+allocation. At this moment two possible options are available:
+
+- Prioritize warehouses by sorting order (`PRIORITIZE_SORTING_ORDER`) - allocate stocks
+  according to the warehouses' order within the channel. If stock is insufficient,
+  the remaining quantity is allocated in the next warehouse on the list
+  and repeated if necessary.
+  To change the warehouses' order within the channel, use `channelReorderWarehouses` mutation.
+- Prioritize warehouses with highest stock (`PRIORITIZE_HIGH_STOCK`) - allocate stock
+  in a warehouse with the most stock. If not enough stock is available in a single
+  warehouse, the remaining quantity is allocated in the next warehouse on the list
+  and repeated if necessary.
+  In this scenario, the warehouses' order within the channel is ignored.
 
 ## Allocation flow
 
-Stocks are allocated in the checkout completion process for all lines
-with track inventory turned on. The allocation is made for every line
-on stocks with the highest quantity available value. Multiple allocations are created when there is insufficient available quantity in one stock. Insufficient quantity in all product stocks raises the `InsufficientStock` error.
+Stocks are allocated in the checkout completion process, for all lines
+that have track inventory turned on. The allocation is made for every line
+according to the allocation strategy in the given channel.
+Multiple allocations are created when there is insufficient available quantity in one stock.
+Insufficient quantity in all product stocks raises the `InsufficientStock` error.
 
 The line can be allocated only in the stocks that fulfill the following conditions:
 

--- a/docs/developer/stock-allocation.mdx
+++ b/docs/developer/stock-allocation.mdx
@@ -50,9 +50,9 @@ classDiagram
 
 ## Allocation flow
 
-Stocks are allocated in the checkout completion process, for all lines
-that have track inventory turned on. The allocation is made for every line
-according to the [allocation strategy](#allocation-strategies) in the given channel.
+Stocks are allocated in the checkout completion process for all lines
+with track inventory turned on. Each line is allocated according to the
+[allocation strategy](#allocation-strategies) in the given channel.
 Multiple allocations are created when there is insufficient available quantity in one stock.
 Insufficient quantity in all product stocks raises the `InsufficientStock` error.
 
@@ -67,7 +67,7 @@ The line can be allocated only in the stocks that fulfill the following conditio
 ### Allocation strategies
 
 The allocation strategies allow defining the rule that is used during the stock
-allocation. At this moment two possible options are available:
+allocation. At this moment, two possible options are available:
 
 - Prioritize warehouses by sorting order (`PRIORITIZE_SORTING_ORDER`) - allocate stocks
   according to the warehouses' order within the channel. If stock is insufficient,
@@ -75,27 +75,11 @@ allocation. At this moment two possible options are available:
   and repeated if necessary.
   To change the warehouses' order within the channel, use
   [`channelReorderWarehouses`](developer/api-reference/mutations/channel-reorder-warehouses.mdx) mutation.
-- Prioritize warehouses with highest stock (`PRIORITIZE_HIGH_STOCK`) - allocate stock
+- Prioritize warehouses with the highest stock (`PRIORITIZE_HIGH_STOCK`) - allocate stock
   in a warehouse with the most stock. If not enough stock is available in a single
   warehouse, the remaining quantity is allocated in the next warehouse on the list
   and continues to the next one if necessary.
   In this scenario, the warehouses' order within the channel is ignored.
-
-## Allocation flow
-
-Stocks are allocated in the checkout completion process, for all lines
-that have track inventory turned on. The allocation is made for every line
-according to the allocation strategy in the given channel.
-Multiple allocations are created when there is insufficient available quantity in one stock.
-Insufficient quantity in all product stocks raises the `InsufficientStock` error.
-
-The line can be allocated only in the stocks that fulfill the following conditions:
-
-- the stock's warehouse is available in the channel in which the order is created
-- the stock's warehouse has a shipping zone that includes the shipping address
-  (or billing address if the shipping address is not set) country code
-  and this shipping zone is available in the channel in which the order is created
-- the stock has available quantities
 
 ## Warehouse configuration
 

--- a/docs/developer/stock-allocation.mdx
+++ b/docs/developer/stock-allocation.mdx
@@ -57,7 +57,8 @@ allocation. At this moment two possible options are available:
   according to the warehouses' order within the channel. If stock is insufficient,
   the remaining quantity is allocated in the next warehouse on the list
   and repeated if necessary.
-  To change the warehouses' order within the channel, use `channelReorderWarehouses` mutation.
+  To change the warehouses' order within the channel, use
+  [`channelReorderWarehouses`](developer/api-reference/mutations/channel-reorder-warehouses.mdx) mutation.
 - Prioritize warehouses with highest stock (`PRIORITIZE_HIGH_STOCK`) - allocate stock
   in a warehouse with the most stock. If not enough stock is available in a single
   warehouse, the remaining quantity is allocated in the next warehouse on the list

--- a/docs/developer/stock-allocation.mdx
+++ b/docs/developer/stock-allocation.mdx
@@ -48,6 +48,22 @@ classDiagram
     }
 ```
 
+## Allocation flow
+
+Stocks are allocated in the checkout completion process, for all lines
+that have track inventory turned on. The allocation is made for every line
+according to the [allocation strategy](#allocation-strategies) in the given channel.
+Multiple allocations are created when there is insufficient available quantity in one stock.
+Insufficient quantity in all product stocks raises the `InsufficientStock` error.
+
+The line can be allocated only in the stocks that fulfill the following conditions:
+
+- the stock's warehouse is available in the channel in which the order is created
+- the stock's warehouse has a shipping zone that includes the shipping address
+  (or billing address if the shipping address is not set) country code
+  and this shipping zone is available in the channel in which the order is created
+- the stock has available quantities
+
 ### Allocation strategies
 
 The allocation strategies allow defining the rule that is used during the stock
@@ -62,7 +78,7 @@ allocation. At this moment two possible options are available:
 - Prioritize warehouses with highest stock (`PRIORITIZE_HIGH_STOCK`) - allocate stock
   in a warehouse with the most stock. If not enough stock is available in a single
   warehouse, the remaining quantity is allocated in the next warehouse on the list
-  and repeated if necessary.
+  and continues to the next one if necessary.
   In this scenario, the warehouses' order within the channel is ignored.
 
 ## Allocation flow


### PR DESCRIPTION
Docs regarding the following changes: https://github.com/saleor/saleor/pull/10416

- Explain the `allocation strategies`
- Update `channel` section - explain `channelReorderWarehouses`