### PR TITLE
Fix search in darkmode

### DIFF
--- a/src/css/components/search.css
+++ b/src/css/components/search.css
@@ -3,6 +3,10 @@
   --docsearch-text-color: var(--ifm-font-color-base);
 }
 
+:root[data-theme="dark"] {
+  --docsearch-hit-active-color: var(--ifm-background-surface-color);
+}
+
 .DocSearch-Button {
   margin: 0;
   transition: all var(--ifm-transition-fast)

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -13,6 +13,7 @@
 @import url("components/api-reference.css");
 @import url("components/mermaid.css");
 @import url("components/navbar.css");
+@import url("components/search.css");
 @import url("components/card.css");
 @import url("components/table-of-contents.css");
 @import url("components/ask-ai.css");


### PR DESCRIPTION
This PR fixes search text color in dark mode

Before:
<img width="607" alt="CleanShot 2023-04-25 at 13 48 20@2x" src="https://user-images.githubusercontent.com/4144459/234267407-c24ceab9-8504-4322-8a7e-121d096dcf2e.png">

After:
<img width="679" alt="CleanShot 2023-04-25 at 13 48 08@2x" src="https://user-images.githubusercontent.com/4144459/234267429-4bf5af37-e126-4afb-94a5-d9b88d4e41e4.png">

