### PR TITLE
Extend `requiredSaleorVersion` and `author` App manifest fields descriptions

### DIFF
--- a/docs/developer/extending/apps/manifest.mdx
+++ b/docs/developer/extending/apps/manifest.mdx
@@ -62,9 +62,9 @@ Saleor expects the manifest to use the following format:
 
 - `id`: id of application used internally by Saleor
 - `version`: App version
-- `requiredSaleorVersion`: Version range, in the `semver` format, which specifies Saleor version required by the app
+- `requiredSaleorVersion`: Version range, in the `semver` format, which specifies Saleor version required by the app. The field will be respected starting from Saleor 3.13
 - `name`: App name displayed in the dashboard
-- `author`: App author name displayed in the dashboard
+- `author`: App author name displayed in the dashboard (starting from Saleor 3.13)
 - `about`: Description of the app displayed in the dashboard
 - `permissions`: Array of [permissions](developer/permissions.mdx#available-permissions) requested by the app
 - `appUrl`: App website rendered in the dashboard


### PR DESCRIPTION
I want to highlight that the new `requiredSaleorVersion` and `author` App manifest fields will be respected starting from Saleor 3.13