### PR TITLE
Update list of supported metadata objects

### DIFF
--- a/docs/developer/metadata.mdx
+++ b/docs/developer/metadata.mdx
@@ -8,32 +8,7 @@ Metadata allows you to store additional information about each object, for examp
 
 ## Supported object types
 
-The following models contain metadata fields in which data can be modified:
-
-- [`App`](docs/api-reference/apps/objects/app.mdx)
-- [`Attribute`](docs/api-reference/attributes/objects/attribute.mdx)
-- [`Category`](docs/api-reference/products/objects/category.mdx)
-- [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx)
-- [`CheckoutLine`](docs/api-reference/checkout/objects/checkout-line.mdx)
-- [`Collection`](docs/api-reference/products/objects/collection.mdx)
-- [`Fulfillment`](docs/api-reference/orders/objects/fulfillment.mdx)
-- [`Invoice`](docs/api-reference/orders/objects/invoice.mdx)
-- [`Menu`](docs/api-reference/menu/objects/menu.mdx)
-- [`MenuItem`](docs/api-reference/menu/objects/menu-item.mdx)
-- [`Order`](docs/api-reference/orders/objects/order.mdx)
-- [`OrderLine`](docs/api-reference/orders/objects/order-line.mdx)
-- [`Page`](docs/api-reference/pages/objects/page.mdx)
-- [`PageType`](docs/api-reference/pages/objects/page-type.mdx)
-- [`Product`](docs/api-reference/products/objects/product.mdx)
-- [`ProductType`](docs/api-reference/products/objects/product-type.mdx)
-- [`ProductVariant`](docs/api-reference/products/objects/product-variant.mdx)
-- [`Sale`](docs/api-reference/discounts/objects/sale.mdx)
-- [`ShippingMethod`](docs/api-reference/shipping/objects/shipping-method.mdx)
-- [`ShippingMethodType`](docs/api-reference/shipping/objects/shipping-method-type.mdx)
-- [`ShippingZone`](docs/api-reference/shipping/objects/shipping-zone.mdx)
-- [`User`](docs/api-reference/users/objects/user.mdx)
-- [`Voucher`](docs/api-reference/discounts/objects/voucher.mdx)
-- [`Warehouse`](docs/api-reference/products/objects/warehouse.mdx)
+Metadata is avaialble in all GraphQL types that implement the `ObjectWithMetadata` interface. See the [Implemented by](api-reference/miscellaneous/interfaces/object-with-metadata.mdx#implemented-by) section of the `ObjectWithMetadata` interface for the full list of supported types.
 
 ## Private and public metadata
 


### PR DESCRIPTION
We can link to the ObjectWithMetadata type for the list of all supported items, which is easier to maintain than updating the list manually.