### PR TITLE
[programmatic-payments] Stored payment methods

### DIFF
--- a/docs/developer/extending/webhooks/synchronous-events/overview.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/overview.mdx
@@ -36,7 +36,7 @@ The Synchronous can be grouped into the following categories:
 - [Payment events](./payment.mdx): allow delegating payment handling to Saleor Apps
 - [Shipping events](./shipping.mdx): allow Saleor Apps to control shipping methods available for checkouts and draft orders.
 - [Tax events](./tax.mdx): allow delegating tax calculations to Saleor Apps.
-- [Transaction events](./transaction.mdx): allow delegating the transaction's action to the Saleor App.
-- [Stored payment method events](./stored-payment-method.mdx): allow delegating the management of stored payment method to the Saleor App.
+- [Transaction events](./transaction.mdx): allow delegating the transaction's action to Saleor App.
+- [Stored payment method events](./stored-payment-method.mdx): allow delegating the management of stored payment method to Saleor App.
 
 The [WebhookEventTypeSyncEnum](../../../../api-reference/webhooks/enums/webhook-event-type-sync-enum#values) represents the latest list of synchronous webhooks.

--- a/docs/developer/extending/webhooks/synchronous-events/overview.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/overview.mdx
@@ -37,5 +37,6 @@ The Synchronous can be grouped into the following categories:
 - [Shipping events](./shipping.mdx): allow Saleor Apps to control shipping methods available for checkouts and draft orders.
 - [Tax events](./tax.mdx): allow delegating tax calculations to Saleor Apps.
 - [Transaction events](./transaction.mdx): allow delegating the transaction's action to the Saleor App.
+- [Stored payment method events](./stored-payment-method.mdx): allow delegating the management of stored payment method to the Saleor App.
 
 The [WebhookEventTypeSyncEnum](../../../../api-reference/webhooks/enums/webhook-event-type-sync-enum#values) represents the latest list of synchronous webhooks.

--- a/docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx
@@ -1,0 +1,123 @@
+---
+title: Stored payment method events
+---
+
+# Introduction
+
+:::caution
+This feature is in the **Feature Preview** stage, which means that it is available for experimentation and
+feedback. However, it is still undergoing development and is subject to modifications.
+:::
+
+A stored payment method is a payment method that can be used later by customers without providing all payment details.
+Saleor has synchronous webhooks that allow delegating the stored payment method's management to the payment app.
+
+## Key concepts
+
+The `HANDLE_PAYMENTS` permission is required for the App to receive store payment method webhooks.
+
+The usage of the webhook is strictly related to the usage of stored payment method.
+You can find more details about it in the [_Stored Payment Methods_](../../../payments#stored-payment-methods).
+
+:::info
+
+This feature is dedicated to [third-party](api-reference/apps/enums/app-type-enum.mdx#code-style-fontweight-normal-apptypeenumbthirdpartybcode) apps.
+
+:::
+
+## List stored payment methods
+
+`LIST_STORED_PAYMENT_METHODS`
+
+:::info
+
+This feature was introduced in **Saleor 3.15**.
+
+:::
+
+A synchronous webhook is called when the user wants to fetch stored payment methods. Triggered when a
+customer requested a field [User.storedPaymentMethod](api-storefront/users/objects/user.mdx#code-style-fontweight-normal-userbstoredpaymentmethodsbcodestoredpaymentmethod--), [checkout.storedPaymentMethods](api-storefront/checkout/objects/checkout.mdx#code-style-fontweight-normal-checkoutbstoredpaymentmethodsbcodestoredpaymentmethod--).
+
+The webhook expects to return a list of payment methods that are assigned by the customer. The payment
+methods from the webhook response will be returned as a response for [User.storedPaymentMethod](api-storefront/users/objects/user.mdx#code-style-fontweight-normal-userbstoredpaymentmethodsbcodestoredpaymentmethod--), [checkout.storedPaymentMethods](api-storefront/checkout/objects/checkout.mdx#code-style-fontweight-normal-checkoutbstoredpaymentmethodsbcodestoredpaymentmethod--) fields.
+
+:::info
+
+To reduce the number of HTTP requests triggered to the payment app, the response is cached on
+Saleor side. Saleor will trigger a new request when the cache will expire or become invalid.
+
+:::
+
+### Request
+
+Saleor will send a
+[LIST_STORED_PAYMENT_METHODS](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#code-style-fontweight-normal-webhookeventtypesyncenumblist_stored_payment_methodsbcode)
+webhook by using the [ListStoredPaymentMethods](api-reference/payments/objects/list-stored-payment-methods.mdx) subscription type or with a pre-defined payload in case of a missing subscription query.
+
+You can find more details about building webhook subscription query
+[here](../../../extending/webhooks/subscription-webhook-payloads).
+
+The example below shows a sample webhook subscription defined to list stored payment methods:
+
+```graphql
+subscription {
+  event {
+    ... on ListStoredPaymentMethods {
+      user {
+        id
+      }
+      channel {
+        id
+      }
+      value {
+        amount
+        currency
+      }
+    }
+  }
+}
+```
+
+The example below shows the pre-defined payload that will be used in the case when a subscription query is not provided:
+
+```json
+{
+  "user_id": "VXNlcjoyOA==",
+  "channel_slug": "main",
+  "currency": "USD",
+  "amount": "100"
+}
+```
+
+### Response
+
+The app needs to return a list of stored payment methods that can be used by customer.
+
+The response in this case should have the following structure:
+
+```json
+{
+  "paymentMethods": [
+    {
+      "id": "<ID of stored payment method>",
+      "supportedPaymentFlows": "<list of supported flows that can be performed with this payment method.>",
+      "type": "<type of the payment method. For example: Credit Card>",
+      // "creditCardInfo": [Optional] credit card information if the payment method is a credit card.
+      "creditCardInfo": {
+        "brand": "<credit card bran>",
+        "lastDigits": "<last digits>",
+        "expMonth": "<expiration month>",
+        "expYear": "<expiration year>",
+        "firstDigits": "<[Optional] first digits>"
+      },
+      "name": "<[Optional] name of the payment method. Example: last 4 digits of credit card, obfuscated email>",
+      "data": "<[Optional] JSON data tha will be returned to storefront>"
+    }
+  ]
+}
+```
+
+Below are the possible `supportedPaymentFlows` values and their explanations:
+
+- `INTERACTIVE` - Payment method can be used for 1 click checkout - it's prefilled in checkout
+  form (might require additional authentication from user).

--- a/docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx
@@ -69,10 +69,6 @@ subscription {
       channel {
         id
       }
-      value {
-        amount
-        currency
-      }
     }
   }
 }
@@ -83,9 +79,7 @@ The example below shows the pre-defined payload that will be used in the case wh
 ```json
 {
   "user_id": "VXNlcjoyOA==",
-  "channel_slug": "main",
-  "currency": "USD",
-  "amount": "100"
+  "channel_slug": "main"
 }
 ```
 

--- a/docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx
@@ -38,7 +38,7 @@ This feature was introduced in **Saleor 3.15**.
 A synchronous webhook is called when the user wants to fetch stored payment methods. Triggered when a
 customer requested a field [User.storedPaymentMethod](api-storefront/users/objects/user.mdx#code-style-fontweight-normal-userbstoredpaymentmethodsbcodestoredpaymentmethod--), [checkout.storedPaymentMethods](api-storefront/checkout/objects/checkout.mdx#code-style-fontweight-normal-checkoutbstoredpaymentmethodsbcodestoredpaymentmethod--).
 
-The webhook expects to return a list of payment methods that are assigned by the customer. The payment
+The webhook expects to return a list of payment methods that are assigned to the customer. The payment
 methods from the webhook response will be returned as a response for [User.storedPaymentMethod](api-storefront/users/objects/user.mdx#code-style-fontweight-normal-userbstoredpaymentmethodsbcodestoredpaymentmethod--), [checkout.storedPaymentMethods](api-storefront/checkout/objects/checkout.mdx#code-style-fontweight-normal-checkoutbstoredpaymentmethodsbcodestoredpaymentmethod--) fields.
 
 :::info

--- a/docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx
@@ -10,7 +10,7 @@ feedback. However, it is still undergoing development and is subject to modifica
 :::
 
 A stored payment method is a payment method that can be used later by customers without providing all payment details.
-Saleor has synchronous webhooks that allow delegating the stored payment method's management to the payment app.
+Saleor has synchronous webhooks that allow delegating the stored payment methods management to payment apps.
 
 ## Key concepts
 
@@ -44,7 +44,7 @@ methods from the webhook response will be returned as a response for [User.store
 :::info
 
 To reduce the number of HTTP requests triggered to the payment app, the response is cached on
-Saleor side. Saleor will trigger a new request when the cache will expire or become invalid.
+Saleor side. Saleor will trigger a new request when the cache expires or becomes invalid.
 
 :::
 
@@ -94,18 +94,18 @@ The response in this case should have the following structure:
   "paymentMethods": [
     {
       "id": "<ID of stored payment method>",
-      "supportedPaymentFlows": "<list of supported flows that can be performed with this payment method.>",
+      "supportedPaymentFlows": "<list of supported flows that can be performed with this payment method>",
       "type": "<type of the payment method. For example: Credit Card>",
       // "creditCardInfo": [Optional] credit card information if the payment method is a credit card.
       "creditCardInfo": {
-        "brand": "<credit card bran>",
+        "brand": "<credit card brand>",
         "lastDigits": "<last digits>",
         "expMonth": "<expiration month>",
         "expYear": "<expiration year>",
         "firstDigits": "<[Optional] first digits>"
       },
-      "name": "<[Optional] name of the payment method. Example: last 4 digits of credit card, obfuscated email>",
-      "data": "<[Optional] JSON data tha will be returned to storefront>"
+      "name": "<[Optional] name of the payment method. For example: last 4 digits of credit card, obfuscated email>",
+      "data": "<[Optional] JSON data that will be returned to storefront>"
     }
   ]
 }

--- a/docs/developer/payments.mdx
+++ b/docs/developer/payments.mdx
@@ -10,20 +10,20 @@ deliver a base reference for the user to work with.
 
 Saleor distinguishes two different approaches to processing a payment:
 
-- By using a [Saleor App](docs/developer/extending/apps/overview.mdx).
-- By using a [plugin](docs/developer/extending/plugins/overview.mdx) embedded in the Saleor code.
+- By using a [Saleor App](developer/extending/apps/overview.mdx).
+- By using a [plugin](developer/extending/plugins/overview.mdx) embedded in the Saleor code.
 
 ## Saleor App
 
 Saleor offers two ways to process payments using the Saleor app:
 
-- [Saleor payment app](docs/developer/payments.mdx#processing-a-payment-with-payment-app) - The communication between the storefront and payment app goes through Saleor.
+- [Saleor payment app](developer/payments.mdx#processing-a-payment-with-payment-app) - The communication between the storefront and payment app goes through Saleor.
   Saleor allows the storefront to provide and receive data directly from the app. Based on the response received from the app,
   Saleor can determine the current status of the payment and update it on its side.
-- [Saleor app with existing checkout app](docs/developer/payments.mdx#processing-a-payment-with-checkout-app): This is recommended for more advanced use cases when a shop owner needs to provide more
+- [Saleor app with existing checkout app](developer/payments.mdx#processing-a-payment-with-checkout-app): This is recommended for more advanced use cases when a shop owner needs to provide more
   validation before finalizing the checkout or to cover specific cases. The `CheckoutApp` handles the payment process on its side
   and uses Saleor's mutation to report any changes that happen for a specific `transactionItem`.
-  The order can be created by protected mutation [orderCreateFromCheckout](docs/api-reference/orders/mutations/order-create-from-checkout.mdx).
+  The order can be created by protected mutation [orderCreateFromCheckout](api-reference/orders/mutations/order-create-from-checkout.mdx).
 
 ### Processing a payment with the Payment App
 
@@ -957,7 +957,7 @@ and its amount is added to `transaction.chargedAmount`. Finally, the amount of t
 ### Stored payment methods
 
 A stored payment method is a payment method that can be used later by customers without providing all payment details.
-Saleor uses synchronous webhooks to notify the payment app about actions (such as [list-stored-payment-method](docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx#list-stored-payment-methods)) requested by the customer.
+Saleor uses synchronous webhooks to notify the payment app about actions (such as [list-stored-payment-method](developer/extending/webhooks/synchronous-events/stored-payment-method.mdx#list-stored-payment-methods)) requested by the customer.
 
 #### Listing user's stored payment methods
 
@@ -983,7 +983,7 @@ field will make a synchronous requests to each app subscribed to [LIST_STORED_PA
 webhook. Saleor as a response will return a list of payment methods returned by subscribed apps. The stored payment methods can be used in further steps of processing the payment.
 
 All details related to [LIST_STORED_PAYMENT_METHODS](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#code-style-fontweight-normal-webhookeventtypesyncenumblist_stored_payment_methodsbcode)
-webhook can be found [here](docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx#list-stored-payment-methods).
+webhook can be found [here](developer/extending/webhooks/synchronous-events/stored-payment-method.mdx#list-stored-payment-methods).
 
 The diagram below shows the workflow of a fetching stored payment methods with a payment app:
 

--- a/docs/developer/payments.mdx
+++ b/docs/developer/payments.mdx
@@ -957,7 +957,7 @@ and its amount is added to `transaction.chargedAmount`. Finally, the amount of t
 ### Stored payment methods
 
 A stored payment method is a payment method that can be used later by customers without providing all payment details.
-Saleor uses synchronous webhooks to notify the payment app about actions (such as list-stored-payment-method) requested by the customer.
+Saleor uses synchronous webhooks to notify the payment app about actions (such as [list-stored-payment-method](docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx#list-stored-payment-methods)) requested by the customer.
 
 #### Listing user's stored payment methods
 

--- a/docs/developer/payments.mdx
+++ b/docs/developer/payments.mdx
@@ -954,6 +954,52 @@ and its amount is added to `transaction.chargedAmount`. Finally, the amount of t
 
 ---
 
+### Stored payment methods
+
+A stored payment method is a payment method that can be used later by customers without providing all payment details.
+Saleor uses synchronous webhooks to notify the payment app about actions (such as list-stored-payment-method) requested by the customer.
+
+#### Listing user's stored payment methods
+
+:::info
+
+This feature was introduced in **Saleor 3.15**.
+
+:::
+
+:::caution
+
+This feature is in the **Feature Preview** stage, which means that it is available for experimentation and
+feedback. However, it is still undergoing development and is subject to modifications.
+
+:::
+
+:::info
+This feature is dedicated to [third-party](api-reference/apps/enums/app-type-enum.mdx#code-style-fontweight-normal-apptypeenumbthirdpartybcode) apps.
+:::
+
+Requesting [checkout.storedPaymentMethods](api-storefront/checkout/objects/checkout.mdx#code-style-fontweight-normal-checkoutbstoredpaymentmethodsbcodestoredpaymentmethod--) or [User.storedPaymentMethod](api-storefront/users/objects/user.mdx#code-style-fontweight-normal-userbstoredpaymentmethodsbcodestoredpaymentmethod--)
+field will make a synchronous requests to each app subscribed to [LIST_STORED_PAYMENT_METHODS](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#code-style-fontweight-normal-webhookeventtypesyncenumblist_stored_payment_methodsbcode)
+webhook. Saleor as a response will return a list of payment methods returned by subscribed apps. The stored payment methods can be used in further steps of processing the payment.
+
+All details related to [LIST_STORED_PAYMENT_METHODS](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#code-style-fontweight-normal-webhookeventtypesyncenumblist_stored_payment_methodsbcode)
+webhook can be found [here](docs/developer/extending/webhooks/synchronous-events/stored-payment-method.mdx#list-stored-payment-methods).
+
+The diagram below shows the workflow of a fetching stored payment methods with a payment app:
+
+```mermaid
+sequenceDiagram
+    actor User
+    User->>Storefront: Request a stored payment methods
+    Storefront->>Saleor: checkout.storedPaymentMethods query
+    loop Fetching from Payment Apps
+    Saleor->>Payment App: LIST_STORED_PAYMENT_METHODS webhook
+    Payment App->>Saleor: List of stored payment methods for the user
+    end
+    Saleor->>Storefront: Views list of stored payment methods
+    Storefront->>User: Sees a list of saved payment methods
+```
+
 ## Payment Plugin
 
 Using PaymentPlugin is strictly related to the checkout object and is explained in

--- a/sidebars.js
+++ b/sidebars.js
@@ -153,6 +153,7 @@ module.exports = {
                 "developer/extending/webhooks/synchronous-events/shipping",
                 "developer/extending/webhooks/synchronous-events/tax",
                 "developer/extending/webhooks/synchronous-events/transaction",
+                "developer/extending/webhooks/synchronous-events/stored-payment-method",
               ],
             },
           ],


### PR DESCRIPTION
It adds:
- section to payments: `stored-payment-methods`
- description of the list-stored-payment-methods webhook

More details can be found [here](https://github.com/saleor/saleor/issues/13384)