### PR TITLE
Add invoices docs

### DIFF
--- a/components/AppMetadata/AppMetadata.module.css
+++ b/components/AppMetadata/AppMetadata.module.css
@@ -1,0 +1,7 @@
+.root {
+  display: flex;
+  gap: 20px;
+  padding: 20px;
+  border-radius: 10px;
+  border: 1px solid var(--gray5);
+}

--- a/components/AppMetadata/AppMetadata.tsx
+++ b/components/AppMetadata/AppMetadata.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import styles from "./AppMetadata.module.css";
+
+type Props = {
+  minSaleorVersion: string;
+  roadmapUrl: string;
+  githubUrl: string;
+};
+
+export const AppMetadata = ({
+  minSaleorVersion,
+  roadmapUrl,
+  githubUrl,
+}: Props) => {
+  return (
+    <div className={styles.root}>
+      <div>
+        <span>
+          Saleor version required: <strong>{minSaleorVersion}</strong>
+        </span>
+      </div>
+      <div>
+        <span>
+          Roadmap: <a href={roadmapUrl}>GitHub</a>
+        </span>
+      </div>
+      <div>
+        <span>
+          Repository: <a href={githubUrl}>GitHub</a>
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/docs/developer/app-store/apps/invoices.mdx
+++ b/docs/developer/app-store/apps/invoices.mdx
@@ -78,7 +78,7 @@ Check [Github issues](https://github.com/saleor/apps/labels/App%3A%20Invoices) t
 
 ## Development
 
-Visit the [development guide](../extending/apps/developing-apps/app-examples#saleor-apps) to learn more about App Store app development.
+Visit the [development guide](../../extending/apps/developing-apps/app-examples) to learn more about App Store app development.
 
 ### Env variables
 

--- a/docs/developer/app-store/apps/invoices.mdx
+++ b/docs/developer/app-store/apps/invoices.mdx
@@ -3,14 +3,15 @@ title: Invoices
 sidebar_position: 4
 ---
 
+import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
+
 # Invoices
 
-## Metadata
-
-- Saleor version: 3.10
-- Roadmap https://github.com/saleor/apps/labels/App%3A%20Invoices
-- Link to dashboard
-- Link to GitHub
+<AppMetadata
+  minSaleorVersion="3.10"
+  roadmapUrl="https://github.com/saleor/apps/labels/App%3A%20Invoices"
+  githubUrl="https://github.com/saleor/apps/tree/main/apps/invoices"
+/>
 
 ## Introduction
 

--- a/docs/developer/app-store/apps/invoices.mdx
+++ b/docs/developer/app-store/apps/invoices.mdx
@@ -1,0 +1,86 @@
+---
+title: Invoices
+sidebar_position: 4
+---
+
+# Invoices
+
+## Metadata
+
+- Saleor version: 3.10
+- Roadmap https://github.com/saleor/apps/labels/App%3A%20Invoices
+- Link to dashboard
+- Link to GitHub
+
+## Introduction
+
+The Invoices app allows you to generate simple PDF invoice files for every order in your store.
+
+## Features
+
+Generates a PDF file when an invoice is requested (in Dashboard or with an API). Then attaches it to the order.
+
+The invoice shop address can be inherited from Shop settings or configured manually per channel.
+
+## Assumptions & limitations
+
+- The PDF template is fixed and can't be changed by the user.
+- The PDF template is in English only.
+
+## Permissions
+
+The App requires `MANAGE_ORDERS` permission to be able to:
+
+- Receive the `INVOICE_REQUESTED` webhook
+- Read order data to generate the invoice
+- Attach the invoice to the order
+
+The staff user configuring the App must have `MANAGE_APPS` and `MANAGE_ORDERS` permissions.
+
+## Application flow
+
+The App reacts on a single webhook, and it ends its flow once a PDF file is attached to the order.
+
+See the detailed flow below:
+
+```mermaid
+sequenceDiagram
+    Saleor->>+App: Trigger INVOICE_REQUESTED
+    App->>+App: Generate a PDF file in memory
+    App->>+Saleor: Upload a PDF file
+    Saleor->>+App: Provide a link to the PDF file
+    App->>+Saleor: Attach a link to the PDF file to the Order
+```
+
+## Configuration
+
+The app allows to configure a shop address per each channel separately.
+
+If the channel is not configured, the app will fetch the Shop address from settings and use it.
+
+### Testing
+
+To verify if the app works:
+
+1. Ensure the "Invoices" plugin is disabled; otherwise, duplicated invoices can be generated.
+2. Ensure the App is installed and enabled.
+3. Optionally configure the custom address. If the custom address is not configured, fill shop address in the Dashboard settings.
+4. Find any order in the Dashboard, find the "Invoices" section, and click the "Generate" button.
+5. Wait a couple of seconds and refresh the dashboard.
+6. The invoice should be attached to the order in the "Invoices" section.
+
+## Troubleshooting
+
+- During local development with Saleor running locally, there are file uploading issues; see [this issue](https://github.com/saleor/apps/issues/285).
+
+Check [Github issues](https://github.com/saleor/apps/labels/App%3A%20Invoices) to see up to date list of known issues or to report a new one.
+
+## Development
+
+Visit the development guide to learn more about App Store app development.
+
+### Env variables
+
+Apart from common env variables, the Invoice app accepts the following:
+
+- `TEMP_PDF_STORAGE_DIR=` - a temp directory where the PDF files will be stored. In Vercel, set `/tmp`. Add it to `.gitignore`

--- a/docs/developer/app-store/apps/invoices.mdx
+++ b/docs/developer/app-store/apps/invoices.mdx
@@ -21,7 +21,7 @@ The Invoices app allows you to generate simple PDF invoice files for every order
 
 Generates a PDF file when an invoice is requested (in Dashboard or with an API). Then attaches it to the order.
 
-The invoice shop address can be inherited from Shop settings or configured manually per channel.
+The invoice shop address can be inherited from the [Shop](https://docs.saleor.io/docs/3.x/api-storefront/miscellaneous/objects/shop) settings or configured manually per channel.
 
 ## Assumptions & limitations
 
@@ -72,13 +72,13 @@ To verify if the app works:
 
 ## Troubleshooting
 
-- During local development with Saleor running locally, there are file uploading issues; see [this issue](https://github.com/saleor/apps/issues/285).
+- During development with Saleor running locally, there are file uploading issues; see [this issue](https://github.com/saleor/apps/issues/285).
 
 Check [Github issues](https://github.com/saleor/apps/labels/App%3A%20Invoices) to see up to date list of known issues or to report a new one.
 
 ## Development
 
-Visit the development guide to learn more about App Store app development.
+Visit the [development guide](../extending/apps/developing-apps/app-examples#saleor-apps) to learn more about App Store app development.
 
 ### Env variables
 

--- a/docs/developer/app-store/apps/invoices.mdx
+++ b/docs/developer/app-store/apps/invoices.mdx
@@ -21,7 +21,7 @@ The Invoices app allows you to generate simple PDF invoice files for every order
 
 Generates a PDF file when an invoice is requested (in Dashboard or with an API). Then attaches it to the order.
 
-The invoice shop address can be inherited from the [Shop](https://docs.saleor.io/docs/3.x/api-storefront/miscellaneous/objects/shop) settings or configured manually per channel.
+The invoice shop address can be inherited from the [Shop](../../../api-storefront/miscellaneous/objects/shop) settings or configured manually per channel.
 
 ## Assumptions & limitations
 
@@ -65,7 +65,7 @@ To verify if the app works:
 
 1. Ensure the "Invoices" plugin is disabled; otherwise, duplicated invoices can be generated.
 2. Ensure the App is installed and enabled.
-3. Optionally configure the custom address. If the custom address is not configured, fill shop address in the Dashboard settings.
+3. Optionally configure the custom address. If the custom address is not configured, fill [Shop address](../../../api-storefront/miscellaneous/objects/shop) in the Dashboard settings.
 4. Find any order in the Dashboard, find the "Invoices" section, and click the "Generate" button.
 5. Wait a couple of seconds and refresh the dashboard.
 6. The invoice should be attached to the order in the "Invoices" section.

--- a/sidebars.js
+++ b/sidebars.js
@@ -103,6 +103,7 @@ module.exports = {
             "developer/app-store/apps/crm",
             "developer/app-store/apps/stripe",
             "developer/app-store/apps/adyen",
+            "developer/app-store/apps/invoices",
             "developer/app-store/apps/cms",
             {
               type: "category",


### PR DESCRIPTION
This adds missing functional docs for Invoices app, based on the [template](https://github.com/saleor/saleor-docs/pull/829)