### PR TITLE
apps docs improvement

### DIFF
--- a/docs/developer/extending/apps/developing-apps/app-template.mdx
+++ b/docs/developer/extending/apps/developing-apps/app-template.mdx
@@ -10,6 +10,15 @@ If you want to explore implementations of the Saleor App Template, head over to 
 
 ## Installation
 
+:::info
+`saleor-app-template` repository requires you to install [`pnpm`](https://pnpm.io/). If you haven't already, please do so by running:
+
+```bash
+npm install -g pnpm
+```
+
+:::
+
 ### With CLI
 
 First, please make sure you have installed the [Saleor CLI](cli.mdx):

--- a/docs/developer/extending/apps/quickstart.mdx
+++ b/docs/developer/extending/apps/quickstart.mdx
@@ -2,15 +2,13 @@
 title: Quickstart
 ---
 
-Using the Saleor App is the fastest way of extending Saleor with custom logic. To start App development use [Saleor App Template](https://github.com/saleor/saleor-app-template) as a reference point. It is the boilerplate for writing Saleor Apps with Next.js.
+Saleor apps can be written in any programming language as long as it's a Web application conforming to the [app requirements](architecture/app-requirements).
 
-:::tip
+The existing app ecosystem in JavaScript can help you get up and running quickly.
 
-Saleor App can be written in any programming language as long as it's a Web application conforming to [requirements](architecture/app-requirements)
+## JavaScript
 
-:::
-
-The simplest way is to use [Saleor CLI](/cli.mdx) create your first Saleor App.
+The simplest way to create a Saleor app is to use [Saleor CLI](/cli.mdx):
 
 ```bash
 saleor app create my-saleor-app
@@ -24,22 +22,19 @@ with `npx`
 npx saleor app create my-saleor-app
 ```
 
-CLI clones the [Saleor App Template](https://github.com/saleor/saleor-app-template) repository and installs dependencies. Saleor recommends using [Saleor CLI](/cli.mdx) as it provides more commands for the App development which may be useful with the journey with Apps.
+CLI clones the [Saleor App Template](developing-apps/app-template) repository and installs dependencies. Saleor recommends using [Saleor CLI](/cli.mdx) as it provides more commands for the App development.
 
-While the process is done `cd` the App folder and start the App
+While the process is done, `cd` into the App folder and start the App:
 
 ```bash
 cd my-saleor-app
 pnpm dev
 ```
 
-:::info
-To work with the `saleor-app-template` repository, you need to install [`pnpm`](https://pnpm.io/). If you haven't already, please do so by running:
-
-```bash
-npm install -g pnpm
-```
-
-:::
-
 That's it! Your app should be up and running.
+
+## Other languages
+
+### Python
+
+While Saleor doesn't provide an official template for Python apps, we can recommend using [`mirumee/saleor-app-framework-python`](https://github.com/mirumee/saleor-app-framework-python). It was created by our partner [Mirumee Software](https://github.com/mirumee), with some contributions from core Saleor members.


### PR DESCRIPTION
## Context
We received feedback from @aniav that it's not clear enough that JavaScript isn't the only option to create Saleor apps.

## Features
- I split up the "Quickstart" article into sections "JavaScript" and "Other languages", while making it clear there is an existing app ecosystem in JS.
- Added a paragraph about the app solutions in Python, linking to Mirumee's [`saleor-app-framework-python`](https://github.com/mirumee/saleor-app-framework-python).