### PR TITLE
Update upgrade guide for 3.14

### DIFF
--- a/docs/upgrade-guides/3-13-to-3-14.mdx
+++ b/docs/upgrade-guides/3-13-to-3-14.mdx
@@ -4,7 +4,7 @@ sidebar_position: 7
 ---
 
 :::info
-To follow the zero-downtime strategy when upgrading to 3.14, **It is recommend first migrating to at least 3.13.8** and turn on the celery worker to process all data migrations asynchronously.
+To follow the zero-downtime strategy when upgrading to 3.14, **It is recommend first migrating to at least 3.13.17** and turn on the celery worker to process all data migrations asynchronously.
 Otherwise, you will need to downtime your solution to ensure correct data migration.
 :::
 

--- a/docs/upgrade-guides/3-13-to-3-14.mdx
+++ b/docs/upgrade-guides/3-13-to-3-14.mdx
@@ -4,7 +4,7 @@ sidebar_position: 7
 ---
 
 :::info
-To follow the zero-downtime strategy when upgrading to 3.14, **It is recommended first migrate to at least 3.13.17** and turn on the Celery worker to process all data migrations asynchronously.
+To follow the zero-downtime strategy when upgrading to 3.14, **It is recommended to first migrate to at least 3.13.17** and turn on the Celery worker to process all data migrations asynchronously.
 Otherwise, you will need to downtime your solution to ensure correct data migration.
 :::
 

--- a/docs/upgrade-guides/3-13-to-3-14.mdx
+++ b/docs/upgrade-guides/3-13-to-3-14.mdx
@@ -4,7 +4,7 @@ sidebar_position: 7
 ---
 
 :::info
-To follow the zero-downtime strategy when upgrading to 3.14, **It is recommend first migrating to at least 3.13.17** and turn on the celery worker to process all data migrations asynchronously.
+To follow the zero-downtime strategy when upgrading to 3.14, **It is recommended first migrate to at least 3.13.17** and turn on the Celery worker to process all data migrations asynchronously.
 Otherwise, you will need to downtime your solution to ensure correct data migration.
 :::
 


### PR DESCRIPTION
Upgrade update guide for 3.14 to contain the last 3.13 patch with the required migrations to migrate without downtime