### PR TITLE
Update 3.13 to 3.14 upgrade guide

### DIFF
--- a/docs/upgrade-guides/3-13-to-3-14.mdx
+++ b/docs/upgrade-guides/3-13-to-3-14.mdx
@@ -4,7 +4,7 @@ sidebar_position: 7
 ---
 
 :::info
-To follow the zero-downtime strategy when upgrading to 3.14, **we recommend migrating to 3.13.6 first** and turn on the celery worker to process all data migrations asynchronously.
+To follow the zero-downtime strategy when upgrading to 3.14, **we recommend migrating to 3.13.8 first** and turn on the celery worker to process all data migrations asynchronously.
 Otherwise, you will need to downtime your solution to ensure correct data migration.
 :::
 

--- a/docs/upgrade-guides/3-13-to-3-14.mdx
+++ b/docs/upgrade-guides/3-13-to-3-14.mdx
@@ -4,7 +4,7 @@ sidebar_position: 7
 ---
 
 :::info
-To follow the zero-downtime strategy when upgrading to 3.14, **we recommend migrating to 3.13.8 first** and turn on the celery worker to process all data migrations asynchronously.
+To follow the zero-downtime strategy when upgrading to 3.14, **we recommend first migrating to at least 3.13.8** and turn on the celery worker to process all data migrations asynchronously.
 Otherwise, you will need to downtime your solution to ensure correct data migration.
 :::
 


### PR DESCRIPTION
I want to merge this change because when Saleor `3.13.8`, with new celery data migrations, is released, we need to recommend migrations to this version before 3.14 to follow the zero-downtime strategy. 