### PR TITLE
Fix missing backticks in docs/setup/configuration.mdx file

### DIFF
--- a/docs/setup/configuration.mdx
+++ b/docs/setup/configuration.mdx
@@ -191,7 +191,7 @@ Multiple values should be separated with a comma.
 
 ### `JWT_TTL_ACCESS`
 
-The time until JWT access tokens expire. The value should be a time expression like `5m`, `5 minutes, `5d`, `5 days`, `1w`, or `1 week`. Defaults to `5 minutes`.
+The time until JWT access tokens expire. The value should be a time expression like `5m`, `5 minutes`, `5d`, `5 days`, `1w`, or `1 week`. Defaults to `5 minutes`.
 
 ### `JWT_TTL_REFRESH`
 


### PR DESCRIPTION
Fix missing backtick in the documentation which broke the code highlighting.