### PR TITLE
Change the recipient email in sample webhook payloads for `Customer requested email change`

### DIFF
--- a/docs/developer/extending/apps/sample-webhook-payloads.mdx
+++ b/docs/developer/extending/apps/sample-webhook-payloads.mdx
@@ -88,7 +88,7 @@ Each webhook payload has the `notify_event` field which defines the type of the 
     },
     "old_email": "test@example.com1",
     "new_email": "new.email@example.com1",
-    "recipient_email": "test@example.com1",
+    "recipient_email": "new.email@example.com1",
     "token": "ajcv09-f3f7880d4a5e33650fe12f9cc372a23f",
     "redirect_url": "https://dev.saleor.cloud/account-change?email=test%40example.com1&token=ajcv09-f3f7880d4a5e33650fe12f9cc372a23f",
     "domain": "example.com",


### PR DESCRIPTION
The `recipient_email` that we use to send an email is the `email` from `new_email` field, not from `old_email`. 