### PR TITLE
Change Overview/Architecture page content

### DIFF
--- a/docs/overview/architecture.mdx
+++ b/docs/overview/architecture.mdx
@@ -5,33 +5,22 @@ title: Architecture
 Saleor consists of three distinctive components:
 
 1. First is the **Saleor Core**, the backend server that exposes the [GraphQL API](api-usage/overview.mdx). The core is written in Python and does not have a user interface. It maintains its state in a PostgreSQL database and caches some information in Redis where available.
-
 2. Then, there's the **Saleor Dashboard**, which implements the user interface that staff members can use to operate a store. The dashboard is a React application that runs in the browser and talks to the core server. It's a static website, so it does not have any backend code.
-
-3. Lastly, there's the **Next.js Storefront**, an example storefront implemented in React with Next.js. You can customize its code to suit your needs or build a custom storefront using the underlying **Saleor SDK**.
+3. To connect Saleor with external services, best way will be to use **Apps**. They can react on Saleor Events via Webhooks and call Saleor via GraphQL API. Saleor provides official App Store with first-party Apps by the Saleor Team. Learn more about [extending Saleor](developer/extending/overview.mdx)
+4. Lastly, there's a **Storefront**, usually custom frontend dedicated for every business. It's connected with Saleor via GraphQL API, other technologies can be chosen individually. Saleor provides example Storefront that can be used of forked.
 
 All three components communicate using GraphQL over HTTPS.
 
 ```mermaid
 graph LR
-  S[Storefront] ---|JavaScript| SDK[Saleor SDK]
-  SDK ---|GraphQL| CORE((Saleor Core))
-  D[Dashboard] ---|GraphQL| CORE
-  CORE ---|PostgreSQL| P[(Database)]
-  CORE ---|Redis| CACHE[(Cache)]
+  S[Storefront] -->|GraphQL| C((Saleor Core API))
+  D[Dashboard] -->|GraphQL| C((Saleor Core API))
+  C((Saleor Core API)) -->|Webhooks| A
+  A[App] -->|GraphQL| C((Saleor Core API))
 ```
 
-## Extending Saleor
+## Saleor Core Architecture
 
-While you could modify Saleor directly, we advise against this as once your deployment diverges from the upstream Saleor, it becomes hard to keep it updated.
+Saleor Core contains several components
 
-Extending Saleor is best done using external applications that rely on webhooks and GraphQL to communicate with Saleor.
-
-```mermaid
-graph LR
-  C -->|Webhooks| A[App]
-  A -->|GraphQL| C
-  C((Saleor Core))
-```
-
-To learn more, see [Extending Saleor](developer/extending/overview.mdx).
+TODO Diagram with Saleor internal components: Python Service, Postgres, Redis, queue, workers, tracing...


### PR DESCRIPTION
1. Remove mentions about Saleor/SDK
2. Changed Storefront description to better highlight headless approach
3. Included Apps as a first-party architecture component
4. Extracted Saleor details from Architecture diagram

Based on [C4 model](https://c4model.com/)
1. Architecture - container abstraction
2. Core - component abstraction

<img width="555" alt="Zrzut ekranu 2023-05-21 o 10 26 49" src="https://github.com/saleor/saleor-docs/assets/9268745/e9a30e6f-0cf5-4f59-829c-92851b1cf78c">

- [ ] TODO - add Saleor Core diagram
