### PR TITLE
EAM App: Mention using a proper sender address

### DIFF
--- a/docs/developer/app-store/apps/emails-and-messages/smtp.mdx
+++ b/docs/developer/app-store/apps/emails-and-messages/smtp.mdx
@@ -47,7 +47,9 @@ Both services have similar functionality. The following guide will use MailSlurp
 2. Create a new inbox - [documentation](https://www.mailslurp.com/guides/creating-inboxes/)
 3. Choose `SMTP` as the inbox type
 4. Choose `Virtual inbox`. This will create an inbox that captures all emails, so none will be sent to the original addressee
-5. Use credentials of the new inbox to configure the SMTP provider in the application
+5. Configure the SMTP provider in the application:
+   - Fill SMTP server credentials form
+   - Use inbox address as sender email
 
 More information can be found in [the official guide](https://help.mailtrap.io/article/109-getting-started-with-mailtrap-email-testing).
 

--- a/docs/developer/app-store/apps/emails-and-messages/troubleshooting.mdx
+++ b/docs/developer/app-store/apps/emails-and-messages/troubleshooting.mdx
@@ -30,6 +30,9 @@ If you encounter a problem that is not covered here or need further assistance, 
   1. Go to configuration details
   2. In the `Events` section, click on `Edit` for the event you are investigating
   3. Template on the right-hand side should be rendered properly
+- If your server validates outgoing messages, the sender's email address is the same as used by the inbox
+  1. Go to configuration details
+  2. Check the Sender's email address
 
 ## Sendgrid
 


### PR DESCRIPTION
Added instructions for easy-to-miss mistake - using the wrong sender address.