### PR TITLE
Add `requiredSaleorVersion` and `author` fields to App manifest

### DIFF
--- a/docs/developer/extending/apps/manifest.mdx
+++ b/docs/developer/extending/apps/manifest.mdx
@@ -10,7 +10,9 @@ Saleor expects the manifest to use the following format:
 {
   "id": "example.app.wonderful",
   "version": "1.0.0",
+  "requiredSaleorVersion": "^3.13",
   "name": "My Wonderful App",
+  "author": "My Wonderful Company",
   "about": "My Wonderful App is a wonderful App for Saleor.",
 
   "permissions": ["MANAGE_USERS", "MANAGE_STAFF"],
@@ -60,7 +62,9 @@ Saleor expects the manifest to use the following format:
 
 - `id`: id of application used internally by Saleor
 - `version`: App version
+- `requiredSaleorVersion`: Version range, in the `semver` format, which specifies Saleor version required by the app
 - `name`: App name displayed in the dashboard
+- `author`: App author name displayed in the dashboard
 - `about`: Description of the app displayed in the dashboard
 - `permissions`: Array of [permissions](developer/permissions.mdx#available-permissions) requested by the app
 - `appUrl`: App website rendered in the dashboard


### PR DESCRIPTION
Add new fields `requiredSaleorVersion` and `author` to the App manifest description