### PR TITLE
Add information on where to look for a local dashboard instance

### DIFF
--- a/docs/setup/docker-compose.mdx
+++ b/docs/setup/docker-compose.mdx
@@ -56,6 +56,8 @@ Use the following command to run all Saleor containers (from within the `saleor-
 docker compose up
 ```
 
+The dashboard will now be available at [localhost:9000](localhost:9000).
+
 :::note
 Both storefront and dashboard are relatively large frontend projects, and it might take up to a few minutes for them to compile, depending on your CPU. If nothing shows up on port 3001 or 9000, wait until `Compiled successfully` shows in the console output.
 :::

--- a/docs/setup/docker-compose.mdx
+++ b/docs/setup/docker-compose.mdx
@@ -56,7 +56,7 @@ Use the following command to run all Saleor containers (from within the `saleor-
 docker compose up
 ```
 
-The dashboard will now be available at [localhost:9000](localhost:9000).
+The dashboard will now be available at [localhost:9000](http://localhost:9000).
 
 :::note
 Both storefront and dashboard are relatively large frontend projects, and it might take up to a few minutes for them to compile, depending on your CPU. If nothing shows up on port 3001 or 9000, wait until `Compiled successfully` shows in the console output.


### PR DESCRIPTION
It's not clear how to access dashboard after the docker based setup has been performed so I added a sentence about that.