### PR TITLE
chore: suggest alternative for non-tty environment

### DIFF
--- a/docs/setup/docker-compose.mdx
+++ b/docs/setup/docker-compose.mdx
@@ -50,6 +50,13 @@ Finally, create an admin account:
 docker-compose run --rm api python3 manage.py createsuperuser
 ```
 
+> If you are running these steps in a non-tty environment (e.g. a CI), you run the `manager.py` executable from inside the API container:
+> ```
+> $ docker exec -it saleor_api /bin/bash
+> root # python manager.py createsuperuser
+> ```
+> You will be able to type in the email and password of the superuser account.
+
 ## Running the services
 
 Use the following command to run all Saleor containers (from within the `saleor-platform` directory):


### PR DESCRIPTION
Suggest an alternative method of creating the superuser account when Saleor was deployed from a non-tty environment (e.g. Github Action).