### PR TITLE
Add currently set max to field descriptions for first and last 

### DIFF
--- a/docs/api-usage/pagination.mdx
+++ b/docs/api-usage/pagination.mdx
@@ -99,7 +99,7 @@ Pagination is subject to [usage limits](./usage-limits.mdx).
 
 To indicate how you want the queried items to be selected, use a combination of the following connection arguments:
 
-- `first`: the number of items (nodes) you want the query to return. This argument will return items from the beginning of the list. Cannot be combined with `last`.
+- `first`: the number of items (nodes) you want the query to return. This argument will return items from the beginning of the list. The system only allows fetching up to 100 objects in a single query. Cannot be combined with `last`.
 
   <details>
 
@@ -121,7 +121,7 @@ To indicate how you want the queried items to be selected, use a combination of 
 
   </details>
 
-- `last`: the number of items (nodes) you want the query to return. This argument will return items from the end of the list. Cannot be combined with `first`.
+- `last`: the number of items (nodes) you want the query to return. This argument will return items from the end of the list. The system only allows fetching up to 100 objects in a single query. Cannot be combined with `first`.
 
   <details>
 


### PR DESCRIPTION
Adding missing information on how many objects could be fetched by on query. 