### PR TITLE
Add missing font weight to card titles

### DIFF
--- a/components/CardGrid/styles.module.css
+++ b/components/CardGrid/styles.module.css
@@ -27,6 +27,7 @@
   display: block;
   color: var(--ifm-link-color);
   font-size: 1.2rem;
+  font-weight: var(--ifm-heading-font-weight);
   line-height: var(--ifm-heading-line-height);
   margin: var(--ifm-heading-margin-top) 0 var(--ifm-heading-margin-bottom) 0;
 }


### PR DESCRIPTION
This corrects the font weight for card grid card titles