### PR TITLE
Update 3.12 upgrade guide for #12191

### DIFF
--- a/docs/upgrade-guides/3-11-to-3-12.mdx
+++ b/docs/upgrade-guides/3-11-to-3-12.mdx
@@ -26,3 +26,10 @@ If you do any calculations on the discount amount or total price, you might need
 If you had an order for $13.00 and applied a 12.5% discount to it, you would get $11.38 with a $1.62 discount.
 
 In Saleor 3.12.0, the numbers would be $11.37 for the order and $1.63 for the discount.
+
+## Include specific products and apply-once-per-order vouchers in checkout discount
+
+The change affects the [checkout discount](../api-reference/objects/checkout#code-style-fontweight-normal-checkoutbdiscountbcodemoney-)
+when a `specific product` voucher or `apply-once-per-order` voucher is used.
+Previously, the checkout discount for such cases was 0, and the discount was only visible on the line level.
+Now, the checkout discount will reflect the amount of the applied discount regardless of the voucher type.

--- a/docs/upgrade-guides/3-11-to-3-12.mdx
+++ b/docs/upgrade-guides/3-11-to-3-12.mdx
@@ -29,7 +29,7 @@ In Saleor 3.12.0, the numbers would be $11.37 for the order and $1.63 for the di
 
 ## Include specific products and apply-once-per-order vouchers in checkout discount
 
-The change affects the [checkout discount](../api-reference/objects/checkout#code-style-fontweight-normal-checkoutbdiscountbcodemoney-)
-when a `specific product` voucher or `apply-once-per-order` voucher is used.
+The change affects value of the [Checkout.discount](../api-reference/objects/checkout#code-style-fontweight-normal-checkoutbdiscountbcodemoney-)
+field when a `specific product` voucher or `apply-once-per-order` voucher is used.
 Previously, the checkout discount for such cases was 0, and the discount was only visible on the line level.
 Now, the checkout discount will reflect the amount of the applied discount regardless of the voucher type.


### PR DESCRIPTION
Add info on how `checkout.discount` is changed in 3.12.

The changes for https://github.com/saleor/saleor/pull/12191 