### PR TITLE
fix: :bug: reload the page on ChunkLoadError

### DIFF
--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -4,6 +4,7 @@ import Layout from "@theme-original/Layout";
 import * as Sentry from "@sentry/react";
 import { BrowserTracing } from "@sentry/tracing";
 import siteConfig from "@generated/docusaurus.config";
+import ErrorBoundary from "@docusaurus/ErrorBoundary";
 
 const sentryDSN = siteConfig.customFields.sentryDSN;
 
@@ -17,8 +18,14 @@ if (sentryDSN) {
 
 export default function LayoutWrapper(props) {
   return (
-    <>
+    <ErrorBoundary
+      fallback={({ error }) => {
+        if (error.name === "ChunkLoadError") {
+          window.location.reload(true);
+        }
+      }}
+    >
       <Layout {...props} />
-    </>
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
I noticed quite a lot of similar Sentry errors saying something along the lines of:
> ChunkLoadError: Loading chunk 26777 failed.
> (error: https://docs.saleor.io/assets/js/3f8f4758.9a9c897c.js)

It happened after the users clicked on any of the article navigation links.

I dug into it and to the best of my knowledge, this is what's happening:
1. The user goes to the page
2. We deploy a new version of the docs in the meantime (and we've had a lot of deploys in the last weeks)
3. The user clicks a link, trying to open a new article
4. The link will not work because it is tied to a JavaScript chunk that the user is no longer able to download ([because it was removed from the CDN](https://vercel.com/docs/concepts/edge-network/caching#cache-invalidation))
5. The error is being thrown

There are two approaches to solving this issue (that I know of):
1. Change the CDN settings to keep the files from the old deployments for some time ([e.g. a week](https://github.com/excalidraw/excalidraw/issues/1244#issuecomment-609988953)). Unfortunately, there seems to be no easy way to do it, because Vercel doesn't allow you to tweak their CDN. The best bet seems to be [setting up your own CDN](https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix).
2. React to the error on the client side.

Out of necessity, I chose the second option. My solution is to do a hard reload of the page when the error is thrown. This is surely not the best UX, but I want to make sure it solves it. If that's the case, we can think about improving the experience.