### PR TITLE
feat/add setup quickstart

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -8,6 +8,10 @@ This page contains a complete list of all available Saleor CLI commands with the
 
 ## Installing the CLI
 
+:::important
+Saleor CLI requires [`pnpm`](https://pnpm.io/) to work. You can install it with `npm install -g pnpm`.
+:::
+
 To download and install Saleor CLI, run the following command:
 
 ```

--- a/docs/cloud.mdx
+++ b/docs/cloud.mdx
@@ -15,7 +15,7 @@ Explore the [features and pricing of Saleor Cloud](https://saleor.io/pricing/).
 
 There are two ways to interact with Saleor Cloud:
 
-- [Using Saleor CLI](#using-saleor-cli)
+- [Saleor CLI](#using-saleor-cli)
 - Using [Saleor Cloud Dashboard](https://cloud.saleor.io)
 
 ### Using Saleor CLI

--- a/docs/cloud.mdx
+++ b/docs/cloud.mdx
@@ -7,9 +7,7 @@ sidebar_position: 2
 
 Saleor is an open-source project which means all of its code is [publicly available](https://github.com/saleor).
 
-The fastest way to try out Saleor is by [utilizing a free developer plan in Saleor Cloud](https://cloud.saleor.io/signup). The free account will get you running in under a minute. We highly encourage you to use it to familiarize yourself with the platform even if you plan to eventually host Saleor yourself.
-
-Choosing Saleor Cloud means you can skip reading through the rest of this chapter.
+However, the fastest way to try out Saleor is by [utilizing a free developer plan in Saleor Cloud](https://cloud.saleor.io/signup). The free account will get you running in under a minute. We highly encourage you to use it to familiarize yourself with the platform even if you plan to eventually host Saleor yourself.
 
 Explore the [features and pricing of Saleor Cloud](https://saleor.io/pricing/).
 
@@ -60,4 +58,4 @@ saleor project create
 
 Now that you have an account, an organization, and a project, you can start exploring the Saleor features.
 
-We suggest heading to [Quickstart](setup/quickstart.mdx) to create the first storefront for your e-commerce.
+We suggest heading to [Quickstart](setup/quickstart.mdx#saleor-cloud) to create your first Saleor application.

--- a/docs/cloud.mdx
+++ b/docs/cloud.mdx
@@ -16,7 +16,7 @@ Explore the [features and pricing of Saleor Cloud](https://saleor.io/pricing/).
 There are two ways to interact with Saleor Cloud:
 
 - [Saleor CLI](#using-saleor-cli)
-- Using [Saleor Cloud Dashboard](https://cloud.saleor.io)
+- [Saleor Cloud Dashboard](https://cloud.saleor.io)
 
 ### Using Saleor CLI
 

--- a/docs/developer/extending/apps/key-concepts.mdx
+++ b/docs/developer/extending/apps/key-concepts.mdx
@@ -12,13 +12,13 @@ Start building a Saleor app by learning about:
 
 <CardGrid>
 
+[**Quickstart** Tutorial, that will walk you through the basic steps of building a Saleor app.](developer/extending/apps/quickstart/getting-started.mdx)
+
 [**Saleor App Template** The best place to start building your Saleor app.](developer/extending/apps/developing-apps/app-template.mdx)
 
 [**App Examples** A curated list of examples of apps built by Saleor maintainers.](developer/extending/apps/developing-apps/app-examples.mdx)
 
 [**Dashboard Integration** Embed your app inside Saleor Dashboard.](developer/extending/apps/extending-dashboard-with-apps.mdx)
-
-[**Quickstart** Tutorial, that will walk you through the basic steps of building a Saleor app.](developer/extending/apps/quickstart/getting-started.mdx)
 
 </CardGrid>
 

--- a/docs/developer/extending/apps/quickstart/getting-started.mdx
+++ b/docs/developer/extending/apps/quickstart/getting-started.mdx
@@ -35,64 +35,12 @@ Setting aside the purpose of this tutorial, we highly recommend learning them. T
 
 ### Saleor CLI
 
-This tutorial relies on a technology we are deeply proud of: [Saleor CLI](cli.mdx). We will use it to spawn an app boilerplate.
+In this tutorial, we will use [Saleor CLI](cli.mdx) to spawn the app boilerplate.
 
-:::important
-Saleor CLI requires [`pnpm`](https://pnpm.io/) to work. You can install it with `npm install -g pnpm`.
-:::
-
-To download and install Saleor CLI, run the following command:
-
-```shell
-npm i -g @saleor/cli
-```
-
-After the installation, you can display all available commands by running the following in your terminal:
-
-```shell
-saleor
-```
+If you haven't installed Saleor CLI, please head over to the [Saleor CLI documentation](/cli.mdx) for the [installation instructions](/cli.mdx#installing-the-cli).
 
 ### Saleor account
 
-#### Login to your existing Saleor account
+Before starting the development, please make sure you are logged in to your Saleor Cloud account.
 
-Before starting the development, please make sure you are logged in to your Saleor Cloud account. To log in let's type:
-
-```shell
-saleor login
-```
-
-The command will redirect you to a webpage with authentication. There, you need to pass in your login credentials. After a successful login, you can come back to the CLI.
-
-:::tip
-
-If your user is assigned to an organization and you have an existing project you want to build an app for, you can go all the way to the next page. See you there 👋!
-
-:::
-
-#### Create a new Saleor account
-
-If you have no prior experience with Saleor, that's okay! Please create a new account with the command:
-
-```shell
-saleor register
-```
-
-The wizard will walk you through the registration process.
-
-#### Create your organization
-
-If you haven't done it already, we need to ensure that you are assigned to an organization before we continue. If that's not the case, please create an organization in the [Saleor Cloud dashboard](https://cloud.saleor.io/) after you have logged in.
-
-#### Create your project
-
-Unless you want to assign your app to an existing project, we will need to create a new one.
-
-You can do so from the Saleor Cloud dashboard. But since we made all the effort to install the Saleor CLI, let's make the most of it!
-
-To create a project, please run:
-
-```shell
-saleor project create
-```
+If you have not set up your Saleor Cloud account yet, we suggest following the [Getting started](setup/cloud.mdx#getting-started) guide.

--- a/docs/developer/extending/apps/quickstart/getting-started.mdx
+++ b/docs/developer/extending/apps/quickstart/getting-started.mdx
@@ -43,4 +43,4 @@ If you haven't installed Saleor CLI, please head over to the [Saleor CLI documen
 
 Before starting the development, please make sure you are logged in to your Saleor Cloud account.
 
-If you have not set up your Saleor Cloud account yet, we suggest following the [Getting started](setup/cloud.mdx#getting-started) guide.
+If you have not set up your Saleor Cloud account yet, we suggest following the [Getting started](cloud.mdx#getting-started) guide.

--- a/docs/setup/cloud.mdx
+++ b/docs/setup/cloud.mdx
@@ -3,7 +3,7 @@ title: Saleor Cloud
 sidebar_position: 1
 ---
 
-import CardGrid from "@site/components/CardGrid";
+## Overview
 
 Saleor is an open-source project which means all of its code is [publicly available](https://github.com/saleor).
 
@@ -12,3 +12,52 @@ The fastest way to try out Saleor is by [utilizing a free developer plan in Sale
 Choosing Saleor Cloud means you can skip reading through the rest of this chapter.
 
 Explore the [features and pricing of Saleor Cloud](https://saleor.io/pricing/).
+
+## Getting started
+
+There are two ways to interact with Saleor Cloud:
+
+- [Using Saleor CLI](#using-saleor-cli)
+- Using [Saleor Cloud Dashboard](https://cloud.saleor.io)
+
+### Using Saleor CLI
+
+Saleor CLI is a command-line tool that allows you to quickly utilize the features of the Saleor platform. In its [documentation](cli.mdx), you can find [the list of all the supported actions](cli.mdx#commands), as well as the [installation instructions](cli.mdx#installing-the-cli).
+
+#### Creating an account
+
+To create a new Saleor Cloud account, run the following command:
+
+```bash
+saleor register
+```
+
+The command will open a browser window with a registration form. Fill in the required fields and come back to the CLI.
+
+After you have registered your account, you can log in using the following command:
+
+```bash
+saleor login
+```
+
+#### Creating an organization
+
+:::info
+Currently, it is not possible to create an organization through Saleor CLI.
+:::
+
+If you are not invited to an existing organization, please open the [Saleor Cloud dashboard](https://cloud.saleor.io/) after registration. As every user must be assigned to an organization, you should see the organization creation form right away.
+
+Once you fill it, you can come back to the CLI.
+
+#### Creating a project
+
+The last missing piece is a project. To create a new one, run the following command:
+
+```shell
+saleor project create
+```
+
+Now that you have an account, an organization, and a project, you can start exploring the Saleor features.
+
+We suggest heading to [Quickstart](setup/quickstart.mdx) to create the first storefront for your e-commerce.

--- a/docs/setup/cloud.mdx
+++ b/docs/setup/cloud.mdx
@@ -1,6 +1,6 @@
 ---
 title: Saleor Cloud
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 ## Overview

--- a/docs/setup/docker-compose.mdx
+++ b/docs/setup/docker-compose.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation with Docker
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 Saleor is a [12-factor](https://12factor.net) application that is configured using environment variables. We recommend using **Docker** because it takes care of all necessary dependencies.

--- a/docs/setup/quickstart.mdx
+++ b/docs/setup/quickstart.mdx
@@ -1,0 +1,25 @@
+---
+title: Quickstart
+sidebar_position: 1
+---
+
+## Prerequisites
+
+Before you start, make sure you went through:
+
+- [Setting up your Saleor Cloud account](/setup/cloud.mdx#getting-started)
+- [Installing Saleor CLI](/cli.mdx#installing-the-cli)
+
+## Quickstart
+
+### Storefront
+
+To spawn a fully functional storefront, connected to your Saleor instance, run the following command using Saleor CLI:
+
+```shell
+saleor storefront create
+```
+
+### Boilerplate
+
+If you want to start with a minimal boilerplate, create a new repository using the [`saleor-next-boilerplate`](https://github.com/saleor/saleor-next-boilerplate/generate) template.

--- a/docs/setup/quickstart.mdx
+++ b/docs/setup/quickstart.mdx
@@ -1,25 +1,55 @@
 ---
 title: Quickstart
+description: Explore the quickest ways to get started with Saleor.
 sidebar_position: 1
 ---
 
-## Prerequisites
+## Saleor Cloud
 
-Before you start, make sure you went through:
+Before you continue, make sure you went through:
 
-- [Setting up your Saleor Cloud account](/setup/cloud.mdx#getting-started)
+- [Setting up your Saleor Cloud account](/cloud.mdx#getting-started)
 - [Installing Saleor CLI](/cli.mdx#installing-the-cli)
-
-## Quickstart
 
 ### Storefront
 
-To spawn a fully functional storefront, connected to your Saleor instance, run the following command using Saleor CLI:
+:::info
+
+Saleor hosts a demo shop to showcase all the main features of the platform. You can access it at [demo.saleor.io](https://demo.saleor.io/).
+
+:::
+
+The underlying technology of the demo shop is [saleor/react-storefront](https://github.com/saleor/react-storefront). It was built using Next.js, TypeScript and Tailwind CSS.
+
+To spawn a fully-featured storefront connected to your Saleor project, run the following command using Saleor CLI:
 
 ```shell
 saleor storefront create
 ```
 
-### Boilerplate
+### Starter
 
-If you want to start with a minimal boilerplate, create a new repository using the [`saleor-next-boilerplate`](https://github.com/saleor/saleor-next-boilerplate/generate) template.
+To set up a minimalistic Next.js & TypeScript boilerplate that only implements the basic features of Saleor, clone the [`saleor-next-starter`](https://github.com/saleor/saleor-next-starter) repository:
+
+```shell
+git clone https://github.com/saleor/saleor-next-starter.git
+```
+
+## Self-hosted
+
+Before you continue, make sure you have installed:
+
+- [Docker](https://docs.docker.com/install/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+### Saleor Platform
+
+If you want to run Saleor API along with all the major applications locally, you can use [`saleor-platform`](https://github.com/saleor/saleor-platform).
+
+You can clone it like so:
+
+```shell
+git clone https://github.com/saleor/saleor-platform.git --recursive --jobs 3
+```
+
+To complete the setup, follow [the instructions in the README file](https://github.com/saleor/saleor-platform#how-to-run-it).

--- a/docs/setup/windows.mdx
+++ b/docs/setup/windows.mdx
@@ -1,6 +1,6 @@
 ---
 title: Manual Installation on Windows
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 import Tabs from "@theme/Tabs";

--- a/sidebars.js
+++ b/sidebars.js
@@ -15,6 +15,7 @@ module.exports = {
         },
       ],
     },
+    "cloud",
     {
       type: "category",
       label: "Setup",


### PR DESCRIPTION
**Feat:**
- Cloud article
  - moved to a separate position in the menu 
  - added "Getting started" that contains instructions on what you need to create before you start fully using Saleor CLI (I extracted it from the "Apps Quickstart" article)
  - Idea💡: once we have more content, we can turn the Saleor Cloud article into a documentation subfolder
- Created a "Setup Quickstart" article
- some small adjustments here and there