### PR TITLE
Add snippets for the examples section in GraphiQL

### DIFF
--- a/examples/snippets/collections/CollectionAddProduct.mutation.graphql
+++ b/examples/snippets/collections/CollectionAddProduct.mutation.graphql
@@ -1,0 +1,10 @@
+mutation CollectionAddProduct($collectionId: ID!, $product: ID!) {
+  collectionAddProducts(collectionId: $collectionId, products: [$product]) {
+    collection {
+      id
+    }
+    errors {
+      message
+    }
+  }
+}

--- a/examples/snippets/collections/CollectionList.query.graphql
+++ b/examples/snippets/collections/CollectionList.query.graphql
@@ -1,0 +1,10 @@
+query CollectionList {
+  collections(first: 10) {
+    edges {
+      node {
+        id
+        name
+      }
+    }
+  }
+}

--- a/examples/snippets/collections/CollectionListWithProducts.query.graphql
+++ b/examples/snippets/collections/CollectionListWithProducts.query.graphql
@@ -1,0 +1,17 @@
+query CollectionListWithProducts {
+  collections(first: 10) {
+    edges {
+      node {
+        id
+        name
+        products(first: 10) {
+          edges {
+            node {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/snippets/products/ProductByID.query.graphql
+++ b/examples/snippets/products/ProductByID.query.graphql
@@ -1,0 +1,13 @@
+query ProductByID($id: ID!) {
+  product(id: $id, channel: "default-channel") {
+    id
+    name
+    description
+    media {
+      url
+    }
+    category {
+      name
+    }
+  }
+}

--- a/examples/snippets/products/ProductByIDwithVariants.query.graphql
+++ b/examples/snippets/products/ProductByIDwithVariants.query.graphql
@@ -1,0 +1,17 @@
+query ProductByID($id: ID!) {
+  product(id: $id, channel: "default-channel") {
+    id
+    name
+    description
+    media {
+      url
+    }
+    category {
+      name
+    }
+    variants {
+      id
+      name
+    }
+  }
+}

--- a/examples/snippets/products/SimpleProductList.query.graphql
+++ b/examples/snippets/products/SimpleProductList.query.graphql
@@ -1,0 +1,10 @@
+query ProductGetTwelveElements {
+  products(first: 12) {
+    edges {
+      node {
+        id
+        name
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the snippets directory that will be used to display the examples in the built-in GraphiQL playground when in Saleor Dashboard