### PR TITLE
docs: replace deprecated accountErrors with errors

### DIFF
--- a/docs/developer/users.mdx
+++ b/docs/developer/users.mdx
@@ -47,7 +47,7 @@ mutation {
       channel: "default-channel"
     }
   ) {
-    accountErrors {
+    errors {
       field
       code
     }
@@ -65,7 +65,7 @@ As a result, we get the data of the newly created user:
 {
   "data": {
     "accountRegister": {
-      "accountErrors": [],
+      "errors": [],
       "user": {
         "email": "customer@example.com",
         "isActive": true
@@ -77,13 +77,13 @@ As a result, we get the data of the newly created user:
 
 The `isActive` flag informs that the account is active and the user can log in to their account.
 
-Examples above include `accountErrors` field, which may return any [data-level errors](developer/api-conventions/error-handling.mdx#data-level-errors). Here is a response that would be returned if there is already an account registered for the given email:
+Examples above include `errors` field, which may return any [data-level errors](developer/api-conventions/error-handling.mdx#data-level-errors). Here is a response that would be returned if there is already an account registered for the given email:
 
 ```json
 {
   "data": {
     "accountRegister": {
-      "accountErrors": [
+      "errors": [
         {
           "field": "email",
           "code": "UNIQUE"
@@ -118,7 +118,7 @@ mutation {
       channel: "default-channel"
     }
   ) {
-    accountErrors {
+    errors {
       field
       code
     }
@@ -136,7 +136,7 @@ As a result, we get the data of the newly created but yet inactive user:
 {
   "data": {
     "accountRegister": {
-      "accountErrors": [],
+      "errors": [],
       "user": {
         "email": "customer@example.com",
         "isActive": false
@@ -160,7 +160,7 @@ mutation {
     email: "customer@example.com"
     token: "5fc-9f2116f96bdafd612cf4"
   ) {
-    accountErrors {
+    errors {
       field
       code
     }
@@ -178,7 +178,7 @@ If the token is valid, the user will be successfully activated:
 {
   "data": {
     "confirmAccount": {
-      "accountErrors": [],
+      "errors": [],
       "user": {
         "email": "customer@example.com",
         "isActive": true
@@ -290,7 +290,7 @@ To verify a token, use the following mutation:
 mutation {
   tokenVerify(token: "<your-access-token>") {
     isValid
-    accountErrors {
+    errors {
       field
       code
     }
@@ -309,7 +309,7 @@ A successful response:
   "data": {
     "tokenVerify": {
       "isValid": true,
-      "accountErrors": []
+      "errors": []
     }
   }
 }
@@ -336,7 +336,7 @@ The mutation takes the following input fields:
 mutation {
   tokenRefresh(csrfToken: "<your-csrf-token>") {
     token
-    accountErrors {
+    errors {
       code
     }
   }
@@ -350,7 +350,7 @@ A successful response:
   "data": {
     "tokenRefresh": {
       "token": "new-token",
-      "accountErrors": []
+      "errors": []
     }
   }
 }
@@ -366,7 +366,7 @@ The mutation takes the following input fields:
 mutation {
   tokenRefresh(refreshToken: "<your-refresh-token>") {
     token
-    accountErrors {
+    errors {
       code
     }
   }
@@ -380,7 +380,7 @@ A successful response:
   "data": {
     "tokenRefresh": {
       "token": "new-token",
-      "accountErrors": []
+      "errors": []
     }
   }
 }
@@ -393,7 +393,7 @@ The `tokensDeactivateAll` mutation will invalidate all tokens (access and refres
 ```graphql
 mutation {
   tokensDeactivateAll {
-    accountErrors {
+    errors {
       field
       message
       code
@@ -457,7 +457,7 @@ mutation {
     email: "customer@example.com"
     redirectUrl: "http://localhost:3001/reset-password/"
   ) {
-    accountErrors {
+    errors {
       field
       code
     }
@@ -486,7 +486,7 @@ mutation {
     email: "customer@example.com"
     password: "new-secret"
   ) {
-    accountErrors {
+    errors {
       field
       code
     }
@@ -506,7 +506,7 @@ If you wish to change your password as an authenticated customer, use the `passw
 ```graphql {2}
 mutation {
   passwordChange(oldPassword: "secret", newPassword: "new-secret") {
-    accountErrors {
+    errors {
       field
       code
     }
@@ -535,7 +535,7 @@ mutation {
     password: "secret"
     redirectUrl: "http://localhost:3001/confirm-email/"
   ) {
-    accountErrors {
+    errors {
       field
       code
     }
@@ -552,7 +552,7 @@ If there are no errors, the mutation sends an email to the `newEmail` address wi
 {
   "data": {
     "requestEmailChange": {
-      "accountErrors": [],
+      "errors": [],
       "user": {
         "email": "admin@example.com"
       }
@@ -576,7 +576,7 @@ mutation {
   confirmEmailChange(
     token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1ODYxNzY5OTQsIm9sZF9lbWFpbCI6ImFkbWluQGV4YW1wbGUuY29tIiwibmV3X2VtYWlsIjoibmV3LWFkZHJlc3NAZXhhbXBsZS5jb20iLCJ1c2VyX3BrIjoyMX0.aGAo28Ss_zOn_TwAzLCXdY1xENpf_-uw2khORoodKR8"
   ) {
-    accountErrors {
+    errors {
       field
       code
     }
@@ -593,7 +593,7 @@ If the token is valid the email should be now updated:
 {
   "data": {
     "confirmEmailChange": {
-      "accountErrors": [],
+      "errors": [],
       "user": {
         "email": "new-address@example.com"
       }
@@ -613,7 +613,7 @@ If you wish to remove your own customer account, you can do so by using two muta
 ```graphql {2}
 mutation {
   accountRequestDeletion(redirectUrl: "http://localhost:3001/confirm-delete/") {
-    accountErrors {
+    errors {
       field
       message
       code
@@ -635,7 +635,7 @@ To confirm deleting the account, use the `accountDelete` mutation which accepts 
 ```graphql {2}
 mutation {
   accountDelete(token: "5ff-b5818345d8b64331b068") {
-    accountErrors {
+    errors {
       field
       message
       code


### PR DESCRIPTION
Deprecated `accountErrors` causes this warning in mutations in [users](https://docs.saleor.io/docs/3.x/developer/users) page.

"This field will be removed in Saleor 4.0. Use errors field instead."