### PR TITLE
Inject examples to api-reference

### DIFF
--- a/.github/workflows/update-reference.yml
+++ b/.github/workflows/update-reference.yml
@@ -22,6 +22,8 @@ jobs:
 
       - run: npx docusaurus graphql-to-doc --pretty -s https://master.staging.saleor.cloud/graphql/
 
+      - run: npx tsx scripts/inject-examples.ts
+
       - run: git status
 
       - name: Create Pull Request

--- a/docs/api-reference/queries/product.mdx
+++ b/docs/api-reference/queries/product.mdx
@@ -77,3 +77,7 @@ Added in Saleor 3.10.
 #### [`Product`](../../api-reference/objects/product) <Badge class="secondary" text="object"/>
 
 > Represents an individual item for sale in the storefront.
+
+import Product from "@site/examples/api-reference/queries/product.mdx";
+
+<Product />

--- a/docs/api-reference/queries/products.mdx
+++ b/docs/api-reference/queries/products.mdx
@@ -88,3 +88,7 @@ products(
 #### [`ProductCountableConnection`](../../api-reference/objects/product-countable-connection) <Badge class="secondary" text="object"/>
 
 >
+
+import Products from "@site/examples/api-reference/queries/products.mdx";
+
+<Products />

--- a/examples/api-reference/queries/product.mdx
+++ b/examples/api-reference/queries/product.mdx
@@ -1,0 +1,41 @@
+### Examples
+
+<details>
+  <summary>Get a product by ID</summary>
+
+#### Get a product by ID
+
+The following query retrieves the product with the associated ID. It returns the product fields specified in the query.
+
+| Query arguments |                                                          |
+| --------------- | -------------------------------------------------------- |
+| id: ID!         | The ID of the product to return                          |
+| channel: String | Slug of a channel for which the data should be returned. |
+
+```graphql title="Query"
+{
+  product(id: "UHJvZHVjdDoxOTg=", channel: "default-channel") {
+    id
+    name
+  }
+}
+```
+
+```json title="Response"
+{
+  "data": {
+    "product": {
+      "id": "UHJvZHVjdDoxOTg=",
+      "name": "ABBA Again"
+    }
+  },
+  "extensions": {
+    "cost": {
+      "requestedQueryCost": 1,
+      "maximumAvailable": 50000
+    }
+  }
+}
+```
+
+</details>

--- a/examples/api-reference/queries/products.mdx
+++ b/examples/api-reference/queries/products.mdx
@@ -1,0 +1,77 @@
+### Examples
+
+<details>
+  <summary>Get products</summary>
+
+#### Get the first ten products
+
+The following query retrieves the first ten products for a shop and returns the associated ID.
+
+| Query arguments |                                                          |
+| --------------- | -------------------------------------------------------- |
+| first: Int      | Return the first n elements from the list.               |
+| channel: String | Slug of a channel for which the data should be returned. |
+
+Returns up to the first n elements from the list.
+
+```graphql title="Query"
+{
+  products(first: 10, channel: "default-channel") {
+    edges {
+      node {
+        id
+        name
+      }
+    }
+  }
+}
+```
+
+```json title="Response"
+{
+  "data": {
+    "products": {
+      "edges": [
+        {
+          "node": {
+            "id": "UHJvZHVjdDoxOTY=",
+            "name": "1970-1982"
+          }
+        },
+        {
+          "node": {
+            "id": "UHJvZHVjdDoxOTg=",
+            "name": "ABBA Again"
+          }
+        },
+        {
+          "node": {
+            "id": "UHJvZHVjdDoyMDA=",
+            "name": "ABBA - MP3"
+          }
+        },
+        {
+          "node": {
+            "id": "UHJvZHVjdDoxNzc=",
+            "name": "Aniversario Los 10 Años De ABBA"
+          }
+        },
+        {
+          "node": {
+            "id": "UHJvZHVjdDoxNjY=",
+            "name": "A Wie ABBA (Die Grössten Erfolge Von »Waterloo« Bis »Super Trouper«)"
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "cost": {
+      "requestedQueryCost": 5,
+      "maximumAvailable": 50000
+    }
+  }
+}
+```
+
+</details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-mdx": "^2.0.5",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.31.11",
+        "fast-glob": "^3.2.12",
         "graphql": "^16.6.0",
         "husky": "^8.0.2",
         "prettier": "^2.8.1",
@@ -11479,6 +11480,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
@@ -11700,26 +11721,6 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
       "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==",
       "dev": true
-    },
-    "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
@@ -12539,7 +12540,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -15811,7 +15812,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -17929,6 +17930,26 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/robust-predicates": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
@@ -18464,6 +18485,26 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/shelljs/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/side-channel": {
@@ -29045,6 +29086,20 @@
             "universalify": "^2.0.0"
           }
         },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "schema-utils": {
           "version": "2.7.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
@@ -29207,20 +29262,6 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
       "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==",
       "dev": true
-    },
-    "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
     },
     "glob-parent": {
       "version": "5.1.2",
@@ -29834,7 +29875,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -32122,7 +32163,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-is-inside": {
@@ -33639,6 +33680,22 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "robust-predicates": {
@@ -34071,6 +34128,22 @@
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "side-channel": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "rename-version": "docusaurus rename-version",
     "update-api-reference": "docusaurus graphql-to-doc --force --pretty",
     "prepare": "husky install",
-    "swizzle": "docusaurus swizzle"
+    "swizzle": "docusaurus swizzle",
+    "inject-examples": "npx tsx ./scripts/inject-examples.ts"
   },
   "eslintConfig": {
     "overrides": [
@@ -64,6 +65,7 @@
     "eslint-plugin-mdx": "^2.0.5",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.11",
+    "fast-glob": "^3.2.12",
     "graphql": "^16.6.0",
     "husky": "^8.0.2",
     "prettier": "^2.8.1",

--- a/scripts/inject-examples.ts
+++ b/scripts/inject-examples.ts
@@ -1,0 +1,36 @@
+const fg = require("fast-glob");
+import * as fs from "node:fs/promises";
+
+function filePathToPascalCase(path: string): string {
+  const nameRe = /\/(\w+)\.mdx/;
+  const name = (path.match(nameRe) || ["", ""])[1];
+  const camelCaseStr = name.replace(/-([a-z])/g, function (g) {
+    return g[1].toUpperCase();
+  });
+  return camelCaseStr.charAt(0).toUpperCase() + camelCaseStr.slice(1);
+}
+
+async function injectExamples() {
+  const files = await fg("examples/**/*.mdx");
+
+  for (const file of files) {
+    const name = filePathToPascalCase(file);
+    const importLine = `import ${name} from "@site/${file}";`;
+    const targetFile = file.replace("examples/", "docs/");
+    const targetFileContent = await fs.readFile(targetFile);
+
+    if (
+      targetFileContent &&
+      targetFileContent.toString().indexOf(importLine) === -1
+    ) {
+      const content = `
+${importLine}
+
+<${name} />`;
+
+      await fs.appendFile(targetFile, content);
+    }
+  }
+}
+
+injectExamples();


### PR DESCRIPTION
This PR introduces the `Examples` section to the API reference pages. 

<img width="1494" alt="image" src="https://user-images.githubusercontent.com/779644/226859269-bc67f818-da15-45db-bf75-02e66243df82.png">


### How it works
Example section is put in the generated API reference page using [Markdown imports](https://docusaurus.io/docs/markdown-features/react#importing-markdown). The import is put into the page with the use of the `inject-examples` script. The script takes the corresponding file with examples and imports into the page.  

The `update-reference` workflow has been modified to do that.

### How to add examples
Pages with examples are stored in a separate `examples` folder. 
This folder structure should be the same as the one generated with the [GraphQL-Markdown](https://graphql-markdown.github.io/) `api-reference`. 

1. Create a new file in the `examples` folder with the same path as the API reference page you are documenting.
1. Import the file to the API reference page eg.

```
import Product from "@site/examples/docs/api-reference/queries/product.mdx";

<Product />
```

