### PR TITLE
Fix manifest example - use `asyncEvents` instead of `events`

### DIFF
--- a/docs/developer/extending/apps/manifest.mdx
+++ b/docs/developer/extending/apps/manifest.mdx
@@ -42,14 +42,14 @@ Saleor expects the manifest to use the following format:
   "webhooks": [
     {
       "name": "Order created",
-      "events": ["ORDER_CREATED"],
+      "asyncEvents": ["ORDER_CREATED"],
       "query": "subscription { event { ... on OrderCreated { order { id }}}}",
       "targetUrl": "https://example.com/api/webhooks/order-created",
       "isActive": false
     },
     {
       "name": "Multiple order's events",
-      "events": ["ORDER_CREATED", "ORDER_FULLY_PAID"],
+      "asyncEvents": ["ORDER_CREATED", "ORDER_FULLY_PAID"],
       "query": "subscription { event { ... on OrderCreated { order { id }} ... on OrderFullyPaid { order { id }}}}",
       "targetUrl": "https://example.com/api/webhooks/order-event",
       "isActive": true


### PR DESCRIPTION
This PR fixes incorrect example of app's manifest. It should use `asyncEvents` and `syncEvents` properties instead of `events`, just like in `webhookCreate` mutation
