### PR TITLE
Add note about `actions` field in the webhook response for transactions

### DIFF
--- a/docs/developer/extending/apps/synchronous-webhooks/transaction-webhooks.mdx
+++ b/docs/developer/extending/apps/synchronous-webhooks/transaction-webhooks.mdx
@@ -147,8 +147,9 @@ The response, in this case, should have bellowed structure:
   "result": "<CHARGE_SUCCESS or CHARGE_FAILURE>",
   "amount": "<Decimal amount of the processed action>",
   "time": "<[Optional] time of the action>",
-  "externalUrl": "<[Optional] external url with action details.",
-  "message": "<[Optional] message related to the action."
+  "externalUrl": "<[Optional] external url with action details>",
+  "message": "<[Optional] message related to the action>",
+  "actions": "<[Optional] list of actions available for the transaction. Possible items: CHARGE, REFUND, CANCEL>"
 }
 ```
 
@@ -281,8 +282,9 @@ The response in this case should have bellowed structure:
   "result": "<CANCEL_SUCCESS or CANCEL_FAILURE>",
   "amount": "<Decimal amount of the processed action>",
   "time": "<[Optional] time of the action>",
-  "externalUrl": "<[Optional] external url with action details.",
-  "message": "<[Optional] message related to the action."
+  "externalUrl": "<[Optional] external url with action details>",
+  "message": "<[Optional] message related to the action>",
+  "actions": "<[Optional] list of actions available for the transaction. Possible items: CHARGE, REFUND, CANCEL>"
 }
 ```
 
@@ -413,8 +415,9 @@ The response in this case should have bellowed structure:
   "result": "<REFUND_SUCCESS or REFUND_FAILURE>",
   "amount": "<Decimal amount of the processed action>",
   "time": "<[Optional] time of the action>",
-  "externalUrl": "<[Optional] external url with action details.",
-  "message": "<[Optional] message related to the action."
+  "externalUrl": "<[Optional] external url with action details>",
+  "message": "<[Optional] message related to the action>",
+  "actions": "<[Optional] list of actions available for the transaction. Possible items: CHARGE, REFUND, CANCEL>"
 }
 ```
 
@@ -596,7 +599,8 @@ The response in this case should have bellowed structure:
   "data": "<[Optional] JSON data tha will be returned to storefront>",
   "time": "<[Optional] time of the action>",
   "externalUrl": "<[Optional] external url with action details.",
-  "message": "<[Optional] message related to the action."
+  "message": "<[Optional] message related to the action>",
+  "actions": "<[Optional] list of actions available for the transaction. Possible items: CHARGE, REFUND, CANCEL>"
 }
 ```
 
@@ -707,7 +711,8 @@ The response in this case should have bellowed structure:
   "data": "<[Optional] JSON data tha will be returned to storefront>",
   "time": "<[Optional] time of the action>",
   "externalUrl": "<[Optional] external url with action details.",
-  "message": "<[Optional] message related to the action."
+  "message": "<[Optional] message related to the action>",
+  "actions": "<[Optional] list of actions available for the transaction. Possible items: CHARGE, REFUND, CANCEL>"
 }
 ```
 


### PR DESCRIPTION
Covers the bug reported here: https://github.com/saleor/saleor/issues/12787