### PR TITLE
Drop django-versatileimagefield settings

### DIFF
--- a/docs/setup/configuration.mdx
+++ b/docs/setup/configuration.mdx
@@ -105,19 +105,6 @@ Redis is recommended. Heroku’s Redis will export this setting automatically.
 
 Default task broker URL. You can read more about configuring this at [Celery Documentation.](https://docs.celeryproject.org/en/stable/userguide/configuration.html#broker-url)
 
-### `CREATE_IMAGES_ON_DEMAND`
-
-Indicates whether new images are created on the fly. Defaults to `True`.
-
-We recommend setting this to `False` for production to improve performance.
-All images must come with a pre-warm to ensure they’re created and available at the appropriate URL.
-
-To create missing thumbnails for all images use:
-
-```shell
-python manage.py create_thumbnails
-```
-
 ### `DATABASE_URL`
 
 The connection URL to a PostgreSQL database. Defaults to `postgres://saleor:saleor@localhost:5432/saleor`.


### PR DESCRIPTION
I want to remove the `CREATE_IMAGES_ON_DEMAND` paragraph from the configuration as it is no longer relevant after we switched from `django-versatileimagefield` to the custom thumbnails mechanism.