### PR TITLE
Update products.mdx typo mistake

### DIFF
--- a/docs/developer/products.mdx
+++ b/docs/developer/products.mdx
@@ -11,7 +11,7 @@ You can either retrieve a single product or a list of products. You may require 
 ## Multiple channels and products
 
 Customers can only fetch products from available channels. Because listing channels is only available for staff users, you will need to provide channel slugs to your storefront.
-Besides availability, you can define more parameters on a channel basis using [ProductChannelListing](docs/api-reference/products/objects/product-channel-listing.mdx):
+Besides availability, you can define more parameters on a channel basis, using [ProductChannelListing](docs/api-reference/products/objects/product-channel-listing.mdx):
 
 - `publicationDate`
 - `isPublished`


### PR DESCRIPTION
In the sentence: "Besides availability, you can define more parameters on a channel basis using ProductChannelListing."

The word "basis" should be changed to "basis," with a comma after it. The corrected sentence would be: "Besides availability, you can define more parameters on a channel basis, using ProductChannelListing."