### PR TITLE
Remove searchParameters from Algolia

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -232,9 +232,6 @@ module.exports = {
       apiKey: "e4b2fbb46f8e998981100702d37da551",
       indexName: "saleor",
       placeholder: "Search Saleor Documentation",
-      searchParameters: {
-        customRanking: ["desc(rank)"],
-      },
     },
 
     colorMode: {


### PR DESCRIPTION
DOCSEARCH can use only [Search API Parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/)