### PR TITLE
Fix paths for versioning

### DIFF
--- a/docs/api-usage/authentication.mdx
+++ b/docs/api-usage/authentication.mdx
@@ -158,7 +158,7 @@ along with the [source code](https://github.com/saleor/example-auth-sdk).
 
 This is the most common way of authenticating users. It is used in the Saleor Storefront and Dashboard.
 
-To authenticate a user, you need to use the [`tokenCreate`](docs/api-reference/authentication/mutations/token-create.mdx) mutation. It takes an email and password as input and returns an **access token** that can be used to access resources related to the user and a **refresh token** that can be used to generate future access tokens.
+To authenticate a user, you need to use the [`tokenCreate`](api-reference/authentication/mutations/token-create.mdx) mutation. It takes an email and password as input and returns an **access token** that can be used to access resources related to the user and a **refresh token** that can be used to generate future access tokens.
 
 ```graphql
 mutation {
@@ -237,7 +237,7 @@ A decoded token has the following structure:
 
 #### Fetching information about the currently authenticated user
 
-You can use the [`me`](docs/api-reference/users/queries/me.mdx) query to retrieve information about the currently authenticated user:
+You can use the [`me`](api-reference/users/queries/me.mdx) query to retrieve information about the currently authenticated user:
 
 ```graphql
 query {
@@ -280,7 +280,7 @@ console.log(result);
 
 ##### Verifying tokens with a mutation
 
-You can verify tokens by calling the [`tokenVerify`](docs/api-reference/authentication/mutations/token-verify.mdx) mutation:
+You can verify tokens by calling the [`tokenVerify`](api-reference/authentication/mutations/token-verify.mdx) mutation:
 
 ```graphql {2}
 mutation {
@@ -314,7 +314,7 @@ In the future, `tokenRefresh` mutation will also generate a new refresh token an
 
 #### Deactivating all tokens of a particular user
 
-The [`tokensDeactivateAll`](docs/api-reference/authentication/mutations/tokens-deactivate-all.mdx) mutation will invalidate all tokens (access and refresh, including the token used to invoke the mutation) that belong to the invoking user.
+The [`tokensDeactivateAll`](api-reference/authentication/mutations/tokens-deactivate-all.mdx) mutation will invalidate all tokens (access and refresh, including the token used to invoke the mutation) that belong to the invoking user.
 
 ```graphql
 mutation {
@@ -399,7 +399,7 @@ The implicit flow requires the following scopes to operate:
 
 If **Use OAuth scope permissions** is enabled, any permissions granted to a user on the authentication provider side will be used as the effective permissions on the Saleor side.
 
-If the plugin is configured to manage user permissions, you need to create OAuth scopes corresponding to Saleor permissions on the identity provider side. The plugin will request lowercase scope names based on the [`PermissionEnum`](docs/api-reference/users/enums/permission-enum.mdx). For example, the `MANAGE_PRODUCTS` corresponds to the `saleor:manage_products` scope.
+If the plugin is configured to manage user permissions, you need to create OAuth scopes corresponding to Saleor permissions on the identity provider side. The plugin will request lowercase scope names based on the [`PermissionEnum`](api-reference/users/enums/permission-enum.mdx). For example, the `MANAGE_PRODUCTS` corresponds to the `saleor:manage_products` scope.
 
 Saleor will look for supported permissions in the `scope` field of the access token. If the `scope` doesn't contain any Saleor permissions, Saleor will look for permissions in the token's `permissions` field.
 
@@ -468,7 +468,7 @@ Authorization: Bearer <access-token>
 
 To authenticate the user, you will need to redirect them to the identity provider's login page.
 
-Start by calling the [`externalAuthenticationUrl`](docs/api-reference/authentication/mutations/external-authentication-url.mdx) mutation passing `"mirumee.authentication.openidconnect"` as the `pluginId` argument and include a `redirectUri` parameter in the `input` argument:
+Start by calling the [`externalAuthenticationUrl`](api-reference/authentication/mutations/external-authentication-url.mdx) mutation passing `"mirumee.authentication.openidconnect"` as the `pluginId` argument and include a `redirectUri` parameter in the `input` argument:
 
 ```graphql
 mutation {
@@ -505,7 +505,7 @@ Next, redirect the user to the identity provider's login page. Once the user is 
 
 ### Obtaining an access token
 
-The [`externalObtainAccessTokens`](docs/api-reference/authentication/mutations/external-obtain-access-tokens.mdx) mutation will allow you to exchange the token returned by the identity provider for a Saleor access token.
+The [`externalObtainAccessTokens`](api-reference/authentication/mutations/external-obtain-access-tokens.mdx) mutation will allow you to exchange the token returned by the identity provider for a Saleor access token.
 
 Once again, you will need to pass `"mirumee.authentication.openidconnect"` as the `pluginId` argument, this time including the `code` and `state` received in the query parameters:
 
@@ -534,7 +534,7 @@ mutation {
 
 ### Refreshing tokens
 
-The [`externalRefresh`](docs/api-reference/authentication/mutations/external-refresh.mdx) mutation will generate a new access token when given a valid refresh token.
+The [`externalRefresh`](api-reference/authentication/mutations/external-refresh.mdx) mutation will generate a new access token when given a valid refresh token.
 
 As with the previous calls, you will need to pass `"mirumee.authentication.openidconnect"` as the `pluginId` argument, this time including the `refreshToken`:
 
@@ -559,7 +559,7 @@ mutation {
 
 ### Verifying tokens
 
-To verify the token, use the following [`externalVerify`](docs/api-reference/authentication/mutations/external-verify.mdx) mutation.
+To verify the token, use the following [`externalVerify`](api-reference/authentication/mutations/external-verify.mdx) mutation.
 
 Once again, you will need to pass `"mirumee.authentication.openidconnect"` as the `pluginId` argument, this time including the `token`:
 
@@ -588,7 +588,7 @@ The `user` field will contain the user's details if the token is valid.
 
 Logging out requires the user to be redirected to the identity provider's logout page.
 
-You can prepare the logout URL by calling the [`externalLogout`](docs/api-reference/authentication/mutations/external-logout.mdx) mutation. Any parameters you pass in the `input` argument will be included in the logout URL.
+You can prepare the logout URL by calling the [`externalLogout`](api-reference/authentication/mutations/external-logout.mdx) mutation. Any parameters you pass in the `input` argument will be included in the logout URL.
 
 ```graphql
 mutation ($input: JSONString!) {

--- a/docs/api-usage/error-handling.mdx
+++ b/docs/api-usage/error-handling.mdx
@@ -143,4 +143,4 @@ Validation errors are returned in a dedicated error field inside mutation result
 Although all error types contain a `message` field, the returned message is only meant for debugging and is not suitable for display to your customers. Please use the `code` field and provide your own meaningful error messages.
 :::
 
-We use enums for representing code values. All possible values for the query above can be found on the [AccountError](docs/api-reference/users/enums/account-error-code.mdx) page of the API reference section.
+We use enums for representing code values. All possible values for the query above can be found on the [AccountError](api-reference/users/enums/account-error-code.mdx) page of the API reference section.

--- a/docs/api-usage/filtering.mdx
+++ b/docs/api-usage/filtering.mdx
@@ -20,7 +20,7 @@ feedback. However, it is still undergoing development and is subject to modifica
 
 The `where` filtering allows specifying more complex conditions with the use of `AND` and `OR` operators,
 combined with operations like equal (`eq`), one of, and range. It's available under the `where` option,
-for now, only on the [attributes](docs/api-reference/attributes/queries/attributes.mdx) query.
+for now, only on the [attributes](api-reference/attributes/queries/attributes.mdx) query.
 
 ### General approach
 

--- a/docs/api-usage/i18n.mdx
+++ b/docs/api-usage/i18n.mdx
@@ -20,21 +20,21 @@ For web applications, you can manage the frontend part using libraries like [For
 
 For translating database data, Saleor delivers specialized translation objects that can you can modify in the dashboard or using the API.
 
-- [`ProductTranslation`](docs/api-reference/products/objects/product-translation.mdx)
-- [`CollectionTranslation`](docs/api-reference/products/objects/collection-translation.mdx)
-- [`CategoryTranslation`](docs/api-reference/products/objects/category-translation.mdx)
-- [`AttributeTranslation`](docs/api-reference/attributes/objects/attribute-translation.mdx)
-- [`AttributeValueTranslation`](docs/api-reference/attributes/objects/attribute-value-translation.mdx)
-- [`ProductVariantTranslation`](docs/api-reference/products/objects/product-variant-translation.mdx)
-- [`PageTranslation`](docs/api-reference/pages/objects/page-translation.mdx)
-- [`ShippingMethodTranslation`](docs/api-reference/shipping/objects/shipping-method-translation.mdx)
-- [`SaleTranslation`](docs/api-reference/discounts/objects/sale-translation.mdx)
-- [`VoucherTranslation`](docs/api-reference/discounts/objects/voucher-translation.mdx)
-- [`MenuItemTranslation`](docs/api-reference/menu/objects/menu-item-translation.mdx)
+- [`ProductTranslation`](api-reference/products/objects/product-translation.mdx)
+- [`CollectionTranslation`](api-reference/products/objects/collection-translation.mdx)
+- [`CategoryTranslation`](api-reference/products/objects/category-translation.mdx)
+- [`AttributeTranslation`](api-reference/attributes/objects/attribute-translation.mdx)
+- [`AttributeValueTranslation`](api-reference/attributes/objects/attribute-value-translation.mdx)
+- [`ProductVariantTranslation`](api-reference/products/objects/product-variant-translation.mdx)
+- [`PageTranslation`](api-reference/pages/objects/page-translation.mdx)
+- [`ShippingMethodTranslation`](api-reference/shipping/objects/shipping-method-translation.mdx)
+- [`SaleTranslation`](api-reference/discounts/objects/sale-translation.mdx)
+- [`VoucherTranslation`](api-reference/discounts/objects/voucher-translation.mdx)
+- [`MenuItemTranslation`](api-reference/menu/objects/menu-item-translation.mdx)
 
 ### Fetching translated data
 
-Here's an example fetching the Polish translation of an existing category. A `translation` field in the [`Category`](docs/api-reference/products/objects/category.mdx) model takes a `languageCode` argument with one of the values defined by [`LanguageCodeEnum`](docs/api-reference/miscellaneous/enums/language-code-enum.mdx):
+Here's an example fetching the Polish translation of an existing category. A `translation` field in the [`Category`](api-reference/products/objects/category.mdx) model takes a `languageCode` argument with one of the values defined by [`LanguageCodeEnum`](api-reference/miscellaneous/enums/language-code-enum.mdx):
 
 ```graphql
 query {
@@ -75,7 +75,7 @@ Prices and dates can be localized using [`Intl.NumberFormat`](https://developer.
 
 ## Localizing address input
 
-Saleor provides an [`AddressInput`](docs/api-reference/miscellaneous/inputs/address-input.mdx) type that you can use to collect address data from the user. It offers fields to store the country, city, postal code, and street address. Which fields to show and how to label them can be determined by querying the address validation API.
+Saleor provides an [`AddressInput`](api-reference/miscellaneous/inputs/address-input.mdx) type that you can use to collect address data from the user. It offers fields to store the country, city, postal code, and street address. Which fields to show and how to label them can be determined by querying the address validation API.
 
 For more details, see documentation on [address validation](developer/address.mdx).
 

--- a/docs/api-usage/prices.mdx
+++ b/docs/api-usage/prices.mdx
@@ -16,7 +16,7 @@ Presenting a number depends on the language and region. If you are building a we
 
 ### Money
 
-[`Money`](docs/api-reference/miscellaneous/objects/money.mdx) is a basic type for keeping prices without taxes. We do not restrict currency code values, so a user uses crypto-currencies or other custom currency.
+[`Money`](api-reference/miscellaneous/objects/money.mdx) is a basic type for keeping prices without taxes. We do not restrict currency code values, so a user uses crypto-currencies or other custom currency.
 
 ```graphql
 type Money {
@@ -30,7 +30,7 @@ type Money {
 
 ### TaxedMoney
 
-The most common example of [`TaxedMoney`](docs/api-reference/miscellaneous/objects/taxed-money.mdx) is a [`ProductVariant`](docs/api-reference/products/objects/product-variant.mdx) price. If a user does not use any tax integration, both net and gross prices will be populated with the same value.
+The most common example of [`TaxedMoney`](api-reference/miscellaneous/objects/taxed-money.mdx) is a [`ProductVariant`](api-reference/products/objects/product-variant.mdx) price. If a user does not use any tax integration, both net and gross prices will be populated with the same value.
 
 ```graphql
 type TaxedMoney {
@@ -48,7 +48,7 @@ type TaxedMoney {
 
 ### MoneyRange
 
-[`MoneyRange`](docs/api-reference/miscellaneous/objects/money-range.mdx) is used to display prices for a [`ShippingZone`](docs/api-reference/shipping/objects/shipping-zone.mdx).
+[`MoneyRange`](api-reference/miscellaneous/objects/money-range.mdx) is used to display prices for a [`ShippingZone`](api-reference/shipping/objects/shipping-zone.mdx).
 
 ```graphql
 type MoneyRange {
@@ -62,7 +62,7 @@ type MoneyRange {
 
 ### TaxedMoneyRange
 
-[`TaxedMoneyRange`](docs/api-reference/miscellaneous/objects/taxed-money-range.mdx) is used in [`Products`](docs/api-reference/products/objects/product.mdx), because variants can differ in prices. You can display it as "price starts from $10" or "$10–$20".
+[`TaxedMoneyRange`](api-reference/miscellaneous/objects/taxed-money-range.mdx) is used in [`Products`](api-reference/products/objects/product.mdx), because variants can differ in prices. You can display it as "price starts from $10" or "$10–$20".
 
 ```graphql
 type TaxedMoneyRange {

--- a/docs/developer/address.mdx
+++ b/docs/developer/address.mdx
@@ -14,7 +14,7 @@ Validation is only performed on the format of address data. To check if the addr
 
 ## Validation rules
 
-Using the [addressValidationRules](docs/api-reference/users/queries/address-validation-rules.mdx) query, API clients can fetch validation rules depending on the selected country. Based on the ruleset, some address fields can be hidden (e.g. `countryArea`).
+Using the [addressValidationRules](api-reference/users/queries/address-validation-rules.mdx) query, API clients can fetch validation rules depending on the selected country. Based on the ruleset, some address fields can be hidden (e.g. `countryArea`).
 Saleor Core uses [Google i18n address](https://github.com/mirumee/google-i18n-address) under the hood, with a ruleset from [Google Address Data](https://chromium-i18n.appspot.com/ssl-address).
 
 ```graphql
@@ -54,7 +54,7 @@ Depending on the country, not all `allowedFields` fields are necessary. Neverthe
 
 ## Setting up the address using the API
 
-As an example of the address validation API, we will set the billing address in the checkout. The operation can be made with [checkoutBillingAddressUpdate](docs/api-reference/checkout/mutations/checkout-billing-address-update.mdx):
+As an example of the address validation API, we will set the billing address in the checkout. The operation can be made with [checkoutBillingAddressUpdate](api-reference/checkout/mutations/checkout-billing-address-update.mdx):
 
 ```graphql
 mutation {

--- a/docs/developer/app-store/apps/taxes/architecture.mdx
+++ b/docs/developer/app-store/apps/taxes/architecture.mdx
@@ -6,13 +6,13 @@ title: Architecture
 
 The Taxes App uses the following webhook events for tax reporting and calculations:
 
-- [`OrderCalculateTaxes`](docs/api-reference/taxes/objects/calculate-taxes.mdx)
-- [`CheckoutCalculateTaxes`](docs/api-reference/taxes/objects/calculate-taxes.mdx)
-- [`OrderConfirmed`](docs/api-reference/orders/objects/order-confirmed.mdx)
+- [`OrderCalculateTaxes`](api-reference/taxes/objects/calculate-taxes.mdx)
+- [`CheckoutCalculateTaxes`](api-reference/taxes/objects/calculate-taxes.mdx)
+- [`OrderConfirmed`](api-reference/orders/objects/order-confirmed.mdx)
 
 ## Calculating taxes
 
-Calculating taxes using external tax providers happens through a synchronous [`CalculateTaxes`](docs/api-reference/taxes/objects/calculate-taxes.mdx) webhook event. A [synchronous webhook](docs/developer/extending/webhooks/synchronous-events/overview.mdx) awaits a response from the app before continuing.
+Calculating taxes using external tax providers happens through a synchronous [`CalculateTaxes`](api-reference/taxes/objects/calculate-taxes.mdx) webhook event. A [synchronous webhook](developer/extending/webhooks/synchronous-events/overview.mdx) awaits a response from the app before continuing.
 
 While the app is waiting for the values of the calculated taxes, the sequence of actions is as follows:
 
@@ -30,7 +30,7 @@ During tax calculation, the transactions on the tax providers' side are not reco
 
 ## Recording transactions
 
-Once the order is finalized, we want to send a transaction to the tax provider for tax reporting. This is done through [asynchronous webhook](docs/developer/extending/webhooks/asynchronous-events.mdx) events that fire on different order lifecycle actions.
+Once the order is finalized, we want to send a transaction to the tax provider for tax reporting. This is done through [asynchronous webhook](developer/extending/webhooks/asynchronous-events.mdx) events that fire on different order lifecycle actions.
 
 ```mermaid
 sequenceDiagram

--- a/docs/developer/app-store/apps/taxes/avatax/overview.mdx
+++ b/docs/developer/app-store/apps/taxes/avatax/overview.mdx
@@ -59,7 +59,7 @@ After entering, the address must be verified by clicking the _Verify_ button tha
 
 ## Mapping transaction fields
 
-When an order is confirmed, the Taxes App [creates a transaction in AvaTax](https://developer.avalara.com/api-reference/avatax/rest/v2/methods/Transactions/CreateTransaction/). The transaction contains fields that are mapped from the order. For several fields, you can provide custom values with [`privateMetadata`](docs/developer/metadata.mdx#private-and-public-metadata). You have to make sure to set the value before confirming the order (e.g. when the order is still a draft).
+When an order is confirmed, the Taxes App [creates a transaction in AvaTax](https://developer.avalara.com/api-reference/avatax/rest/v2/methods/Transactions/CreateTransaction/). The transaction contains fields that are mapped from the order. For several fields, you can provide custom values with [`privateMetadata`](developer/metadata.mdx#private-and-public-metadata). You have to make sure to set the value before confirming the order (e.g. when the order is still a draft).
 
 The mutation for setting the private metadata is:
 
@@ -87,7 +87,7 @@ Taxes App supports the following mappings:
 
 **Metadata key: `avataxDocumentCode`**
 
-By default, the [document code](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-document-codes/) is set to be equal to Saleor [`order`](docs/api-storefront/orders/objects/order.mdx) id.
+By default, the [document code](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-document-codes/) is set to be equal to Saleor [`order`](api-storefront/orders/objects/order.mdx) id.
 
 If you want to override it, you can do so by providing a value for the `privateMetadata` field `avataxDocumentCode`.
 
@@ -109,7 +109,7 @@ To map the entity type, you need to provide the value for the `entityUseCode` fi
 
 **Metadata key: `avataxTaxCalculationDate`**
 
-By default, the [tax calculation date](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-tax-calc-date/) is set to be equal to the order creation date from Saleor [`order`](docs/api-storefront/orders/objects/order.mdx).
+By default, the [tax calculation date](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-tax-calc-date/) is set to be equal to the order creation date from Saleor [`order`](api-storefront/orders/objects/order.mdx).
 
 If you want to override it, you can do so by providing a value for the `privateMetadata` field `avataxTaxCalculationDate`.
 

--- a/docs/developer/app-store/apps/taxes/overview.mdx
+++ b/docs/developer/app-store/apps/taxes/overview.mdx
@@ -11,7 +11,7 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
   githubUrl="https://github.com/saleor/apps/tree/main/apps/taxes"
 />
 
-_Taxes_ is a Saleor app that allows delegating tax calculations to external tax providers. It can replace the default ([flat rates](docs/developer/taxes.mdx#flat-rates)) tax calculation method in Saleor. It affects both the checkout and the order creation process.
+_Taxes_ is a Saleor app that allows delegating tax calculations to external tax providers. It can replace the default ([flat rates](developer/taxes.mdx#flat-rates)) tax calculation method in Saleor. It affects both the checkout and the order creation process.
 
 The currently supported providers are:
 
@@ -37,7 +37,7 @@ Besides the shared features, AvaTax integration also offers:
 - [Mapping the entity type](avatax/overview#entity-type)
 - [Mapping the document code](avatax/overview#document-code)
 - [Mapping the tax calculation date](avatax/overview#tax-calculation-date)
-- Voiding transaction on [`OrderCancelled`](docs/api-reference/orders/objects/order-cancelled.mdx) event
+- Voiding transaction on [`OrderCancelled`](api-reference/orders/objects/order-cancelled.mdx) event
 
 ## Architecture
 

--- a/docs/developer/app-store/legacy-plugins/dummy-credit-card.mdx
+++ b/docs/developer/app-store/legacy-plugins/dummy-credit-card.mdx
@@ -30,7 +30,7 @@ Any other card numbers with valid expiration dates and random CVV values create 
 
 In the case of testing dummy payment responses with API, you need to have a checkout with shipping and billing address set. See [the checkout page](developer/checkout/overview.mdx#creating-a-checkout-session)
 to know how to create a checkout object.
-Then create checkout payment with use of [`checkoutPaymentCreate`](docs/api-reference/checkout/mutations/checkout-payment-create.mdx) mutation,
+Then create checkout payment with use of [`checkoutPaymentCreate`](api-reference/checkout/mutations/checkout-payment-create.mdx) mutation,
 set card number as a `token` value and `mirumee.payments.dummy` as a `gateway`.
 To check gateway response use `CheckoutComplete` mutation.
 Let's see an example for a token that causes Card Expired error.

--- a/docs/developer/attributes.mdx
+++ b/docs/developer/attributes.mdx
@@ -9,8 +9,8 @@ Properly configured attributes provide crucial information about your products a
 
 Attributes can be used for:
 
-- [Products](docs/api-reference/products/objects/product.mdx) and [ProductVariants](docs/api-reference/products/objects/product-variant.mdx)
-- [Pages](docs/api-reference/pages/objects/page.mdx)
+- [Products](api-reference/products/objects/product.mdx) and [ProductVariants](api-reference/products/objects/product-variant.mdx)
+- [Pages](api-reference/pages/objects/page.mdx)
 
 ## Use cases
 
@@ -32,7 +32,7 @@ To assign attributes to products and pages, a user needs only the following perm
 
 ## Input types
 
-Each attribute has an input type defined upon attribute creation. Input types determine the data type you can enter as the attribute values in the dashboard. Available input types are defined in the [`AttributeInputTypeEnum`](docs/api-reference/attributes/enums/attribute-input-type-enum.mdx) enum. Below is the list of available input types:
+Each attribute has an input type defined upon attribute creation. Input types determine the data type you can enter as the attribute values in the dashboard. Available input types are defined in the [`AttributeInputTypeEnum`](api-reference/attributes/enums/attribute-input-type-enum.mdx) enum. Below is the list of available input types:
 
 | Name          | Description                                                                                  | Example                                                                                  |
 | ------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
@@ -85,7 +85,7 @@ The `attributes` field supports pagination and filtering, e.g., searching attrib
 
 ## Fetching assigned attributes
 
-Attributes assigned to an object are represented by the [`SelectedAttribute`](docs/api-reference/attributes/objects/selected-attribute.mdx) GraphQL type. Below is the example of fetching attributes assigned to a product:
+Attributes assigned to an object are represented by the [`SelectedAttribute`](api-reference/attributes/objects/selected-attribute.mdx) GraphQL type. Below is the example of fetching attributes assigned to a product:
 
 ```graphql
 {
@@ -109,7 +109,7 @@ Similarly, you can fetch assigned attributes for `ProductVariant` and `Page` typ
 
 A user can use a `slug` to filter products by attributes. The query parameters can be encoded in URL and will be the same in all languages.
 
-An example of a [`products`](docs/api-reference/products/queries/products.mdx) query:
+An example of a [`products`](api-reference/products/queries/products.mdx) query:
 
 ```graphql
 query {

--- a/docs/developer/channels.mdx
+++ b/docs/developer/channels.mdx
@@ -19,29 +19,29 @@ Popular use cases:
 
 There are many models you can customize per channel. The details of which fields you can define on a per-channel basis are described in the `ChannelListing` models:
 
-- [Collection](docs/api-reference/products/objects/collection-channel-listing.mdx)
-- [Product](docs/api-reference/products/objects/product-channel-listing.mdx)
-- [ProductVariant](docs/api-reference/products/objects/product-variant-channel-listing.mdx)
-- [Sale](docs/api-reference/discounts/objects/sale-channel-listing.mdx)
-- [ShippingMethod](docs/api-reference/shipping/objects/shipping-method-channel-listing.mdx)
-- [Voucher](docs/api-reference/discounts/objects/voucher-channel-listing.mdx)
+- [Collection](api-reference/products/objects/collection-channel-listing.mdx)
+- [Product](api-reference/products/objects/product-channel-listing.mdx)
+- [ProductVariant](api-reference/products/objects/product-variant-channel-listing.mdx)
+- [Sale](api-reference/discounts/objects/sale-channel-listing.mdx)
+- [ShippingMethod](api-reference/shipping/objects/shipping-method-channel-listing.mdx)
+- [Voucher](api-reference/discounts/objects/voucher-channel-listing.mdx)
 
-Many [Saleor Apps](docs/developer/app-store/overview.mdx) allow to configure them per-channel. We recommend to allow it for the best flexibility.
+Many [Saleor Apps](developer/app-store/overview.mdx) allow to configure them per-channel. We recommend to allow it for the best flexibility.
 
 ## Permissions
 
-Listing channels is allowed only for users with the active [`isStaff`](docs/api-reference/users/objects/user.mdx#isstaff-boolean) flag.
+Listing channels is allowed only for users with the active [`isStaff`](api-reference/users/objects/user.mdx#isstaff-boolean) flag.
 
 You need the `MANAGE_CHANNELS` permission to create, edit, and remove channels.
 Changing `ChannelListing` does not require additional permissions. For example, changing Product availability requires only `MANAGE_PRODUCTS` permission.
 
 Objects with customized per-channel visibility are restricted by channel permissions.
 If a user with restricted channel access fetches per-channel objects, only objects from accessible channels will be returned.
-You can read more about channel permissions [here](docs/developer/permissions.mdx).
+You can read more about channel permissions [here](developer/permissions.mdx).
 
 ## Getting channel details
 
-Use [`channel`](docs/api-reference/channels/queries/channel.mdx) query to get channel details.
+Use [`channel`](api-reference/channels/queries/channel.mdx) query to get channel details.
 
 Channel query requires channel ID, but from Saleor 3.6 it can be executed with channel slug too.
 
@@ -115,7 +115,7 @@ Response:
 
 ## Creating a new channel
 
-You can create a new channel using [`channelCreate`](docs/api-reference/channels/mutations/channel-create.mdx) mutation.
+You can create a new channel using [`channelCreate`](api-reference/channels/mutations/channel-create.mdx) mutation.
 During checkout creation, you can define the allocation strategy. Right now the
 two possible options are available: `PRIORITIZE_HIGH_STOCK` and `PRIORITIZE_SORTING_ORDER`,
 the `PRIORITIZE_SORTING_ORDER` strategy is used as default.
@@ -185,7 +185,7 @@ Response:
 
 ### Channel list
 
-Because some of the channels may be considered non-public (for example - a channel for business partners), non-staff users cannot use the [`channels`](docs/api-reference/channels/queries/channels.mdx) query.
+Because some of the channels may be considered non-public (for example - a channel for business partners), non-staff users cannot use the [`channels`](api-reference/channels/queries/channels.mdx) query.
 
 Request:
 
@@ -216,7 +216,7 @@ Response:
 
 ### Activate / Deactivate channel
 
-If you want to make the channel unavailable for customers, you can change it's status to `deactivated` using [`channelDeactivate`](docs/api-reference/channels/mutations/channel-deactivate.mdx) mutation:
+If you want to make the channel unavailable for customers, you can change it's status to `deactivated` using [`channelDeactivate`](api-reference/channels/mutations/channel-deactivate.mdx) mutation:
 
 ```graphql
 mutation {
@@ -248,7 +248,7 @@ Response:
 }
 ```
 
-And to reverse the previous operation use the [`channelActivate`](docs/api-reference/channels/mutations/channel-activate.mdx) mutation:
+And to reverse the previous operation use the [`channelActivate`](api-reference/channels/mutations/channel-activate.mdx) mutation:
 
 ```graphql
 mutation {
@@ -388,7 +388,7 @@ Channels can be removed only when:
 - There are no orders created in them.
 - If there are orders created, `targetChannel` is required. Its currency has to be the same as the channel you are about to delete. All orders will be moved to `targetChannel`.
 
-[`channelDelete`](docs/api-reference/channels/mutations/channel-delete.mdx) mutation takes [input](docs/api-reference/channels/inputs/channel-delete-input.mdx):
+[`channelDelete`](api-reference/channels/mutations/channel-delete.mdx) mutation takes [input](api-reference/channels/inputs/channel-delete-input.mdx):
 
 - `id`: ID of the Channel that will be deleted
 - `channelId`: all existing orders will be moved into this channel
@@ -425,7 +425,7 @@ enum ChannelErrorCode {
 }
 ```
 
-[`ChannelErrorCode`](docs/api-reference/channels/enums/channel-error-code.mdx) values:
+[`ChannelErrorCode`](api-reference/channels/enums/channel-error-code.mdx) values:
 
 - `ALREADY_EXISTS`: Object already exists in the database
 - `GRAPHQL_ERROR`: Wrong query

--- a/docs/developer/checkout/address.mdx
+++ b/docs/developer/checkout/address.mdx
@@ -4,7 +4,7 @@ title: Shipping and Billing
 
 ## Shipping
 
-This step is only used if purchased items require shipping (if they are physical products). The user must select a specific shipping method to create shipping for this checkout. To signify whether shipping is required, use the `isShippingRequired` field in the [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object.
+This step is only used if purchased items require shipping (if they are physical products). The user must select a specific shipping method to create shipping for this checkout. To signify whether shipping is required, use the `isShippingRequired` field in the [`Checkout`](api-reference/checkout/objects/checkout.mdx) object.
 
 ```mermaid
 sequenceDiagram
@@ -27,7 +27,7 @@ sequenceDiagram
 
 ### Adding address data
 
-Address can be assigned using the [`checkoutShippingAddressUpdate`](docs/api-reference/checkout/mutations/checkout-shipping-address-update.mdx) mutation:
+Address can be assigned using the [`checkoutShippingAddressUpdate`](api-reference/checkout/mutations/checkout-shipping-address-update.mdx) mutation:
 
 ```graphql
 mutation {
@@ -85,7 +85,7 @@ More information about address validation can be found on the [address validatio
 
 #### Default address
 
-Customers with accounts can set up default addresses, which will be attached automatically during the checkout creation. More information on API reference page for [accountSetDefaultAddress](docs/api-reference/users/mutations/account-set-default-address.mdx).
+Customers with accounts can set up default addresses, which will be attached automatically during the checkout creation. More information on API reference page for [accountSetDefaultAddress](api-reference/users/mutations/account-set-default-address.mdx).
 
 ### Listing available shipping methods
 
@@ -159,12 +159,12 @@ Response:
 
 ### Selecting the delivery method
 
-Use the [`checkoutDeliveryMethodUpdate`](docs/api-reference/checkout/mutations/checkout-delivery-method-update.mdx) mutation to effectively pair the specific [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object with the specified delivery method selected by the user.
+Use the [`checkoutDeliveryMethodUpdate`](api-reference/checkout/mutations/checkout-delivery-method-update.mdx) mutation to effectively pair the specific [`Checkout`](api-reference/checkout/objects/checkout.mdx) object with the specified delivery method selected by the user.
 
 This operation requires the following input:
 
-- `id`: the checkout ID (the `id` field of the [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object).
-- `deliveryMethodId`: the shipping method ID or Warehouse ID (from the `shippingMethods` or `availableCollectionPoints` field of the [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object).
+- `id`: the checkout ID (the `id` field of the [`Checkout`](api-reference/checkout/objects/checkout.mdx) object).
+- `deliveryMethodId`: the shipping method ID or Warehouse ID (from the `shippingMethods` or `availableCollectionPoints` field of the [`Checkout`](api-reference/checkout/objects/checkout.mdx) object).
 
 In the following mutation, we assign a delivery method to the checkout using IDs from the previous example. Note that for the checkout object, we want to get back the update `totalPrice` including shipping costs:
 
@@ -231,7 +231,7 @@ As a result, we get an updated checkout object with a delivery method set:
 
 The checkout's mutations that accept an address as an input have a field that can turn off the address validation. It allows assigning a partial or not fully valid address to the checkout. Providing country code is mandatory for all addresses regardless of the rules provided in this input.
 
-The address [validation](docs/api-reference/checkout/inputs/checkout-address-validation-rules.mdx) input has two boolean fields:
+The address [validation](api-reference/checkout/inputs/checkout-address-validation-rules.mdx) input has two boolean fields:
 
 - `checkRequiredFields` - signals Saleor to raise an error when the provided address doesn't have all the required fields. Set to `true` by default.
 - `checkFieldsFormat` - signals Saleor to raise an error when the provided address doesn't match the expected format. Set to `true` by default.
@@ -239,9 +239,9 @@ The address [validation](docs/api-reference/checkout/inputs/checkout-address-val
 
 #### checkoutCreate
 
-The [`checkoutCreate`](docs/api-reference/checkout/mutations/checkout-create.mdx) mutation has an optional input for providing shipping and billing addresses. If you want to provide only a part of the address, you can disable the address validation.
+The [`checkoutCreate`](api-reference/checkout/mutations/checkout-create.mdx) mutation has an optional input for providing shipping and billing addresses. If you want to provide only a part of the address, you can disable the address validation.
 
-The mutation accepts [validationRules](docs/api-reference/checkout/inputs/checkout-validation-rules.mdx) as an [input](docs/api-reference/checkout/inputs/checkout-create-input.mdx) field.
+The mutation accepts [validationRules](api-reference/checkout/inputs/checkout-validation-rules.mdx) as an [input](api-reference/checkout/inputs/checkout-create-input.mdx) field.
 
 ```graphql
 mutation {
@@ -286,7 +286,7 @@ The response contains the created checkout object:
 
 #### CheckoutShippingAddressUpdate
 
-The [`checkoutShippingAddressUpdate`](docs/api-reference/checkout/mutations/checkout-shipping-address-update.mdx) mutation has an optional field for controlling the shipping address validation: [validationRules](docs/api-reference/checkout/inputs/checkout-address-validation-rules.mdx).
+The [`checkoutShippingAddressUpdate`](api-reference/checkout/mutations/checkout-shipping-address-update.mdx) mutation has an optional field for controlling the shipping address validation: [validationRules](api-reference/checkout/inputs/checkout-address-validation-rules.mdx).
 
 ```graphql
 mutation {
@@ -342,7 +342,7 @@ The response contains the updated checkout object:
 
 #### CheckoutBillingAddressUpdate
 
-The [`checkoutBillingAddressUpdate`](docs/api-reference/checkout/mutations/checkout-billing-address-update.mdx) mutation has an optional field for controlling the billing address validation: [validationRules](docs/api-reference/checkout/inputs/checkout-address-validation-rules.mdx).
+The [`checkoutBillingAddressUpdate`](api-reference/checkout/mutations/checkout-billing-address-update.mdx) mutation has an optional field for controlling the billing address validation: [validationRules](api-reference/checkout/inputs/checkout-address-validation-rules.mdx).
 
 ```graphql
 mutation {
@@ -397,9 +397,9 @@ The information about address validation can be found on the [address validation
 :::
 
 :::note
-The shipping and billing addresses need to be valid when finalizing checkout by calling [checkoutComplete](docs/api-reference/checkout/mutations/checkout-complete.mdx) mutation.
+The shipping and billing addresses need to be valid when finalizing checkout by calling [checkoutComplete](api-reference/checkout/mutations/checkout-complete.mdx) mutation.
 :::
 
 :::note
-The fields for shipping and billing addresses will be normalized (if needed) on completing the checkout by calling [checkoutComplete](docs/api-reference/checkout/mutations/checkout-complete.mdx) mutation.
+The fields for shipping and billing addresses will be normalized (if needed) on completing the checkout by calling [checkoutComplete](api-reference/checkout/mutations/checkout-complete.mdx) mutation.
 :::

--- a/docs/developer/checkout/finalizing.mdx
+++ b/docs/developer/checkout/finalizing.mdx
@@ -8,7 +8,7 @@ The payment flow uses the Saleor's payment gateway or payment synchronous webhoo
 
 ### Payment
 
-Depending on the selected payment gateway, you will use the payment provider's form, which can be integrated with Saleor or be redirected to an external payment page. The payment gateway returns information if the payment is successful, along with tokenized credit card payment information. This token is then used to run the [`checkoutPaymentCreate`](docs/api-reference/checkout/mutations/checkout-payment-create.mdx) mutation.
+Depending on the selected payment gateway, you will use the payment provider's form, which can be integrated with Saleor or be redirected to an external payment page. The payment gateway returns information if the payment is successful, along with tokenized credit card payment information. This token is then used to run the [`checkoutPaymentCreate`](api-reference/checkout/mutations/checkout-payment-create.mdx) mutation.
 
 ```mermaid
 sequenceDiagram
@@ -76,16 +76,16 @@ Response:
 
 #### Creating payment
 
-The [`checkoutPaymentCreate`](docs/api-reference/checkout/mutations/checkout-payment-create.mdx) mutation takes the following arguments:
+The [`checkoutPaymentCreate`](api-reference/checkout/mutations/checkout-payment-create.mdx) mutation takes the following arguments:
 
 - `id`: the checkout id (if required by a payment gateway).
-- `input`: [PaymentInput](docs/api-reference/payments/inputs/payment-input.mdx) object:
+- `input`: [PaymentInput](api-reference/payments/inputs/payment-input.mdx) object:
   - `gateway`: the ID of the selected payment gateway (a list of the available payment gateways can be fetched from the `Checkout.availablePaymentGateways` field). The selected gateway must support the checkout currency.
   - `token`: a client-side generated payment token (if required).
   - `amount`: the total amount of this operation.
   - `returnUrl`: URL of a storefront view where the user should be redirected after requiring additional actions. Payment with additional actions will not be finished if this field is not provided.
-  - `storePaymentMethod`: the type of payment storage in a gateway. [StorePaymentMethod](docs/api-reference/payments/enums/store-payment-method-enum.mdx) value. If not provided, defaults to `NONE` (added in Saleor 3.1).
-  - `metadata`: a list of [MetadataInput](docs/api-reference/miscellaneous/inputs/metadata-input.mdx) (added in Saleor 3.1).
+  - `storePaymentMethod`: the type of payment storage in a gateway. [StorePaymentMethod](api-reference/payments/enums/store-payment-method-enum.mdx) value. If not provided, defaults to `NONE` (added in Saleor 3.1).
+  - `metadata`: a list of [MetadataInput](api-reference/miscellaneous/inputs/metadata-input.mdx) (added in Saleor 3.1).
 
 This mutation returns the following fields:
 
@@ -169,7 +169,7 @@ sequenceDiagram
   Saleor -->>- Client: order data
 ```
 
-The [`checkoutComplete`](docs/api-reference/checkout/mutations/checkout-complete.mdx) mutation requires the following input:
+The [`checkoutComplete`](api-reference/checkout/mutations/checkout-complete.mdx) mutation requires the following input:
 
 - `id`: the ID of the checkout to complete.
 - `redirectUrl`: URL of a view where users should be redirected to see the order details. URL in RFC 1808 format.
@@ -217,7 +217,7 @@ A successful response would look like this:
 }
 ```
 
-Here is an example of the [`checkoutComplete`](docs/api-reference/checkout/mutations/checkout-complete.mdx) mutation where the payment gateway requires additional data to finalize the payment using the Adyen payment gateway:
+Here is an example of the [`checkoutComplete`](api-reference/checkout/mutations/checkout-complete.mdx) mutation where the payment gateway requires additional data to finalize the payment using the Adyen payment gateway:
 
 ```graphql {2-5}
 mutation{
@@ -527,12 +527,12 @@ sequenceDiagram
     Checkout App-->>-Customer: Order
 ```
 
-The [orderCreateFromCheckout](docs/api-reference/orders/mutations/order-create-from-checkout.mdx) mutation takes the following arguments:
+The [orderCreateFromCheckout](api-reference/orders/mutations/order-create-from-checkout.mdx) mutation takes the following arguments:
 
 - `id`: The ID of the checkout that should be used to create a new order.
 - `removeCheckout`: Determines if checkout should be removed after creating an order. Default `true`.
 
-The following example shows how the [orderCreateFromCheckout](docs/api-reference/orders/mutations/order-create-from-checkout.mdx) mutation creates a new order and removes the checkout.
+The following example shows how the [orderCreateFromCheckout](api-reference/orders/mutations/order-create-from-checkout.mdx) mutation creates a new order and removes the checkout.
 
 ```graphql
 mutation {
@@ -570,4 +570,4 @@ As a result, we get an order object:
 #### Managing payments
 
 Saleor uses transaction flow to manage the payments attached to the checkout by Saleor apps.
-You can find more details about it [here](docs/developer/payments.mdx#processing-a-payment-with-checkout-app).
+You can find more details about it [here](developer/payments.mdx#processing-a-payment-with-checkout-app).

--- a/docs/developer/checkout/lines.mdx
+++ b/docs/developer/checkout/lines.mdx
@@ -4,7 +4,7 @@ title: Managing products
 
 ### Adding a line to checkout
 
-To add an item to the cart, use [`checkoutLinesAdd`](docs/api-reference/checkout/mutations/checkout-lines-add.mdx). Total prices will be updated automatically:
+To add an item to the cart, use [`checkoutLinesAdd`](api-reference/checkout/mutations/checkout-lines-add.mdx). Total prices will be updated automatically:
 
 ```graphql {4}
 mutation {
@@ -75,11 +75,11 @@ feedback. However, it is still undergoing development and is subject to modifica
 The creation of multiple lines with the same variant is possible upon using the `forceNewLine` flag.
 The `forceNewLine` can be used in the:
 
-[CheckoutLineInput](docs/api-reference/checkout/inputs/checkout-line-input.mdx)
+[CheckoutLineInput](api-reference/checkout/inputs/checkout-line-input.mdx)
 in the following mutations:
 
-- [checkoutCreate](docs/api-reference/checkout/mutations/checkout-create.mdx)
-- [checkoutLinesAdd](docs/api-reference/checkout/mutations/checkout-lines-add.mdx)
+- [checkoutCreate](api-reference/checkout/mutations/checkout-create.mdx)
+- [checkoutLinesAdd](api-reference/checkout/mutations/checkout-lines-add.mdx)
 
 ```graphql {5}
 mutation {
@@ -208,16 +208,16 @@ If the variant is already added to the checkout and exists in more than one line
 
 ### Updating a line
 
-To modify a line, use [checkoutLinesUpdate](docs/api-reference/checkout/mutations/checkout-lines-update.mdx).
+To modify a line, use [checkoutLinesUpdate](api-reference/checkout/mutations/checkout-lines-update.mdx).
 
-Currently, [CheckoutLineUpdateInput](docs/api-reference/checkout/inputs/checkout-line-update-input.mdx) supports `variantId` and `lineId` parameters to operate on the selected line object.
-The version `3.6` featured [adding the same product to multiple lines](docs/developer/checkout/lines.mdx#adding-the-same-product-to-multiple-lines). Since then, we recommend using the `lineId` parameter, as `variantId` will be deprecated in the future.
+Currently, [CheckoutLineUpdateInput](api-reference/checkout/inputs/checkout-line-update-input.mdx) supports `variantId` and `lineId` parameters to operate on the selected line object.
+The version `3.6` featured [adding the same product to multiple lines](developer/checkout/lines.mdx#adding-the-same-product-to-multiple-lines). Since then, we recommend using the `lineId` parameter, as `variantId` will be deprecated in the future.
 
 :::caution
 
 Is not allowed to use `variantId` and `lineId` in the same line input.
 
-If the `variantId` parameter is used in line input and the variant exists in multiple lines, [checkoutLinesUpdate](docs/api-reference/checkout/mutations/checkout-lines-update.mdx) will return an error. In that case, you are required to use `lineId`.
+If the `variantId` parameter is used in line input and the variant exists in multiple lines, [checkoutLinesUpdate](api-reference/checkout/mutations/checkout-lines-update.mdx) will return an error. In that case, you are required to use `lineId`.
 
 :::
 
@@ -271,7 +271,7 @@ If the quantity is changed to 0, API will remove this line from checkout.
 
 ### Removing line from checkout
 
-Running the [checkoutLineDelete](docs/api-reference/checkout/mutations/checkout-line-delete.mdx) mutation will remove the whole line, no matter the quantity:
+Running the [checkoutLineDelete](api-reference/checkout/mutations/checkout-line-delete.mdx) mutation will remove the whole line, no matter the quantity:
 
 ```graphql
 mutation {
@@ -320,13 +320,13 @@ This feature is only available for apps with `HANDLE_CHECKOUTS` permission.
 :::
 
 The custom price can be set with the use of field `price` in the
-[CheckoutLineInput](docs/api-reference/checkout/inputs/checkout-line-input.mdx)
+[CheckoutLineInput](api-reference/checkout/inputs/checkout-line-input.mdx)
 in the following mutations:
 
-- [checkoutCreate](docs/api-reference/checkout/mutations/checkout-create.mdx),
-- [checkoutLinesAdd](docs/api-reference/checkout/mutations/checkout-lines-add.mdx) - when adding
+- [checkoutCreate](api-reference/checkout/mutations/checkout-create.mdx),
+- [checkoutLinesAdd](api-reference/checkout/mutations/checkout-lines-add.mdx) - when adding
   a variant that already exists in the checkout, the corresponding line gets overridden - the quantity is incremented and the price is updated.
-- [checkoutLinesUpdate](docs/api-reference/checkout/mutations/checkout-lines-update.mdx) - overrides
+- [checkoutLinesUpdate](api-reference/checkout/mutations/checkout-lines-update.mdx) - overrides
   the existing line with the price provided in the mutation.
 
 The following example shows how to set a custom price with the use of `checkoutLinesAdd` mutation:

--- a/docs/developer/checkout/order-to-checkout.mdx
+++ b/docs/developer/checkout/order-to-checkout.mdx
@@ -17,23 +17,23 @@ feedback. However, it is still undergoing development and is subject to modifica
 
 Saleor allows you to create a checkout from existing orders. This feature can be used when implementing the reordering functionality.
 
-The [checkoutCreateFromOrder](docs/api-reference/checkout/mutations/checkout-create-from-order.mdx) mutation accepts the `Order`
-[ID](docs/api-reference/checkout/mutations/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbidbcodeid--)
-as input and returns the new [checkout](docs/api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbcheckoutbcodecheckout-),
+The [checkoutCreateFromOrder](api-reference/checkout/mutations/checkout-create-from-order.mdx) mutation accepts the `Order`
+[ID](api-reference/checkout/mutations/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbidbcodeid--)
+as input and returns the new [checkout](api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbcheckoutbcodecheckout-),
 with the lines from the order attached to it. Lines that are not available (variants deleted, products deleted, variants not published, out of stock, etc.) are returned as
-[unavailableVariants](docs/api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbunavailablevariantsbcodecheckoutcreatefromorderunavailablevariant--).
+[unavailableVariants](api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbunavailablevariantsbcodecheckoutcreatefromorderunavailablevariant--).
 Any discounts or custom prices attached to the order will not be carried over to the newly created checkout. The price of each checkout line will be based on the current price of the variant.
 
-[UnavailableVariants](docs/api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbunavailablevariantsbcodecheckoutcreatefromorderunavailablevariant--)
+[UnavailableVariants](api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbunavailablevariantsbcodecheckoutcreatefromorderunavailablevariant--)
 is a list of variants that could not be attached to the checkout.
-Each [item](docs/api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx) has:
+Each [item](api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx) has:
 
-- [code](docs/api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbcodebcodecheckoutcreatefromorderunavailablevarianterrorcode--) that describes why Saleor could not add it to the checkout.
-- [variantId](docs/api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbvariantidbcodeid--) that contains the ID of the unavailable variant.
-- [lineId](docs/api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantblineidbcodeid--) that contains the ID of the related `orderLine`.
-- [message](docs/api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbmessagebcodestring--) the error message.
+- [code](api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbcodebcodecheckoutcreatefromorderunavailablevarianterrorcode--) that describes why Saleor could not add it to the checkout.
+- [variantId](api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbvariantidbcodeid--) that contains the ID of the unavailable variant.
+- [lineId](api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantblineidbcodeid--) that contains the ID of the related `orderLine`.
+- [message](api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbmessagebcodestring--) the error message.
 
-The following example shows how the [checkoutCreateFromOrder](docs/api-reference/checkout/mutations/checkout-create-from-order.mdx) mutation creates a new checkout:
+The following example shows how the [checkoutCreateFromOrder](api-reference/checkout/mutations/checkout-create-from-order.mdx) mutation creates a new checkout:
 
 ```graphql
 mutation CheckoutCreateFromOrder {

--- a/docs/developer/checkout/overview.mdx
+++ b/docs/developer/checkout/overview.mdx
@@ -43,19 +43,19 @@ If the user is assigned the checkout permission, only this user and staff users 
 ## Creating a checkout session
 
 :::note
-A [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object can be created for logged-in users and for anonymous (guest) users.
+A [`Checkout`](api-reference/checkout/objects/checkout.mdx) object can be created for logged-in users and for anonymous (guest) users.
 :::
 
-- If you use the [`checkoutCreate`](docs/api-reference/checkout/mutations/checkout-create.mdx) mutation including the authentication token, this checkout is assigned to the user who is authenticated by this token. For more information on how to authenticate with our API, see the [Authentication](docs/api-usage/authentication.mdx) topic.
+- If you use the [`checkoutCreate`](api-reference/checkout/mutations/checkout-create.mdx) mutation including the authentication token, this checkout is assigned to the user who is authenticated by this token. For more information on how to authenticate with our API, see the [Authentication](api-usage/authentication.mdx) topic.
 
 - If no authentication token is provided, the checkout is created for an anonymous user,
-  and an email address is used to identify such a [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object,
+  and an email address is used to identify such a [`Checkout`](api-reference/checkout/objects/checkout.mdx) object,
   linking it with the anonymous user.
   User email is not required at this stage but must be provided before adding a promo code, creating a payment, and completing checkout.
 
-To create a [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object, use the [`checkoutCreate`](docs/api-reference/checkout/mutations/checkout-create.mdx) mutation.
+To create a [`Checkout`](api-reference/checkout/objects/checkout.mdx) object, use the [`checkoutCreate`](api-reference/checkout/mutations/checkout-create.mdx) mutation.
 
-This mutation takes the following [input](docs/api-reference/checkout/inputs/checkout-create-input.mdx):
+This mutation takes the following [input](api-reference/checkout/inputs/checkout-create-input.mdx):
 
 - `channel`: Slug of a channel in which to create checkout.
 - `email`: the user's email address.
@@ -64,7 +64,7 @@ This mutation takes the following [input](docs/api-reference/checkout/inputs/che
 - `lines`: a list of checkout lines, each checkout line contains a product variant ID and its quantity.
 - `validationRules`: the checkout validation rules that can be changed.
 
-The resulting [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object contains the following fields:
+The resulting [`Checkout`](api-reference/checkout/objects/checkout.mdx) object contains the following fields:
 
 - `id`: a unique checkout ID.
 - `totalPrice`: the total price of the checkout lines and shipping costs.
@@ -78,7 +78,7 @@ In addition, the following fields are available in the mutation results:
 - `created`: a boolean flag indicating whether a new checkout object was created, or an existing one was used.
 - `errors`: a list of errors that occurred during mutation execution.
 
-The following example shows how the [`checkoutCreate`](docs/api-reference/checkout/mutations/checkout-create.mdx) mutation creates the [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object and returns the checkout information:
+The following example shows how the [`checkoutCreate`](api-reference/checkout/mutations/checkout-create.mdx) mutation creates the [`Checkout`](api-reference/checkout/objects/checkout.mdx) object and returns the checkout information:
 
 ```graphql {2-25}
 mutation {
@@ -211,11 +211,11 @@ We get a newly created checkout object for which we return the ID, total price, 
 ## Checkout email
 
 When anonymous checkout without user email has been created, the email must be set before creating payment and completing checkout.
-Use the [`CheckoutEmailUpdate`](docs/api-reference/checkout/mutations/checkout-email-update.mdx) mutation to update checkout `email`.
+Use the [`CheckoutEmailUpdate`](api-reference/checkout/mutations/checkout-email-update.mdx) mutation to update checkout `email`.
 
 The operation requires the following inputs:
 
-- `id`: the checkout ID (the `id` field of the [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object),
+- `id`: the checkout ID (the `id` field of the [`Checkout`](api-reference/checkout/objects/checkout.mdx) object),
 - `email`: the user email.
 
 ```graphql {2-4}

--- a/docs/developer/community/contributing.mdx
+++ b/docs/developer/community/contributing.mdx
@@ -265,7 +265,7 @@ Use relative imports.
 ### Migrations
 
 Try to combine multiple migrations into one, but remember not to mix changes on the database with updating rows in migrations. In other words, operations that alter tables and use `RunPython` to run methods on existing data should be in separate files.
-From Saleor version 3.13 forward follow [zero-downtime policy](docs/developer/community/zero-downtime-migrations.mdx) when writing migrations.
+From Saleor version 3.13 forward follow [zero-downtime policy](developer/community/zero-downtime-migrations.mdx) when writing migrations.
 
 ### Handling migrations between versions
 

--- a/docs/developer/community/zero-downtime-migrations.mdx
+++ b/docs/developer/community/zero-downtime-migrations.mdx
@@ -2,7 +2,7 @@
 title: Zero downtime migrations
 ---
 
-Following page contains information about writing zero-downtime migrations. If you are interested in section about upgrading Saleor, please visit [upgrading guide](docs/setup/upgrading.mdx).
+Following page contains information about writing zero-downtime migrations. If you are interested in section about upgrading Saleor, please visit [upgrading guide](setup/upgrading.mdx).
 
 ## The problem
 

--- a/docs/developer/discounts.mdx
+++ b/docs/developer/discounts.mdx
@@ -138,7 +138,7 @@ If the voucher specifies certain products, the discount will be applied only to
 the cheapest item included in the discount. If the voucher applies to all products,
 the discount will be applied only to the cheapest item overall.
 
-To apply the voucher on checkout use [checkoutAddPromoCode](docs/api-reference/checkout/mutations/checkout-add-promo-code.mdx)
+To apply the voucher on checkout use [checkoutAddPromoCode](api-reference/checkout/mutations/checkout-add-promo-code.mdx)
 mutation. The discount will be visible both in the line prices and in the `checkout.discount` field. Let's see the examples.
 
 ### Applying the entire order voucher
@@ -823,7 +823,7 @@ will be visible on the order and order line prices. Additionally, the sum of vou
 discounts will be reflected in the `order.discounts` field. This behavior is consistent
 across all voucher types.
 
-The following example shows the response from the [checkoutComplete](docs/api-reference/checkout/mutations/checkout-complete.mdx)
+The following example shows the response from the [checkoutComplete](api-reference/checkout/mutations/checkout-complete.mdx)
 mutation for a checkout that includes **two items** of the same variant with a **10% voucher discount** applied.
 
 ```json {42,57-75}

--- a/docs/developer/extending/apollo-federation.mdx
+++ b/docs/developer/extending/apollo-federation.mdx
@@ -6,7 +6,7 @@ title: Apollo Federation
 
 ## Federation support in Saleor
 
-Saleor supports Apollo Federation. Types that can be used in federated relations are part of the [`_Entity` union](docs/api-reference/miscellaneous/unions/entity.mdx).
+Saleor supports Apollo Federation. Types that can be used in federated relations are part of the [`_Entity` union](api-reference/miscellaneous/unions/entity.mdx).
 
 Most types in the schema use their ID attribute as a key, but the `User` type supports both `id` and `email` while `Product`, `ProductVariant`, and `Collection` use composite keys made of `id` and `channel` slug:
 

--- a/docs/developer/extending/apps/developing-apps/app-sdk/api-handlers.md
+++ b/docs/developer/extending/apps/developing-apps/app-sdk/api-handlers.md
@@ -8,8 +8,8 @@ Currently, Saleor heavily relies on Next.js, but other platforms will be support
 
 Saleor requires two endpoints to be available for a standalone app:
 
-- Manifest endpoint - Returns JSON object with app properties, like its name or permissions. [Read more](docs/developer/extending/apps/architecture/manifest.mdx)
-- Register endpoint - During installation, Saleor sends a `POST` request with auth token to this endpoint. [Read more](docs/developer/extending/apps/installing-apps.mdx#installation-using-graphql-api)
+- Manifest endpoint - Returns JSON object with app properties, like its name or permissions. [Read more](developer/extending/apps/architecture/manifest.mdx)
+- Register endpoint - During installation, Saleor sends a `POST` request with auth token to this endpoint. [Read more](developer/extending/apps/installing-apps.mdx#installation-using-graphql-api)
 
 ## Built-in API handlers
 

--- a/docs/developer/extending/apps/developing-apps/app-sdk/saleor-webhook.md
+++ b/docs/developer/extending/apps/developing-apps/app-sdk/saleor-webhook.md
@@ -23,8 +23,8 @@ In Next.js `pages` directory, create a page, e.g., `pages/api/webhooks/order-cre
 import { SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 
 /**
-* Default body parser must be turned off - the raw body is needed to verify the signature
-*/
+ * Default body parser must be turned off - the raw body is needed to verify the signature
+ */
 export const config = {
   api: {
     bodyParser: false,
@@ -49,8 +49,8 @@ For `SaleorSyncWebhook`, it will be similar. Create e.g., `order-calculate-taxes
 import { SaleorSyncWebhook } from "@saleor/app-sdk/handlers/next";
 
 /**
-* Default body parser must be turned off - the raw body is needed to verify the signature
-*/
+ * Default body parser must be turned off - the raw body is needed to verify the signature
+ */
 export const config = {
   api: {
     bodyParser: false,
@@ -132,25 +132,25 @@ type Options = {
  * To be type-safe, define payload from API. This should be imported from generated GraphQL code
  */
 type OrderPayload = {
- id: string;
+  id: string;
 };
 
 /**
-* Default body parser must be turned off - the raw body is needed to verify the signature
-*/
+ * Default body parser must be turned off - the raw body is needed to verify the signature
+ */
 export const config = {
- api: {
- bodyParser: false,
+  api: {
+    bodyParser: false,
   },
 };
 
 export const orderCreatedWebhook = new SaleorAsyncWebhook<OrderPayload>({
- name: "Order Created",
- webhookPath: "api/webhooks/order-created",
- event: "ORDER_CREATED",
- isActive: true,
- apl: require("../lib/apl"),
- query: `
+  name: "Order Created",
+  webhookPath: "api/webhooks/order-created",
+  event: "ORDER_CREATED",
+  isActive: true,
+  apl: require("../lib/apl"),
+  query: `
  subscription {
  event {
  ... on OrderCreated {
@@ -161,18 +161,18 @@ export const orderCreatedWebhook = new SaleorAsyncWebhook<OrderPayload>({
       }
     }
   `,
- onError(error: WebhookError | Error) {
+  onError(error: WebhookError | Error) {
     // Can be used to e.g. trace errors
- sentry.captureError(error);
+    sentry.captureError(error);
   },
- async formatErrorResponse(
- error: WebhookError | Error,
- req: NextApiRequest,
- res: NextApiResponse
+  async formatErrorResponse(
+    error: WebhookError | Error,
+    req: NextApiRequest,
+    res: NextApiResponse
   ) {
- return {
- code: 400,
- body: "My custom response",
+    return {
+      code: 400,
+      body: "My custom response",
     };
   },
 });
@@ -187,14 +187,14 @@ export const orderCreatedWebhook = new SaleorAsyncWebhook<OrderPayload>({
  * To be type-safe, define payload from API. This should be imported from generated GraphQL code
  */
 type Payload = {
- taxBase: {
- currency: string;
+  taxBase: {
+    currency: string;
   };
 };
 
 /**
-* Default body parser must be turned off - the raw body is needed to verify the signature
-*/
+ * Default body parser must be turned off - the raw body is needed to verify the signature
+ */
 export const config = {
   api: {
     bodyParser: false,
@@ -236,13 +236,13 @@ export const orderCalculateTaxesWebhook = new SaleorAsyncWebhook<Payload>({
 
 ### Resources
 
-- Check available events [here](docs/developer/extending/webhooks/asynchronous-events.mdx#available-webhook-events)
+- Check available events [here](developer/extending/webhooks/asynchronous-events.mdx#available-webhook-events)
 - [Read more about APLs](./apl.md)
-- [Subscription query documentation](docs/developer/extending/webhooks/subscription-webhook-payloads.mdx)
+- [Subscription query documentation](developer/extending/webhooks/subscription-webhook-payloads.mdx)
 
 ### Extending app manifest
 
-Webhooks are created in Saleor when the App is installed. Saleor uses [AppManifest](docs/developer/extending/apps/architecture/manifest.mdx) to get information about webhooks to create.  
+Webhooks are created in Saleor when the App is installed. Saleor uses [AppManifest](developer/extending/apps/architecture/manifest.mdx) to get information about webhooks to create.
 `SaleorSyncWebhook` & `SaleorAsyncWebhook` utility can generate this manifest:
 
 ```typescript

--- a/docs/developer/extending/apps/developing-apps/app-sdk/settings-manager.md
+++ b/docs/developer/extending/apps/developing-apps/app-sdk/settings-manager.md
@@ -39,7 +39,7 @@ For values that should not be migrated during environment cloning (as private ke
 
 # MetadataManager
 
-Default manager used by the [App Template](docs/developer/extending/apps/developing-apps/app-template.mdx). Uses the app metadata as storage. Since the app developer can use any GraphQL client, the constructor must be parametrized with fetch and mutate functions:
+Default manager used by the [App Template](developer/extending/apps/developing-apps/app-template.mdx). Uses the app metadata as storage. Since the app developer can use any GraphQL client, the constructor must be parametrized with fetch and mutate functions:
 
 ```ts
 import { MetadataEntry } from "@saleor/app-sdk/settings-manager";

--- a/docs/developer/extending/apps/developing-apps/apps-patterns/persistence-with-metadata-manager.mdx
+++ b/docs/developer/extending/apps/developing-apps/apps-patterns/persistence-with-metadata-manager.mdx
@@ -16,7 +16,7 @@ A solution built-in in Saleor is [`privateMetadata`](developer/metadata.mdx).
 
 ## What is Metadata and what are its features
 
-Apps are one of the classes implementing [ObjectWithMetadata](docs/api-reference/miscellaneous/interfaces/object-with-metadata.mdx) interface, which can be used to store additional data in the Saleor database.
+Apps are one of the classes implementing [ObjectWithMetadata](api-reference/miscellaneous/interfaces/object-with-metadata.mdx) interface, which can be used to store additional data in the Saleor database.
 
 `privateMetadata` field in the `app` object can be accessed only by the app itself or the users with `MANAGE_APPS` permission. The field returns a list of key and value pairs that can contain any string, including stringified JSON.
 
@@ -98,7 +98,7 @@ Entries in the manager are stored using the structure:
 ```
 
 :::note Optional `domain` field
-Since metadata will be copied if you clone the database of your Saleor instance, we recommend adding the parameter `domain` to prevent misusing secret keys from different domains.  
+Since metadata will be copied if you clone the database of your Saleor instance, we recommend adding the parameter `domain` to prevent misusing secret keys from different domains.
 :::
 
 Interacting with the API is done with the methods:

--- a/docs/developer/gift-cards.mdx
+++ b/docs/developer/gift-cards.mdx
@@ -435,12 +435,12 @@ And we get an active gift card with a new `ACTIVATED` event:
 }
 ```
 
-For bulk activation, use [giftCardBulkActivate](docs/api-reference/gift-cards/mutations/gift-card-bulk-activate.mdx)
-and for bulk deactivation use [giftCardBulkDeactivate](docs/api-reference/gift-cards/mutations/gift-card-bulk-deactivate.mdx) mutation.
+For bulk activation, use [giftCardBulkActivate](api-reference/gift-cards/mutations/gift-card-bulk-activate.mdx)
+and for bulk deactivation use [giftCardBulkDeactivate](api-reference/gift-cards/mutations/gift-card-bulk-deactivate.mdx) mutation.
 
 ## Creating gift card products
 
-To allow customers to purchase gift cards, you have to [create a product type](docs/api-reference/products/mutations/product-type-create.mdx) with `GIFT_CARD` kind and use it to [create a product](docs/api-reference/products/mutations/product-create.mdx).
+To allow customers to purchase gift cards, you have to [create a product type](api-reference/products/mutations/product-type-create.mdx) with `GIFT_CARD` kind and use it to [create a product](api-reference/products/mutations/product-create.mdx).
 
 :::note
 If you want to have an unlimited number of gift cards in your shop you should create a stock in a chosen channel with at least one quantity and unset track inventory flag.
@@ -451,12 +451,12 @@ If you want to have an unlimited number of gift cards in your shop you should cr
 The `automaticallyFulfillNonShippableGiftCard` order setting defines when the bought gift cards will be created. If this flag is set to `True`, a gift card will be created during checkout completion.
 The fulfillment will be created automatically, and a gift card will be generated and sent to the customer.
 If this option is unset, the gift card will be created during order fulfillment and, after that, also sent to the customer.
-The value of this option can be changed with use of [orderSettingsUpdate](docs/api-reference/orders/mutations/order-settings-update.mdx) mutation.
+The value of this option can be changed with use of [orderSettingsUpdate](api-reference/orders/mutations/order-settings-update.mdx) mutation.
 
 The created gift card expiry date is set based on gift card settings.
 Gift card settings can be set never to expire or set to an expiry period, based on which the card expiry date is calculated.
 
-The gift card settings are set as never expiry by default and can be changed with use of [giftCardSettingsUpdate](docs/api-reference/gift-cards/mutations/gift-card-settings-update.mdx).
+The gift card settings are set as never expiry by default and can be changed with use of [giftCardSettingsUpdate](api-reference/gift-cards/mutations/gift-card-settings-update.mdx).
 In the following example, the gif card settings are set to 12 months.
 
 ```graphql {2-7}
@@ -498,7 +498,7 @@ As a result, we get the expiry settings updated.
 
 ## Using gift card in checkout
 
-To use a gift card in the checkout just run [checkoutAddPromoCode](docs/api-reference/checkout/mutations/checkout-add-promo-code.mdx)
+To use a gift card in the checkout just run [checkoutAddPromoCode](api-reference/checkout/mutations/checkout-add-promo-code.mdx)
 mutation with the gift card code.
 When the gift card is used for the first time, it will be assigned to the checkout user.
 If the card was already used, the checkout user will be compared with the gift card user. When the users differ, a validation error is raised.

--- a/docs/developer/payments.mdx
+++ b/docs/developer/payments.mdx
@@ -17,7 +17,7 @@ Saleor distinguishes two different approaches to processing a payment:
 
 Saleor offers two ways to process payments using the Saleor app:
 
-- [Saleor payment app](developer/payments.mdx#processing-a-payment-with-payment-app) - The communication between the storefront and payment app goes through Saleor.
+- [Saleor payment app](developer/payments.mdx#processing-a-payment-with-the-payment-app) - The communication between the storefront and payment app goes through Saleor.
   Saleor allows the storefront to provide and receive data directly from the app. Based on the response received from the app,
   Saleor can determine the current status of the payment and update it on its side.
 - [Saleor app with existing checkout app](developer/payments.mdx#processing-a-payment-with-checkout-app): This is recommended for more advanced use cases when a shop owner needs to provide more

--- a/docs/developer/permissions.mdx
+++ b/docs/developer/permissions.mdx
@@ -16,7 +16,7 @@ The channel restriction affects the access to data restricted by the following p
 - `MANAGE_ORDERS`
 
 Instead of assigning permissions directly to the user, we define them on a group basis.
-Organizing access rights in [Groups](docs/api-reference/users/objects/group.mdx) helps in determining the roles of team members.
+Organizing access rights in [Groups](api-reference/users/objects/group.mdx) helps in determining the roles of team members.
 
 Examples of groups:
 
@@ -32,7 +32,7 @@ they will have access to data from all channels.
 
 ### Creating and removing groups
 
-To create a new group, use the [permissionGroupCreate](docs/api-reference/users/mutations/permission-group-create.mdx) mutation.
+To create a new group, use the [permissionGroupCreate](api-reference/users/mutations/permission-group-create.mdx) mutation.
 
 #### Creating the group without channel restriction
 
@@ -170,7 +170,7 @@ in `addChannels` field will be ignored.
 
 #### Removing a group
 
-To remove a group, use the [permissionGroupDelete](docs/api-reference/users/mutations/permission-group-delete.mdx) mutation:
+To remove a group, use the [permissionGroupDelete](api-reference/users/mutations/permission-group-delete.mdx) mutation:
 
 ```graphql
 mutation {
@@ -187,7 +187,7 @@ mutation {
 
 #### Managing the group members
 
-The [permissionGroupUpdate](docs/api-reference/users/mutations/permission-group-update.mdx) mutation takes a list of user IDs you would like to add or remove from the group. Having the same user in both lists will result in an error.
+The [permissionGroupUpdate](api-reference/users/mutations/permission-group-update.mdx) mutation takes a list of user IDs you would like to add or remove from the group. Having the same user in both lists will result in an error.
 
 Example request:
 
@@ -212,7 +212,7 @@ mutation {
 
 #### Managing the group channels
 
-The [permissionGroupUpdate](docs/api-reference/users/mutations/permission-group-update.mdx)
+The [permissionGroupUpdate](api-reference/users/mutations/permission-group-update.mdx)
 mutation takes a list of channel IDs you would like to add or remove from the group.
 Having the same channels in both lists will result in an error.
 
@@ -245,7 +245,7 @@ in `addChannels` and `removeChannels` fields will be ignored.
 
 ## App permissions
 
-App permissions are defined on a per-app basis. Access can be assigned during the app installation and modified later using the [appUpdate](docs/api-reference/apps/mutations/app-update.mdx) mutation.
+App permissions are defined on a per-app basis. Access can be assigned during the app installation and modified later using the [appUpdate](api-reference/apps/mutations/app-update.mdx) mutation.
 The apps don't have channel restrictions, so all channels data can be visible by the app with the proper permission.
 
 ## JWT token and permissions
@@ -279,7 +279,7 @@ Since Saleor reads permissions from the JWT token, generating a new token is nec
 
 ## Available permissions
 
-Available permissions are kept in the [PermissionEnum](docs/api-reference/users/enums/permission-enum.mdx).
+Available permissions are kept in the [PermissionEnum](api-reference/users/enums/permission-enum.mdx).
 
 | Name                                | Description                         |
 | ----------------------------------- | ----------------------------------- |

--- a/docs/developer/products.mdx
+++ b/docs/developer/products.mdx
@@ -11,7 +11,7 @@ You can either retrieve a single product or a list of products. You may require 
 ## Multiple channels and products
 
 Customers can only fetch products from available channels. Because listing channels is only available for staff users, you will need to provide channel slugs to your storefront.
-Besides availability, you can define more parameters on a channel basis using [ProductChannelListing](docs/api-reference/products/objects/product-channel-listing.mdx):
+Besides availability, you can define more parameters on a channel basis using [ProductChannelListing](api-reference/products/objects/product-channel-listing.mdx):
 
 - `publicationDate`
 - `isPublished`
@@ -19,7 +19,7 @@ Besides availability, you can define more parameters on a channel basis using [P
 - `availableForPurchase`
 - `isAvailableForPurchase`
 
-For variants, there's [ProductVariantChannelListing](docs/api-reference/products/objects/product-variant-channel-listing.mdx):
+For variants, there's [ProductVariantChannelListing](api-reference/products/objects/product-variant-channel-listing.mdx):
 
 - `price`
 - `costPrice`
@@ -80,7 +80,7 @@ The `channel` argument can be skipped only if a user has `is_staff` flag.
 
 ### Filtering
 
-The [`products`](docs/api-reference/products/queries/products.mdx) query gives the ability to filter the results. Use the optional [`filter`](docs/api-reference/products/inputs/product-filter-input.mdx) argument. Some of the filters that are available here are:
+The [`products`](api-reference/products/queries/products.mdx) query gives the ability to filter the results. Use the optional [`filter`](api-reference/products/inputs/product-filter-input.mdx) argument. Some of the filters that are available here are:
 
 - `search: String`: search by name or part of the description.
 - `price: ...`: filter by base price:
@@ -137,7 +137,7 @@ Response:
 
 ### Sorting
 
-In [`products`](docs/api-reference/products/queries/products.mdx) you can also sort the results using two [`sortBy`](docs/api-reference/products/inputs/product-order.mdx) arguments:
+In [`products`](api-reference/products/queries/products.mdx) you can also sort the results using two [`sortBy`](api-reference/products/inputs/product-order.mdx) arguments:
 
 - `field`: the field to use for sorting the results from several predefined choices:
   - `DATE`: sort products by last update.
@@ -207,7 +207,7 @@ Response:
 
 ## Retrieving a single product
 
-To fetch a single product, use the [`product`](docs/api-reference/products/queries/product.mdx) query, which requires only one input field:
+To fetch a single product, use the [`product`](api-reference/products/queries/product.mdx) query, which requires only one input field:
 
 - `id`: the unique product ID.
 
@@ -395,7 +395,7 @@ The tax equals 1.15, which is 23% of the net price. The gross price is the sum o
 The `address` parameter is optional. If it's not provided, Saleor will use the default country code configured in the backend settings (see [DEFAULT_COUNTRY](setup/configuration.mdx#default_country)).
 :::
 
-Learn more about [Taxes](docs/developer/taxes.mdx)
+Learn more about [Taxes](developer/taxes.mdx)
 
 ## Stock availability for customers
 
@@ -465,7 +465,7 @@ To avoid leaking precise stock information, the `quantityAvailable` field will n
 For creating integrations with an external stock management system, you will need to use stock values not restricted by [`MAX_CHECKOUT_LINE_QUANTITY`](setup/configuration.mdx#max_checkout_line_quantity).
 
 :::note
-`stocks` field in the [`ProductVariant`](docs/api-reference/products/objects/product-variant.mdx) object require `MANAGE_PRODUCTS` permission.
+`stocks` field in the [`ProductVariant`](api-reference/products/objects/product-variant.mdx) object require `MANAGE_PRODUCTS` permission.
 :::
 
 To clarify the difference between `quantityAvailable` and stocks, we will query both for the product variant:

--- a/docs/developer/stock-allocation.mdx
+++ b/docs/developer/stock-allocation.mdx
@@ -74,7 +74,7 @@ allocation. At this moment, two possible options are available:
   the remaining quantity is allocated in the next warehouse on the list
   and repeated if necessary.
   To change the warehouses' order within the channel, use
-  [`channelReorderWarehouses`](docs/api-reference/channels/mutations/channel-reorder-warehouses.mdx) mutation.
+  [`channelReorderWarehouses`](api-reference/channels/mutations/channel-reorder-warehouses.mdx) mutation.
 - Prioritize warehouses with the highest stock (`PRIORITIZE_HIGH_STOCK`) - allocate stock
   in a warehouse with the most stock. If not enough stock is available in a single
   warehouse, the remaining quantity is allocated in the next warehouse on the list
@@ -86,7 +86,7 @@ allocation. At this moment, two possible options are available:
 ### Warehouse creation
 
 Firstly we need to create the warehouse with the use of
-[`createWarehouse`](docs/api-reference/products/mutations/create-warehouse.mdx) mutation.
+[`createWarehouse`](api-reference/products/mutations/create-warehouse.mdx) mutation.
 In the following example, we are specifying `name`, `slug`, `email` and `address` of a warehouse.
 
 ```graphql
@@ -144,7 +144,7 @@ As a response we get the newly created warehouse:
 ```
 
 After the warehouse is created it can be changed with the use of
-the [`updateWarehouse`](docs/api-reference/products/mutations/update-warehouse.mdx) mutation.
+the [`updateWarehouse`](api-reference/products/mutations/update-warehouse.mdx) mutation.
 There is an option to change the following warehouse fields: `name`, `slug`, `email`, `address` and
 also define privacy and `click and collect` options.
 
@@ -181,7 +181,7 @@ the stocks are allocated from the next warehouse with the highest available quan
 
 To allow assigning the warehouse to the shipping zone we need to have at least one common
 channel with this zone. So firstly, we need to assign warehouses to channels with the use of
-[`channelUpdate`](docs/api-reference/channels/mutations/channel-update.mdx) mutation.
+[`channelUpdate`](api-reference/channels/mutations/channel-update.mdx) mutation.
 See the example below:
 
 ```graphql
@@ -239,7 +239,7 @@ Shipping zones are required to sell physical products to given countries.
 
 ### Shipping zone creation and update
 
-To create the shipping zone use [`shippingZoneCreate`](docs/api-reference/shipping/mutations/shipping-zone-create.mdx) mutation.
+To create the shipping zone use [`shippingZoneCreate`](api-reference/shipping/mutations/shipping-zone-create.mdx) mutation.
 You can specify such fields as `name`, `description`, `countries`, `warehouses`, `channels` and
 decide if you want to use it as the default one for all countries
 that are not covered by other zones.
@@ -329,7 +329,7 @@ As a result, we get the newly created shipping zone.
 }
 ```
 
-To update the shipping zone use [`shippingZoneUpdate`](docs/api-reference/shipping/mutations/shipping-zone-update.mdx) mutation.
+To update the shipping zone use [`shippingZoneUpdate`](api-reference/shipping/mutations/shipping-zone-update.mdx) mutation.
 You can change all fields you defined during the creation process and unlink the channels and warehouses. Be aware that removing the channel may cause unlinking warehouses if it was the only common channel between zone and warehouse.
 As before, adding warehouses must have a common channel with the shipping zone.
 

--- a/docs/developer/taxes.mdx
+++ b/docs/developer/taxes.mdx
@@ -10,7 +10,7 @@ You can configure the tax calculation method per channel and override the config
 
 ## Tax Configuration
 
-The tax configuration object defines various configuration options for a channel. This includes the tax calculation method, whether to charge taxes in the channel, or whether the entered prices include the tax. The configuration object is created automatically for each sales channel. In the API, it is represented by the [`TaxConfiguration`](docs/api-reference/taxes/objects/tax-configuration.mdx) object.
+The tax configuration object defines various configuration options for a channel. This includes the tax calculation method, whether to charge taxes in the channel, or whether the entered prices include the tax. The configuration object is created automatically for each sales channel. In the API, it is represented by the [`TaxConfiguration`](api-reference/taxes/objects/tax-configuration.mdx) object.
 
 The tax configuration object has several properties, including:
 
@@ -18,9 +18,9 @@ The tax configuration object has several properties, including:
 - `taxCalculationStrategy` - The strategy for tax calculation in the channel. There are two strategies available:
   - flat rates - the default strategy
   - dynamic taxes (tax apps)
-- `displayGrossPrices` - Determines whether prices displayed in a storefront should include taxes. Note that this setting doesn’t affect internal calculations in Saleor, and it’s only meant for the storefront to decide if it should display `TaxedMoney.net` or `TaxedMoney.gross` price (see [TaxedMoney API reference](docs/api-reference/miscellaneous/objects/taxed-money.mdx)). For storefront queries, this property can be fetched at two levels:
-  - product level in the [ProductPricingInfo.displayGrossPrices](docs/api-reference/products/objects/product-pricing-info.mdx) field - use it when rendering product listings or product details pages
-  - checkout level in the [Checkout.displayGrossPrices](docs/api-reference/checkout/objects/checkout.mdx) field - use it when rendering the cart or checkout pages
+- `displayGrossPrices` - Determines whether prices displayed in a storefront should include taxes. Note that this setting doesn’t affect internal calculations in Saleor, and it’s only meant for the storefront to decide if it should display `TaxedMoney.net` or `TaxedMoney.gross` price (see [TaxedMoney API reference](api-reference/miscellaneous/objects/taxed-money.mdx)). For storefront queries, this property can be fetched at two levels:
+  - product level in the [ProductPricingInfo.displayGrossPrices](api-reference/products/objects/product-pricing-info.mdx) field - use it when rendering product listings or product details pages
+  - checkout level in the [Checkout.displayGrossPrices](api-reference/checkout/objects/checkout.mdx) field - use it when rendering the cart or checkout pages
 - `pricesEnteredWithTax` - Determine whether product prices are entered with tax included (typical for B2C in EU) or not (typical for US and B2B).
 
 Additionally, the following properties can be overridden for specific countries within the channel: `chargeTaxes`, `taxCalculationStrategy`, `displayGrossPrices`. This allows for handling various situations where a store operates in different countries with different tax rules.
@@ -273,7 +273,7 @@ mutation {
 
 ### Querying products with taxed prices for a specific country
 
-When using flat rates, the API can list products with prices that include tax rates for different countries. To do this, pass the country code for which you have flat rate configurations available. If the `country` argument is not specified, the default country for the channel is assumed. (See [Channel.defaultCountry](docs/api-reference/channels/objects/channel.mdx).)
+When using flat rates, the API can list products with prices that include tax rates for different countries. To do this, pass the country code for which you have flat rate configurations available. If the `country` argument is not specified, the default country for the channel is assumed. (See [Channel.defaultCountry](api-reference/channels/objects/channel.mdx).)
 
 In this example, we are fetching a product list with prices for Poland.
 
@@ -344,7 +344,7 @@ mutation {
 
 ## Tax exemption
 
-The [Tax Exemption API](docs/api-reference/taxes/mutations/tax-exemption-manage.mdx) allows you to exempt checkouts or orders from taxes, regardless of any channel or country-specific configuration. Note that this API is restricted to users with the `MANAGE_TAXES` permission.
+The [Tax Exemption API](api-reference/taxes/mutations/tax-exemption-manage.mdx) allows you to exempt checkouts or orders from taxes, regardless of any channel or country-specific configuration. Note that this API is restricted to users with the `MANAGE_TAXES` permission.
 
 To exempt a checkout from taxes, use the following mutation:
 

--- a/docs/setup/upgrading.mdx
+++ b/docs/setup/upgrading.mdx
@@ -30,7 +30,7 @@ For instructions specific to upgrading between particular versions, see the [upg
 
 ## Upgrading with zero-downtime
 
-For general knowledge of how zero-downtime migrations work, please check [writing zero-downtime migrations](docs/developer/community/zero-downtime-migrations.mdx).
+For general knowledge of how zero-downtime migrations work, please check [writing zero-downtime migrations](developer/community/zero-downtime-migrations.mdx).
 
 Zero-downtime migrations can only be achieved by upgrading Saleor minor version by minor version, that means, to upgrade Saleor from version 3.11 to 3.13, you need first upgrade your workers
 to version 3.12, then proceed with upgrading to version 3.13. By upgrading from version 3.11 directly to 3.13 you will not follow zero-downtime policy.

--- a/docs/upgrade-guides/2-11-to-3-0.mdx
+++ b/docs/upgrade-guides/2-11-to-3-0.mdx
@@ -35,16 +35,16 @@ Besides the impact on fetching the data, you'll be required to specify the chann
 
 ### Editing channel related fields
 
-If you use the API to modify objects (for example, with an external app), please note that channel-depending fields have dedicated mutations. Updating product price requires using the [productChannelListingUpdate](docs/api-reference/products/mutations/product-channel-listing-update.mdx) mutation.
+If you use the API to modify objects (for example, with an external app), please note that channel-depending fields have dedicated mutations. Updating product price requires using the [productChannelListingUpdate](api-reference/products/mutations/product-channel-listing-update.mdx) mutation.
 
 Object attributes that can be defined on a channel basis can be referenced.
 
-- [Collection Channel Listing](docs/api-reference/products/objects/collection-channel-listing.mdx)
-- [Product Channel Listing](docs/api-reference/products/objects/product-channel-listing.mdx)
-- [ProductVariant Channel Listing](docs/api-reference/products/objects/product-variant-channel-listing.mdx)
-- [Sale Channel Listing](docs/api-reference/discounts/objects/sale-channel-listing.mdx)
-- [ShippingMethod Channel Listing](docs/api-reference/shipping/objects/shipping-method-channel-listing.mdx)
-- [Voucher Channel Listing](docs/api-reference/discounts/objects/voucher-channel-listing.mdx)
+- [Collection Channel Listing](api-reference/products/objects/collection-channel-listing.mdx)
+- [Product Channel Listing](api-reference/products/objects/product-channel-listing.mdx)
+- [ProductVariant Channel Listing](api-reference/products/objects/product-variant-channel-listing.mdx)
+- [Sale Channel Listing](api-reference/discounts/objects/sale-channel-listing.mdx)
+- [ShippingMethod Channel Listing](api-reference/shipping/objects/shipping-method-channel-listing.mdx)
+- [Voucher Channel Listing](api-reference/discounts/objects/voucher-channel-listing.mdx)
 
 ## Email templates
 

--- a/docs/upgrade-guides/3-1-to-3-2.mdx
+++ b/docs/upgrade-guides/3-1-to-3-2.mdx
@@ -9,7 +9,7 @@ Version 3.2 introduces some breaking changes necessary to ensure the highest qua
 
 ## JWT token expiration
 
-Since Saleor 3.2, JWT token expiration time is set to 5 minutes and can be controlled server-side with `JWT_TTL_ACCESS` environment variable. See [Refreshing an access token](docs/api-usage/authentication.mdx#refreshing-the-access-token) to learn how to refresh the token in your client app.
+Since Saleor 3.2, JWT token expiration time is set to 5 minutes and can be controlled server-side with `JWT_TTL_ACCESS` environment variable. See [Refreshing an access token](api-usage/authentication.mdx#refreshing-the-access-token) to learn how to refresh the token in your client app.
 
 ## Saleor Apps inside Dashboard
 

--- a/versioned_docs/version-3.x/api-usage/authentication.mdx
+++ b/versioned_docs/version-3.x/api-usage/authentication.mdx
@@ -158,7 +158,7 @@ along with the [source code](https://github.com/saleor/example-auth-sdk).
 
 This is the most common way of authenticating users. It is used in the Saleor Storefront and Dashboard.
 
-To authenticate a user, you need to use the [`tokenCreate`](docs/api-reference/authentication/mutations/token-create.mdx) mutation. It takes an email and password as input and returns an **access token** that can be used to access resources related to the user and a **refresh token** that can be used to generate future access tokens.
+To authenticate a user, you need to use the [`tokenCreate`](api-reference/authentication/mutations/token-create.mdx) mutation. It takes an email and password as input and returns an **access token** that can be used to access resources related to the user and a **refresh token** that can be used to generate future access tokens.
 
 ```graphql
 mutation {
@@ -237,7 +237,7 @@ A decoded token has the following structure:
 
 #### Fetching information about the currently authenticated user
 
-You can use the [`me`](docs/api-reference/users/queries/me.mdx) query to retrieve information about the currently authenticated user:
+You can use the [`me`](api-reference/users/queries/me.mdx) query to retrieve information about the currently authenticated user:
 
 ```graphql
 query {
@@ -280,7 +280,7 @@ console.log(result);
 
 ##### Verifying tokens with a mutation
 
-You can verify tokens by calling the [`tokenVerify`](docs/api-reference/authentication/mutations/token-verify.mdx) mutation:
+You can verify tokens by calling the [`tokenVerify`](api-reference/authentication/mutations/token-verify.mdx) mutation:
 
 ```graphql {2}
 mutation {
@@ -314,7 +314,7 @@ In the future, `tokenRefresh` mutation will also generate a new refresh token an
 
 #### Deactivating all tokens of a particular user
 
-The [`tokensDeactivateAll`](docs/api-reference/authentication/mutations/tokens-deactivate-all.mdx) mutation will invalidate all tokens (access and refresh, including the token used to invoke the mutation) that belong to the invoking user.
+The [`tokensDeactivateAll`](api-reference/authentication/mutations/tokens-deactivate-all.mdx) mutation will invalidate all tokens (access and refresh, including the token used to invoke the mutation) that belong to the invoking user.
 
 ```graphql
 mutation {
@@ -399,7 +399,7 @@ The implicit flow requires the following scopes to operate:
 
 If **Use OAuth scope permissions** is enabled, any permissions granted to a user on the authentication provider side will be used as the effective permissions on the Saleor side.
 
-If the plugin is configured to manage user permissions, you need to create OAuth scopes corresponding to Saleor permissions on the identity provider side. The plugin will request lowercase scope names based on the [`PermissionEnum`](docs/api-reference/users/enums/permission-enum.mdx). For example, the `MANAGE_PRODUCTS` corresponds to the `saleor:manage_products` scope.
+If the plugin is configured to manage user permissions, you need to create OAuth scopes corresponding to Saleor permissions on the identity provider side. The plugin will request lowercase scope names based on the [`PermissionEnum`](api-reference/users/enums/permission-enum.mdx). For example, the `MANAGE_PRODUCTS` corresponds to the `saleor:manage_products` scope.
 
 Saleor will look for supported permissions in the `scope` field of the access token. If the `scope` doesn't contain any Saleor permissions, Saleor will look for permissions in the token's `permissions` field.
 
@@ -468,7 +468,7 @@ Authorization: Bearer <access-token>
 
 To authenticate the user, you will need to redirect them to the identity provider's login page.
 
-Start by calling the [`externalAuthenticationUrl`](docs/api-reference/authentication/mutations/external-authentication-url.mdx) mutation passing `"mirumee.authentication.openidconnect"` as the `pluginId` argument and include a `redirectUri` parameter in the `input` argument:
+Start by calling the [`externalAuthenticationUrl`](api-reference/authentication/mutations/external-authentication-url.mdx) mutation passing `"mirumee.authentication.openidconnect"` as the `pluginId` argument and include a `redirectUri` parameter in the `input` argument:
 
 ```graphql
 mutation {
@@ -505,7 +505,7 @@ Next, redirect the user to the identity provider's login page. Once the user is 
 
 ### Obtaining an access token
 
-The [`externalObtainAccessTokens`](docs/api-reference/authentication/mutations/external-obtain-access-tokens.mdx) mutation will allow you to exchange the token returned by the identity provider for a Saleor access token.
+The [`externalObtainAccessTokens`](api-reference/authentication/mutations/external-obtain-access-tokens.mdx) mutation will allow you to exchange the token returned by the identity provider for a Saleor access token.
 
 Once again, you will need to pass `"mirumee.authentication.openidconnect"` as the `pluginId` argument, this time including the `code` and `state` received in the query parameters:
 
@@ -534,7 +534,7 @@ mutation {
 
 ### Refreshing tokens
 
-The [`externalRefresh`](docs/api-reference/authentication/mutations/external-refresh.mdx) mutation will generate a new access token when given a valid refresh token.
+The [`externalRefresh`](api-reference/authentication/mutations/external-refresh.mdx) mutation will generate a new access token when given a valid refresh token.
 
 As with the previous calls, you will need to pass `"mirumee.authentication.openidconnect"` as the `pluginId` argument, this time including the `refreshToken`:
 
@@ -559,7 +559,7 @@ mutation {
 
 ### Verifying tokens
 
-To verify the token, use the following [`externalVerify`](docs/api-reference/authentication/mutations/external-verify.mdx) mutation.
+To verify the token, use the following [`externalVerify`](api-reference/authentication/mutations/external-verify.mdx) mutation.
 
 Once again, you will need to pass `"mirumee.authentication.openidconnect"` as the `pluginId` argument, this time including the `token`:
 
@@ -588,7 +588,7 @@ The `user` field will contain the user's details if the token is valid.
 
 Logging out requires the user to be redirected to the identity provider's logout page.
 
-You can prepare the logout URL by calling the [`externalLogout`](docs/api-reference/authentication/mutations/external-logout.mdx) mutation. Any parameters you pass in the `input` argument will be included in the logout URL.
+You can prepare the logout URL by calling the [`externalLogout`](api-reference/authentication/mutations/external-logout.mdx) mutation. Any parameters you pass in the `input` argument will be included in the logout URL.
 
 ```graphql
 mutation ($input: JSONString!) {

--- a/versioned_docs/version-3.x/api-usage/error-handling.mdx
+++ b/versioned_docs/version-3.x/api-usage/error-handling.mdx
@@ -143,4 +143,4 @@ Validation errors are returned in a dedicated error field inside mutation result
 Although all error types contain a `message` field, the returned message is only meant for debugging and is not suitable for display to your customers. Please use the `code` field and provide your own meaningful error messages.
 :::
 
-We use enums for representing code values. All possible values for the query above can be found on the [AccountError](docs/api-reference/users/enums/account-error-code.mdx) page of the API reference section.
+We use enums for representing code values. All possible values for the query above can be found on the [AccountError](api-reference/users/enums/account-error-code.mdx) page of the API reference section.

--- a/versioned_docs/version-3.x/api-usage/filtering.mdx
+++ b/versioned_docs/version-3.x/api-usage/filtering.mdx
@@ -20,7 +20,7 @@ feedback. However, it is still undergoing development and is subject to modifica
 
 The `where` filtering allows specifying more complex conditions with the use of `AND` and `OR` operators,
 combined with operations like equal (`eq`), one of, and range. It's available under the `where` option,
-for now, only on the [attributes](docs/api-reference/attributes/queries/attributes.mdx) query.
+for now, only on the [attributes](api-reference/attributes/queries/attributes.mdx) query.
 
 ### General approach
 

--- a/versioned_docs/version-3.x/api-usage/i18n.mdx
+++ b/versioned_docs/version-3.x/api-usage/i18n.mdx
@@ -20,21 +20,21 @@ For web applications, you can manage the frontend part using libraries like [For
 
 For translating database data, Saleor delivers specialized translation objects that can you can modify in the dashboard or using the API.
 
-- [`ProductTranslation`](docs/api-reference/products/objects/product-translation.mdx)
-- [`CollectionTranslation`](docs/api-reference/products/objects/collection-translation.mdx)
-- [`CategoryTranslation`](docs/api-reference/products/objects/category-translation.mdx)
-- [`AttributeTranslation`](docs/api-reference/attributes/objects/attribute-translation.mdx)
-- [`AttributeValueTranslation`](docs/api-reference/attributes/objects/attribute-value-translation.mdx)
-- [`ProductVariantTranslation`](docs/api-reference/products/objects/product-variant-translation.mdx)
-- [`PageTranslation`](docs/api-reference/pages/objects/page-translation.mdx)
-- [`ShippingMethodTranslation`](docs/api-reference/shipping/objects/shipping-method-translation.mdx)
-- [`SaleTranslation`](docs/api-reference/discounts/objects/sale-translation.mdx)
-- [`VoucherTranslation`](docs/api-reference/discounts/objects/voucher-translation.mdx)
-- [`MenuItemTranslation`](docs/api-reference/menu/objects/menu-item-translation.mdx)
+- [`ProductTranslation`](api-reference/products/objects/product-translation.mdx)
+- [`CollectionTranslation`](api-reference/products/objects/collection-translation.mdx)
+- [`CategoryTranslation`](api-reference/products/objects/category-translation.mdx)
+- [`AttributeTranslation`](api-reference/attributes/objects/attribute-translation.mdx)
+- [`AttributeValueTranslation`](api-reference/attributes/objects/attribute-value-translation.mdx)
+- [`ProductVariantTranslation`](api-reference/products/objects/product-variant-translation.mdx)
+- [`PageTranslation`](api-reference/pages/objects/page-translation.mdx)
+- [`ShippingMethodTranslation`](api-reference/shipping/objects/shipping-method-translation.mdx)
+- [`SaleTranslation`](api-reference/discounts/objects/sale-translation.mdx)
+- [`VoucherTranslation`](api-reference/discounts/objects/voucher-translation.mdx)
+- [`MenuItemTranslation`](api-reference/menu/objects/menu-item-translation.mdx)
 
 ### Fetching translated data
 
-Here's an example fetching the Polish translation of an existing category. A `translation` field in the [`Category`](docs/api-reference/products/objects/category.mdx) model takes a `languageCode` argument with one of the values defined by [`LanguageCodeEnum`](docs/api-reference/miscellaneous/enums/language-code-enum.mdx):
+Here's an example fetching the Polish translation of an existing category. A `translation` field in the [`Category`](api-reference/products/objects/category.mdx) model takes a `languageCode` argument with one of the values defined by [`LanguageCodeEnum`](api-reference/miscellaneous/enums/language-code-enum.mdx):
 
 ```graphql
 query {
@@ -75,7 +75,7 @@ Prices and dates can be localized using [`Intl.NumberFormat`](https://developer.
 
 ## Localizing address input
 
-Saleor provides an [`AddressInput`](docs/api-reference/miscellaneous/inputs/address-input.mdx) type that you can use to collect address data from the user. It offers fields to store the country, city, postal code, and street address. Which fields to show and how to label them can be determined by querying the address validation API.
+Saleor provides an [`AddressInput`](api-reference/miscellaneous/inputs/address-input.mdx) type that you can use to collect address data from the user. It offers fields to store the country, city, postal code, and street address. Which fields to show and how to label them can be determined by querying the address validation API.
 
 For more details, see documentation on [address validation](developer/address.mdx).
 

--- a/versioned_docs/version-3.x/api-usage/prices.mdx
+++ b/versioned_docs/version-3.x/api-usage/prices.mdx
@@ -16,7 +16,7 @@ Presenting a number depends on the language and region. If you are building a we
 
 ### Money
 
-[`Money`](docs/api-reference/miscellaneous/objects/money.mdx) is a basic type for keeping prices without taxes. We do not restrict currency code values, so a user uses crypto-currencies or other custom currency.
+[`Money`](api-reference/miscellaneous/objects/money.mdx) is a basic type for keeping prices without taxes. We do not restrict currency code values, so a user uses crypto-currencies or other custom currency.
 
 ```graphql
 type Money {
@@ -30,7 +30,7 @@ type Money {
 
 ### TaxedMoney
 
-The most common example of [`TaxedMoney`](docs/api-reference/miscellaneous/objects/taxed-money.mdx) is a [`ProductVariant`](docs/api-reference/products/objects/product-variant.mdx) price. If a user does not use any tax integration, both net and gross prices will be populated with the same value.
+The most common example of [`TaxedMoney`](api-reference/miscellaneous/objects/taxed-money.mdx) is a [`ProductVariant`](api-reference/products/objects/product-variant.mdx) price. If a user does not use any tax integration, both net and gross prices will be populated with the same value.
 
 ```graphql
 type TaxedMoney {
@@ -48,7 +48,7 @@ type TaxedMoney {
 
 ### MoneyRange
 
-[`MoneyRange`](docs/api-reference/miscellaneous/objects/money-range.mdx) is used to display prices for a [`ShippingZone`](docs/api-reference/shipping/objects/shipping-zone.mdx).
+[`MoneyRange`](api-reference/miscellaneous/objects/money-range.mdx) is used to display prices for a [`ShippingZone`](api-reference/shipping/objects/shipping-zone.mdx).
 
 ```graphql
 type MoneyRange {
@@ -62,7 +62,7 @@ type MoneyRange {
 
 ### TaxedMoneyRange
 
-[`TaxedMoneyRange`](docs/api-reference/miscellaneous/objects/taxed-money-range.mdx) is used in [`Products`](docs/api-reference/products/objects/product.mdx), because variants can differ in prices. You can display it as "price starts from $10" or "$10–$20".
+[`TaxedMoneyRange`](api-reference/miscellaneous/objects/taxed-money-range.mdx) is used in [`Products`](api-reference/products/objects/product.mdx), because variants can differ in prices. You can display it as "price starts from $10" or "$10–$20".
 
 ```graphql
 type TaxedMoneyRange {

--- a/versioned_docs/version-3.x/developer/address.mdx
+++ b/versioned_docs/version-3.x/developer/address.mdx
@@ -14,7 +14,7 @@ Validation is only performed on the format of address data. To check if the addr
 
 ## Validation rules
 
-Using the [addressValidationRules](docs/api-reference/users/queries/address-validation-rules.mdx) query, API clients can fetch validation rules depending on the selected country. Based on the ruleset, some address fields can be hidden (e.g. `countryArea`).
+Using the [addressValidationRules](api-reference/users/queries/address-validation-rules.mdx) query, API clients can fetch validation rules depending on the selected country. Based on the ruleset, some address fields can be hidden (e.g. `countryArea`).
 Saleor Core uses [Google i18n address](https://github.com/mirumee/google-i18n-address) under the hood, with a ruleset from [Google Address Data](https://chromium-i18n.appspot.com/ssl-address).
 
 ```graphql
@@ -54,7 +54,7 @@ Depending on the country, not all `allowedFields` fields are necessary. Neverthe
 
 ## Setting up the address using the API
 
-As an example of the address validation API, we will set the billing address in the checkout. The operation can be made with [checkoutBillingAddressUpdate](docs/api-reference/checkout/mutations/checkout-billing-address-update.mdx):
+As an example of the address validation API, we will set the billing address in the checkout. The operation can be made with [checkoutBillingAddressUpdate](api-reference/checkout/mutations/checkout-billing-address-update.mdx):
 
 ```graphql
 mutation {

--- a/versioned_docs/version-3.x/developer/app-store/apps/taxes/architecture.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/taxes/architecture.mdx
@@ -6,13 +6,13 @@ title: Architecture
 
 The Taxes App uses the following webhook events for tax reporting and calculations:
 
-- [`OrderCalculateTaxes`](docs/api-reference/taxes/objects/calculate-taxes.mdx)
-- [`CheckoutCalculateTaxes`](docs/api-reference/taxes/objects/calculate-taxes.mdx)
-- [`OrderConfirmed`](docs/api-reference/orders/objects/order-confirmed.mdx)
+- [`OrderCalculateTaxes`](api-reference/taxes/objects/calculate-taxes.mdx)
+- [`CheckoutCalculateTaxes`](api-reference/taxes/objects/calculate-taxes.mdx)
+- [`OrderConfirmed`](api-reference/orders/objects/order-confirmed.mdx)
 
 ## Calculating taxes
 
-Calculating taxes using external tax providers happens through a synchronous [`CalculateTaxes`](docs/api-reference/taxes/objects/calculate-taxes.mdx) webhook event. A [synchronous webhook](docs/developer/extending/webhooks/synchronous-events/overview.mdx) awaits a response from the app before continuing.
+Calculating taxes using external tax providers happens through a synchronous [`CalculateTaxes`](api-reference/taxes/objects/calculate-taxes.mdx) webhook event. A [synchronous webhook](developer/extending/webhooks/synchronous-events/overview.mdx) awaits a response from the app before continuing.
 
 While the app is waiting for the values of the calculated taxes, the sequence of actions is as follows:
 
@@ -30,7 +30,7 @@ During tax calculation, the transactions on the tax providers' side are not reco
 
 ## Recording transactions
 
-Once the order is finalized, we want to send a transaction to the tax provider for tax reporting. This is done through [asynchronous webhook](docs/developer/extending/webhooks/asynchronous-events.mdx) events that fire on different order lifecycle actions.
+Once the order is finalized, we want to send a transaction to the tax provider for tax reporting. This is done through [asynchronous webhook](developer/extending/webhooks/asynchronous-events.mdx) events that fire on different order lifecycle actions.
 
 ```mermaid
 sequenceDiagram

--- a/versioned_docs/version-3.x/developer/app-store/apps/taxes/avatax/document-code.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/taxes/avatax/document-code.mdx
@@ -1,6 +1,6 @@
 # Mapping document code
 
-By default, the [document code](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-document-codes/) is set to be equal to Saleor [`order`](docs/api-storefront/orders/objects/order.mdx) id.
+By default, the [document code](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-document-codes/) is set to be equal to Saleor [`order`](api-storefront/orders/objects/order.mdx) id.
 
 If you want to override it, you can do so by providing a value for the `privateMetadata` field `avataxDocumentCode`.
 

--- a/versioned_docs/version-3.x/developer/app-store/apps/taxes/avatax/overview.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/taxes/avatax/overview.mdx
@@ -59,7 +59,7 @@ After entering, the address must be verified by clicking the _Verify_ button tha
 
 ## Mapping transaction fields
 
-When an order is confirmed, the Taxes App [creates a transaction in AvaTax](https://developer.avalara.com/api-reference/avatax/rest/v2/methods/Transactions/CreateTransaction/). The transaction contains fields that are mapped from the order. For several fields, you can provide custom values with [`privateMetadata`](docs/developer/metadata.mdx#private-and-public-metadata). You have to make sure to set the value before confirming the order (e.g. when the order is still a draft).
+When an order is confirmed, the Taxes App [creates a transaction in AvaTax](https://developer.avalara.com/api-reference/avatax/rest/v2/methods/Transactions/CreateTransaction/). The transaction contains fields that are mapped from the order. For several fields, you can provide custom values with [`privateMetadata`](developer/metadata.mdx#private-and-public-metadata). You have to make sure to set the value before confirming the order (e.g. when the order is still a draft).
 
 The mutation for setting the private metadata is:
 
@@ -87,7 +87,7 @@ Taxes App supports the following mappings:
 
 **Metadata key: `avataxDocumentCode`**
 
-By default, the [document code](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-document-codes/) is set to be equal to Saleor [`order`](docs/api-storefront/orders/objects/order.mdx) id.
+By default, the [document code](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-document-codes/) is set to be equal to Saleor [`order`](api-storefront/orders/objects/order.mdx) id.
 
 If you want to override it, you can do so by providing a value for the `privateMetadata` field `avataxDocumentCode`.
 
@@ -109,7 +109,7 @@ To map the entity type, you need to provide the value for the `entityUseCode` fi
 
 **Metadata key: `avataxTaxCalculationDate`**
 
-By default, the [tax calculation date](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-tax-calc-date/) is set to be equal to the order creation date from Saleor [`order`](docs/api-storefront/orders/objects/order.mdx).
+By default, the [tax calculation date](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-tax-calc-date/) is set to be equal to the order creation date from Saleor [`order`](api-storefront/orders/objects/order.mdx).
 
 If you want to override it, you can do so by providing a value for the `privateMetadata` field `avataxTaxCalculationDate`.
 

--- a/versioned_docs/version-3.x/developer/app-store/apps/taxes/avatax/tax-calculation-date.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/taxes/avatax/tax-calculation-date.mdx
@@ -1,6 +1,6 @@
 # Mapping tax calculation date
 
-By default, the [tax calculation date](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-tax-calc-date/) is set to be equal to the order creation date from Saleor [`order`](docs/api-storefront/orders/objects/order.mdx).
+By default, the [tax calculation date](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-tax-calc-date/) is set to be equal to the order creation date from Saleor [`order`](api-storefront/orders/objects/order.mdx).
 
 If you want to override it, you can do so by providing a value for the `privateMetadata` field `avataxTaxCalculationDate`.
 

--- a/versioned_docs/version-3.x/developer/app-store/apps/taxes/overview.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/taxes/overview.mdx
@@ -11,7 +11,7 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
   githubUrl="https://github.com/saleor/apps/tree/main/apps/taxes"
 />
 
-_Taxes_ is a Saleor app that allows delegating tax calculations to external tax providers. It can replace the default ([flat rates](docs/developer/taxes.mdx#flat-rates)) tax calculation method in Saleor. It affects both the checkout and the order creation process.
+_Taxes_ is a Saleor app that allows delegating tax calculations to external tax providers. It can replace the default ([flat rates](developer/taxes.mdx#flat-rates)) tax calculation method in Saleor. It affects both the checkout and the order creation process.
 
 The currently supported providers are:
 
@@ -37,7 +37,7 @@ Besides the shared features, AvaTax integration also offers:
 - [Mapping the entity type](avatax/overview#entity-type)
 - [Mapping the document code](avatax/overview#document-code)
 - [Mapping the tax calculation date](avatax/overview#tax-calculation-date)
-- Voiding transaction on [`OrderCancelled`](docs/api-reference/orders/objects/order-cancelled.mdx) event
+- Voiding transaction on [`OrderCancelled`](api-reference/orders/objects/order-cancelled.mdx) event
 
 ## Architecture
 

--- a/versioned_docs/version-3.x/developer/app-store/legacy-plugins/dummy-credit-card.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/legacy-plugins/dummy-credit-card.mdx
@@ -30,7 +30,7 @@ Any other card numbers with valid expiration dates and random CVV values create 
 
 In the case of testing dummy payment responses with API, you need to have a checkout with shipping and billing address set. See [the checkout page](developer/checkout/overview.mdx#creating-a-checkout-session)
 to know how to create a checkout object.
-Then create checkout payment with use of [`checkoutPaymentCreate`](docs/api-reference/checkout/mutations/checkout-payment-create.mdx) mutation,
+Then create checkout payment with use of [`checkoutPaymentCreate`](api-reference/checkout/mutations/checkout-payment-create.mdx) mutation,
 set card number as a `token` value and `mirumee.payments.dummy` as a `gateway`.
 To check gateway response use `CheckoutComplete` mutation.
 Let's see an example for a token that causes Card Expired error.

--- a/versioned_docs/version-3.x/developer/attributes.mdx
+++ b/versioned_docs/version-3.x/developer/attributes.mdx
@@ -9,8 +9,8 @@ Properly configured attributes provide crucial information about your products a
 
 Attributes can be used for:
 
-- [Products](docs/api-reference/products/objects/product.mdx) and [ProductVariants](docs/api-reference/products/objects/product-variant.mdx)
-- [Pages](docs/api-reference/pages/objects/page.mdx)
+- [Products](api-reference/products/objects/product.mdx) and [ProductVariants](api-reference/products/objects/product-variant.mdx)
+- [Pages](api-reference/pages/objects/page.mdx)
 
 ## Use cases
 
@@ -32,7 +32,7 @@ To assign attributes to products and pages, a user needs only the following perm
 
 ## Input types
 
-Each attribute has an input type defined upon attribute creation. Input types determine the data type you can enter as the attribute values in the dashboard. Available input types are defined in the [`AttributeInputTypeEnum`](docs/api-reference/attributes/enums/attribute-input-type-enum.mdx) enum. Below is the list of available input types:
+Each attribute has an input type defined upon attribute creation. Input types determine the data type you can enter as the attribute values in the dashboard. Available input types are defined in the [`AttributeInputTypeEnum`](api-reference/attributes/enums/attribute-input-type-enum.mdx) enum. Below is the list of available input types:
 
 | Name          | Description                                                                                  | Example                                                                                  |
 | ------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
@@ -85,7 +85,7 @@ The `attributes` field supports pagination and filtering, e.g., searching attrib
 
 ## Fetching assigned attributes
 
-Attributes assigned to an object are represented by the [`SelectedAttribute`](docs/api-reference/attributes/objects/selected-attribute.mdx) GraphQL type. Below is the example of fetching attributes assigned to a product:
+Attributes assigned to an object are represented by the [`SelectedAttribute`](api-reference/attributes/objects/selected-attribute.mdx) GraphQL type. Below is the example of fetching attributes assigned to a product:
 
 ```graphql
 {
@@ -109,7 +109,7 @@ Similarly, you can fetch assigned attributes for `ProductVariant` and `Page` typ
 
 A user can use a `slug` to filter products by attributes. The query parameters can be encoded in URL and will be the same in all languages.
 
-An example of a [`products`](docs/api-reference/products/queries/products.mdx) query:
+An example of a [`products`](api-reference/products/queries/products.mdx) query:
 
 ```graphql
 query {

--- a/versioned_docs/version-3.x/developer/channels.mdx
+++ b/versioned_docs/version-3.x/developer/channels.mdx
@@ -19,29 +19,29 @@ Popular use cases:
 
 There are many models you can customize per channel. The details of which fields you can define on a per-channel basis are described in the `ChannelListing` models:
 
-- [Collection](docs/api-reference/products/objects/collection-channel-listing.mdx)
-- [Product](docs/api-reference/products/objects/product-channel-listing.mdx)
-- [ProductVariant](docs/api-reference/products/objects/product-variant-channel-listing.mdx)
-- [Sale](docs/api-reference/discounts/objects/sale-channel-listing.mdx)
-- [ShippingMethod](docs/api-reference/shipping/objects/shipping-method-channel-listing.mdx)
-- [Voucher](docs/api-reference/discounts/objects/voucher-channel-listing.mdx)
+- [Collection](api-reference/products/objects/collection-channel-listing.mdx)
+- [Product](api-reference/products/objects/product-channel-listing.mdx)
+- [ProductVariant](api-reference/products/objects/product-variant-channel-listing.mdx)
+- [Sale](api-reference/discounts/objects/sale-channel-listing.mdx)
+- [ShippingMethod](api-reference/shipping/objects/shipping-method-channel-listing.mdx)
+- [Voucher](api-reference/discounts/objects/voucher-channel-listing.mdx)
 
-Many [Saleor Apps](docs/developer/app-store/overview.mdx) allow to configure them per-channel. We recommend to allow it for the best flexibility.
+Many [Saleor Apps](developer/app-store/overview.mdx) allow to configure them per-channel. We recommend to allow it for the best flexibility.
 
 ## Permissions
 
-Listing channels is allowed only for users with the active [`isStaff`](docs/api-reference/users/objects/user.mdx#isstaff-boolean) flag.
+Listing channels is allowed only for users with the active [`isStaff`](api-reference/users/objects/user.mdx#isstaff-boolean) flag.
 
 You need the `MANAGE_CHANNELS` permission to create, edit, and remove channels.
 Changing `ChannelListing` does not require additional permissions. For example, changing Product availability requires only `MANAGE_PRODUCTS` permission.
 
 Objects with customized per-channel visibility are restricted by channel permissions.
 If a user with restricted channel access fetches per-channel objects, only objects from accessible channels will be returned.
-You can read more about channel permissions [here](docs/developer/permissions.mdx).
+You can read more about channel permissions [here](developer/permissions.mdx).
 
 ## Getting channel details
 
-Use [`channel`](docs/api-reference/channels/queries/channel.mdx) query to get channel details.
+Use [`channel`](api-reference/channels/queries/channel.mdx) query to get channel details.
 
 Channel query requires channel ID, but from Saleor 3.6 it can be executed with channel slug too.
 
@@ -115,7 +115,7 @@ Response:
 
 ## Creating a new channel
 
-You can create a new channel using [`channelCreate`](docs/api-reference/channels/mutations/channel-create.mdx) mutation.
+You can create a new channel using [`channelCreate`](api-reference/channels/mutations/channel-create.mdx) mutation.
 During checkout creation, you can define the allocation strategy. Right now the
 two possible options are available: `PRIORITIZE_HIGH_STOCK` and `PRIORITIZE_SORTING_ORDER`,
 the `PRIORITIZE_SORTING_ORDER` strategy is used as default.
@@ -185,7 +185,7 @@ Response:
 
 ### Channel list
 
-Because some of the channels may be considered non-public (for example - a channel for business partners), non-staff users cannot use the [`channels`](docs/api-reference/channels/queries/channels.mdx) query.
+Because some of the channels may be considered non-public (for example - a channel for business partners), non-staff users cannot use the [`channels`](api-reference/channels/queries/channels.mdx) query.
 
 Request:
 
@@ -216,7 +216,7 @@ Response:
 
 ### Activate / Deactivate channel
 
-If you want to make the channel unavailable for customers, you can change it's status to `deactivated` using [`channelDeactivate`](docs/api-reference/channels/mutations/channel-deactivate.mdx) mutation:
+If you want to make the channel unavailable for customers, you can change it's status to `deactivated` using [`channelDeactivate`](api-reference/channels/mutations/channel-deactivate.mdx) mutation:
 
 ```graphql
 mutation {
@@ -248,7 +248,7 @@ Response:
 }
 ```
 
-And to reverse the previous operation use the [`channelActivate`](docs/api-reference/channels/mutations/channel-activate.mdx) mutation:
+And to reverse the previous operation use the [`channelActivate`](api-reference/channels/mutations/channel-activate.mdx) mutation:
 
 ```graphql
 mutation {
@@ -388,7 +388,7 @@ Channels can be removed only when:
 - There are no orders created in them.
 - If there are orders created, `targetChannel` is required. Its currency has to be the same as the channel you are about to delete. All orders will be moved to `targetChannel`.
 
-[`channelDelete`](docs/api-reference/channels/mutations/channel-delete.mdx) mutation takes [input](docs/api-reference/channels/inputs/channel-delete-input.mdx):
+[`channelDelete`](api-reference/channels/mutations/channel-delete.mdx) mutation takes [input](api-reference/channels/inputs/channel-delete-input.mdx):
 
 - `id`: ID of the Channel that will be deleted
 - `channelId`: all existing orders will be moved into this channel
@@ -425,7 +425,7 @@ enum ChannelErrorCode {
 }
 ```
 
-[`ChannelErrorCode`](docs/api-reference/channels/enums/channel-error-code.mdx) values:
+[`ChannelErrorCode`](api-reference/channels/enums/channel-error-code.mdx) values:
 
 - `ALREADY_EXISTS`: Object already exists in the database
 - `GRAPHQL_ERROR`: Wrong query

--- a/versioned_docs/version-3.x/developer/checkout/address.mdx
+++ b/versioned_docs/version-3.x/developer/checkout/address.mdx
@@ -4,7 +4,7 @@ title: Shipping and Billing
 
 ## Shipping
 
-This step is only used if purchased items require shipping (if they are physical products). The user must select a specific shipping method to create shipping for this checkout. To signify whether shipping is required, use the `isShippingRequired` field in the [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object.
+This step is only used if purchased items require shipping (if they are physical products). The user must select a specific shipping method to create shipping for this checkout. To signify whether shipping is required, use the `isShippingRequired` field in the [`Checkout`](api-reference/checkout/objects/checkout.mdx) object.
 
 ```mermaid
 sequenceDiagram
@@ -27,7 +27,7 @@ sequenceDiagram
 
 ### Adding address data
 
-Address can be assigned using the [`checkoutShippingAddressUpdate`](docs/api-reference/checkout/mutations/checkout-shipping-address-update.mdx) mutation:
+Address can be assigned using the [`checkoutShippingAddressUpdate`](api-reference/checkout/mutations/checkout-shipping-address-update.mdx) mutation:
 
 ```graphql
 mutation {
@@ -85,7 +85,7 @@ More information about address validation can be found on the [address validatio
 
 #### Default address
 
-Customers with accounts can set up default addresses, which will be attached automatically during the checkout creation. More information on API reference page for [accountSetDefaultAddress](docs/api-reference/users/mutations/account-set-default-address.mdx).
+Customers with accounts can set up default addresses, which will be attached automatically during the checkout creation. More information on API reference page for [accountSetDefaultAddress](api-reference/users/mutations/account-set-default-address.mdx).
 
 ### Listing available shipping methods
 
@@ -159,12 +159,12 @@ Response:
 
 ### Selecting the delivery method
 
-Use the [`checkoutDeliveryMethodUpdate`](docs/api-reference/checkout/mutations/checkout-delivery-method-update.mdx) mutation to effectively pair the specific [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object with the specified delivery method selected by the user.
+Use the [`checkoutDeliveryMethodUpdate`](api-reference/checkout/mutations/checkout-delivery-method-update.mdx) mutation to effectively pair the specific [`Checkout`](api-reference/checkout/objects/checkout.mdx) object with the specified delivery method selected by the user.
 
 This operation requires the following input:
 
-- `id`: the checkout ID (the `id` field of the [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object).
-- `deliveryMethodId`: the shipping method ID or Warehouse ID (from the `shippingMethods` or `availableCollectionPoints` field of the [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object).
+- `id`: the checkout ID (the `id` field of the [`Checkout`](api-reference/checkout/objects/checkout.mdx) object).
+- `deliveryMethodId`: the shipping method ID or Warehouse ID (from the `shippingMethods` or `availableCollectionPoints` field of the [`Checkout`](api-reference/checkout/objects/checkout.mdx) object).
 
 In the following mutation, we assign a delivery method to the checkout using IDs from the previous example. Note that for the checkout object, we want to get back the update `totalPrice` including shipping costs:
 
@@ -231,7 +231,7 @@ As a result, we get an updated checkout object with a delivery method set:
 
 The checkout's mutations that accept an address as an input have a field that can turn off the address validation. It allows assigning a partial or not fully valid address to the checkout. Providing country code is mandatory for all addresses regardless of the rules provided in this input.
 
-The address [validation](docs/api-reference/checkout/inputs/checkout-address-validation-rules.mdx) input has two boolean fields:
+The address [validation](api-reference/checkout/inputs/checkout-address-validation-rules.mdx) input has two boolean fields:
 
 - `checkRequiredFields` - signals Saleor to raise an error when the provided address doesn't have all the required fields. Set to `true` by default.
 - `checkFieldsFormat` - signals Saleor to raise an error when the provided address doesn't match the expected format. Set to `true` by default.
@@ -239,9 +239,9 @@ The address [validation](docs/api-reference/checkout/inputs/checkout-address-val
 
 #### checkoutCreate
 
-The [`checkoutCreate`](docs/api-reference/checkout/mutations/checkout-create.mdx) mutation has an optional input for providing shipping and billing addresses. If you want to provide only a part of the address, you can disable the address validation.
+The [`checkoutCreate`](api-reference/checkout/mutations/checkout-create.mdx) mutation has an optional input for providing shipping and billing addresses. If you want to provide only a part of the address, you can disable the address validation.
 
-The mutation accepts [validationRules](docs/api-reference/checkout/inputs/checkout-validation-rules.mdx) as an [input](docs/api-reference/checkout/inputs/checkout-create-input.mdx) field.
+The mutation accepts [validationRules](api-reference/checkout/inputs/checkout-validation-rules.mdx) as an [input](api-reference/checkout/inputs/checkout-create-input.mdx) field.
 
 ```graphql
 mutation {
@@ -286,7 +286,7 @@ The response contains the created checkout object:
 
 #### CheckoutShippingAddressUpdate
 
-The [`checkoutShippingAddressUpdate`](docs/api-reference/checkout/mutations/checkout-shipping-address-update.mdx) mutation has an optional field for controlling the shipping address validation: [validationRules](docs/api-reference/checkout/inputs/checkout-address-validation-rules.mdx).
+The [`checkoutShippingAddressUpdate`](api-reference/checkout/mutations/checkout-shipping-address-update.mdx) mutation has an optional field for controlling the shipping address validation: [validationRules](api-reference/checkout/inputs/checkout-address-validation-rules.mdx).
 
 ```graphql
 mutation {
@@ -342,7 +342,7 @@ The response contains the updated checkout object:
 
 #### CheckoutBillingAddressUpdate
 
-The [`checkoutBillingAddressUpdate`](docs/api-reference/checkout/mutations/checkout-billing-address-update.mdx) mutation has an optional field for controlling the billing address validation: [validationRules](docs/api-reference/checkout/inputs/checkout-address-validation-rules.mdx).
+The [`checkoutBillingAddressUpdate`](api-reference/checkout/mutations/checkout-billing-address-update.mdx) mutation has an optional field for controlling the billing address validation: [validationRules](api-reference/checkout/inputs/checkout-address-validation-rules.mdx).
 
 ```graphql
 mutation {
@@ -397,9 +397,9 @@ The information about address validation can be found on the [address validation
 :::
 
 :::note
-The shipping and billing addresses need to be valid when finalizing checkout by calling [checkoutComplete](docs/api-reference/checkout/mutations/checkout-complete.mdx) mutation.
+The shipping and billing addresses need to be valid when finalizing checkout by calling [checkoutComplete](api-reference/checkout/mutations/checkout-complete.mdx) mutation.
 :::
 
 :::note
-The fields for shipping and billing addresses will be normalized (if needed) on completing the checkout by calling [checkoutComplete](docs/api-reference/checkout/mutations/checkout-complete.mdx) mutation.
+The fields for shipping and billing addresses will be normalized (if needed) on completing the checkout by calling [checkoutComplete](api-reference/checkout/mutations/checkout-complete.mdx) mutation.
 :::

--- a/versioned_docs/version-3.x/developer/checkout/finalizing.mdx
+++ b/versioned_docs/version-3.x/developer/checkout/finalizing.mdx
@@ -8,7 +8,7 @@ The payment flow uses the Saleor's payment gateway or payment synchronous webhoo
 
 ### Payment
 
-Depending on the selected payment gateway, you will use the payment provider's form, which can be integrated with Saleor or be redirected to an external payment page. The payment gateway returns information if the payment is successful, along with tokenized credit card payment information. This token is then used to run the [`checkoutPaymentCreate`](docs/api-reference/checkout/mutations/checkout-payment-create.mdx) mutation.
+Depending on the selected payment gateway, you will use the payment provider's form, which can be integrated with Saleor or be redirected to an external payment page. The payment gateway returns information if the payment is successful, along with tokenized credit card payment information. This token is then used to run the [`checkoutPaymentCreate`](api-reference/checkout/mutations/checkout-payment-create.mdx) mutation.
 
 ```mermaid
 sequenceDiagram
@@ -76,16 +76,16 @@ Response:
 
 #### Creating payment
 
-The [`checkoutPaymentCreate`](docs/api-reference/checkout/mutations/checkout-payment-create.mdx) mutation takes the following arguments:
+The [`checkoutPaymentCreate`](api-reference/checkout/mutations/checkout-payment-create.mdx) mutation takes the following arguments:
 
 - `id`: the checkout id (if required by a payment gateway).
-- `input`: [PaymentInput](docs/api-reference/payments/inputs/payment-input.mdx) object:
+- `input`: [PaymentInput](api-reference/payments/inputs/payment-input.mdx) object:
   - `gateway`: the ID of the selected payment gateway (a list of the available payment gateways can be fetched from the `Checkout.availablePaymentGateways` field). The selected gateway must support the checkout currency.
   - `token`: a client-side generated payment token (if required).
   - `amount`: the total amount of this operation.
   - `returnUrl`: URL of a storefront view where the user should be redirected after requiring additional actions. Payment with additional actions will not be finished if this field is not provided.
-  - `storePaymentMethod`: the type of payment storage in a gateway. [StorePaymentMethod](docs/api-reference/payments/enums/store-payment-method-enum.mdx) value. If not provided, defaults to `NONE` (added in Saleor 3.1).
-  - `metadata`: a list of [MetadataInput](docs/api-reference/miscellaneous/inputs/metadata-input.mdx) (added in Saleor 3.1).
+  - `storePaymentMethod`: the type of payment storage in a gateway. [StorePaymentMethod](api-reference/payments/enums/store-payment-method-enum.mdx) value. If not provided, defaults to `NONE` (added in Saleor 3.1).
+  - `metadata`: a list of [MetadataInput](api-reference/miscellaneous/inputs/metadata-input.mdx) (added in Saleor 3.1).
 
 This mutation returns the following fields:
 
@@ -169,7 +169,7 @@ sequenceDiagram
   Saleor -->>- Client: order data
 ```
 
-The [`checkoutComplete`](docs/api-reference/checkout/mutations/checkout-complete.mdx) mutation requires the following input:
+The [`checkoutComplete`](api-reference/checkout/mutations/checkout-complete.mdx) mutation requires the following input:
 
 - `id`: the ID of the checkout to complete.
 - `redirectUrl`: URL of a view where users should be redirected to see the order details. URL in RFC 1808 format.
@@ -217,7 +217,7 @@ A successful response would look like this:
 }
 ```
 
-Here is an example of the [`checkoutComplete`](docs/api-reference/checkout/mutations/checkout-complete.mdx) mutation where the payment gateway requires additional data to finalize the payment using the Adyen payment gateway:
+Here is an example of the [`checkoutComplete`](api-reference/checkout/mutations/checkout-complete.mdx) mutation where the payment gateway requires additional data to finalize the payment using the Adyen payment gateway:
 
 ```graphql {2-5}
 mutation{
@@ -527,12 +527,12 @@ sequenceDiagram
     Checkout App-->>-Customer: Order
 ```
 
-The [orderCreateFromCheckout](docs/api-reference/orders/mutations/order-create-from-checkout.mdx) mutation takes the following arguments:
+The [orderCreateFromCheckout](api-reference/orders/mutations/order-create-from-checkout.mdx) mutation takes the following arguments:
 
 - `id`: The ID of the checkout that should be used to create a new order.
 - `removeCheckout`: Determines if checkout should be removed after creating an order. Default `true`.
 
-The following example shows how the [orderCreateFromCheckout](docs/api-reference/orders/mutations/order-create-from-checkout.mdx) mutation creates a new order and removes the checkout.
+The following example shows how the [orderCreateFromCheckout](api-reference/orders/mutations/order-create-from-checkout.mdx) mutation creates a new order and removes the checkout.
 
 ```graphql
 mutation {
@@ -570,4 +570,4 @@ As a result, we get an order object:
 #### Managing payments
 
 Saleor uses transaction flow to manage the payments attached to the checkout by Saleor apps.
-You can find more details about it [here](docs/developer/payments.mdx#processing-a-payment-with-checkout-app).
+You can find more details about it [here](developer/payments.mdx#processing-a-payment-with-checkout-app).

--- a/versioned_docs/version-3.x/developer/checkout/lines.mdx
+++ b/versioned_docs/version-3.x/developer/checkout/lines.mdx
@@ -4,7 +4,7 @@ title: Managing products
 
 ### Adding a line to checkout
 
-To add an item to the cart, use [`checkoutLinesAdd`](docs/api-reference/checkout/mutations/checkout-lines-add.mdx). Total prices will be updated automatically:
+To add an item to the cart, use [`checkoutLinesAdd`](api-reference/checkout/mutations/checkout-lines-add.mdx). Total prices will be updated automatically:
 
 ```graphql {4}
 mutation {
@@ -75,11 +75,11 @@ feedback. However, it is still undergoing development and is subject to modifica
 The creation of multiple lines with the same variant is possible upon using the `forceNewLine` flag.
 The `forceNewLine` can be used in the:
 
-[CheckoutLineInput](docs/api-reference/checkout/inputs/checkout-line-input.mdx)
+[CheckoutLineInput](api-reference/checkout/inputs/checkout-line-input.mdx)
 in the following mutations:
 
-- [checkoutCreate](docs/api-reference/checkout/mutations/checkout-create.mdx)
-- [checkoutLinesAdd](docs/api-reference/checkout/mutations/checkout-lines-add.mdx)
+- [checkoutCreate](api-reference/checkout/mutations/checkout-create.mdx)
+- [checkoutLinesAdd](api-reference/checkout/mutations/checkout-lines-add.mdx)
 
 ```graphql {5}
 mutation {
@@ -208,16 +208,16 @@ If the variant is already added to the checkout and exists in more than one line
 
 ### Updating a line
 
-To modify a line, use [checkoutLinesUpdate](docs/api-reference/checkout/mutations/checkout-lines-update.mdx).
+To modify a line, use [checkoutLinesUpdate](api-reference/checkout/mutations/checkout-lines-update.mdx).
 
-Currently, [CheckoutLineUpdateInput](docs/api-reference/checkout/inputs/checkout-line-update-input.mdx) supports `variantId` and `lineId` parameters to operate on the selected line object.
-The version `3.6` featured [adding the same product to multiple lines](docs/developer/checkout/lines.mdx#adding-the-same-product-to-multiple-lines). Since then, we recommend using the `lineId` parameter, as `variantId` will be deprecated in the future.
+Currently, [CheckoutLineUpdateInput](api-reference/checkout/inputs/checkout-line-update-input.mdx) supports `variantId` and `lineId` parameters to operate on the selected line object.
+The version `3.6` featured [adding the same product to multiple lines](developer/checkout/lines.mdx#adding-the-same-product-to-multiple-lines). Since then, we recommend using the `lineId` parameter, as `variantId` will be deprecated in the future.
 
 :::caution
 
 Is not allowed to use `variantId` and `lineId` in the same line input.
 
-If the `variantId` parameter is used in line input and the variant exists in multiple lines, [checkoutLinesUpdate](docs/api-reference/checkout/mutations/checkout-lines-update.mdx) will return an error. In that case, you are required to use `lineId`.
+If the `variantId` parameter is used in line input and the variant exists in multiple lines, [checkoutLinesUpdate](api-reference/checkout/mutations/checkout-lines-update.mdx) will return an error. In that case, you are required to use `lineId`.
 
 :::
 
@@ -271,7 +271,7 @@ If the quantity is changed to 0, API will remove this line from checkout.
 
 ### Removing line from checkout
 
-Running the [checkoutLineDelete](docs/api-reference/checkout/mutations/checkout-line-delete.mdx) mutation will remove the whole line, no matter the quantity:
+Running the [checkoutLineDelete](api-reference/checkout/mutations/checkout-line-delete.mdx) mutation will remove the whole line, no matter the quantity:
 
 ```graphql
 mutation {
@@ -320,13 +320,13 @@ This feature is only available for apps with `HANDLE_CHECKOUTS` permission.
 :::
 
 The custom price can be set with the use of field `price` in the
-[CheckoutLineInput](docs/api-reference/checkout/inputs/checkout-line-input.mdx)
+[CheckoutLineInput](api-reference/checkout/inputs/checkout-line-input.mdx)
 in the following mutations:
 
-- [checkoutCreate](docs/api-reference/checkout/mutations/checkout-create.mdx),
-- [checkoutLinesAdd](docs/api-reference/checkout/mutations/checkout-lines-add.mdx) - when adding
+- [checkoutCreate](api-reference/checkout/mutations/checkout-create.mdx),
+- [checkoutLinesAdd](api-reference/checkout/mutations/checkout-lines-add.mdx) - when adding
   a variant that already exists in the checkout, the corresponding line gets overridden - the quantity is incremented and the price is updated.
-- [checkoutLinesUpdate](docs/api-reference/checkout/mutations/checkout-lines-update.mdx) - overrides
+- [checkoutLinesUpdate](api-reference/checkout/mutations/checkout-lines-update.mdx) - overrides
   the existing line with the price provided in the mutation.
 
 The following example shows how to set a custom price with the use of `checkoutLinesAdd` mutation:

--- a/versioned_docs/version-3.x/developer/checkout/order-to-checkout.mdx
+++ b/versioned_docs/version-3.x/developer/checkout/order-to-checkout.mdx
@@ -17,23 +17,23 @@ feedback. However, it is still undergoing development and is subject to modifica
 
 Saleor allows you to create a checkout from existing orders. This feature can be used when implementing the reordering functionality.
 
-The [checkoutCreateFromOrder](docs/api-reference/checkout/mutations/checkout-create-from-order.mdx) mutation accepts the `Order`
-[ID](docs/api-reference/checkout/mutations/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbidbcodeid--)
-as input and returns the new [checkout](docs/api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbcheckoutbcodecheckout-),
+The [checkoutCreateFromOrder](api-reference/checkout/mutations/checkout-create-from-order.mdx) mutation accepts the `Order`
+[ID](api-reference/checkout/mutations/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbidbcodeid--)
+as input and returns the new [checkout](api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbcheckoutbcodecheckout-),
 with the lines from the order attached to it. Lines that are not available (variants deleted, products deleted, variants not published, out of stock, etc.) are returned as
-[unavailableVariants](docs/api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbunavailablevariantsbcodecheckoutcreatefromorderunavailablevariant--).
+[unavailableVariants](api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbunavailablevariantsbcodecheckoutcreatefromorderunavailablevariant--).
 Any discounts or custom prices attached to the order will not be carried over to the newly created checkout. The price of each checkout line will be based on the current price of the variant.
 
-[UnavailableVariants](docs/api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbunavailablevariantsbcodecheckoutcreatefromorderunavailablevariant--)
+[UnavailableVariants](api-reference/checkout/objects/checkout-create-from-order.mdx#code-style-fontweight-normal-checkoutcreatefromorderbunavailablevariantsbcodecheckoutcreatefromorderunavailablevariant--)
 is a list of variants that could not be attached to the checkout.
-Each [item](docs/api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx) has:
+Each [item](api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx) has:
 
-- [code](docs/api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbcodebcodecheckoutcreatefromorderunavailablevarianterrorcode--) that describes why Saleor could not add it to the checkout.
-- [variantId](docs/api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbvariantidbcodeid--) that contains the ID of the unavailable variant.
-- [lineId](docs/api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantblineidbcodeid--) that contains the ID of the related `orderLine`.
-- [message](docs/api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbmessagebcodestring--) the error message.
+- [code](api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbcodebcodecheckoutcreatefromorderunavailablevarianterrorcode--) that describes why Saleor could not add it to the checkout.
+- [variantId](api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbvariantidbcodeid--) that contains the ID of the unavailable variant.
+- [lineId](api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantblineidbcodeid--) that contains the ID of the related `orderLine`.
+- [message](api-reference/checkout/objects/checkout-create-from-order-unavailable-variant.mdx#code-style-fontweight-normal-checkoutcreatefromorderunavailablevariantbmessagebcodestring--) the error message.
 
-The following example shows how the [checkoutCreateFromOrder](docs/api-reference/checkout/mutations/checkout-create-from-order.mdx) mutation creates a new checkout:
+The following example shows how the [checkoutCreateFromOrder](api-reference/checkout/mutations/checkout-create-from-order.mdx) mutation creates a new checkout:
 
 ```graphql
 mutation CheckoutCreateFromOrder {

--- a/versioned_docs/version-3.x/developer/checkout/overview.mdx
+++ b/versioned_docs/version-3.x/developer/checkout/overview.mdx
@@ -43,19 +43,19 @@ If the user is assigned the checkout permission, only this user and staff users 
 ## Creating a checkout session
 
 :::note
-A [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object can be created for logged-in users and for anonymous (guest) users.
+A [`Checkout`](api-reference/checkout/objects/checkout.mdx) object can be created for logged-in users and for anonymous (guest) users.
 :::
 
-- If you use the [`checkoutCreate`](docs/api-reference/checkout/mutations/checkout-create.mdx) mutation including the authentication token, this checkout is assigned to the user who is authenticated by this token. For more information on how to authenticate with our API, see the [Authentication](docs/api-usage/authentication.mdx) topic.
+- If you use the [`checkoutCreate`](api-reference/checkout/mutations/checkout-create.mdx) mutation including the authentication token, this checkout is assigned to the user who is authenticated by this token. For more information on how to authenticate with our API, see the [Authentication](api-usage/authentication.mdx) topic.
 
 - If no authentication token is provided, the checkout is created for an anonymous user,
-  and an email address is used to identify such a [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object,
+  and an email address is used to identify such a [`Checkout`](api-reference/checkout/objects/checkout.mdx) object,
   linking it with the anonymous user.
   User email is not required at this stage but must be provided before adding a promo code, creating a payment, and completing checkout.
 
-To create a [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object, use the [`checkoutCreate`](docs/api-reference/checkout/mutations/checkout-create.mdx) mutation.
+To create a [`Checkout`](api-reference/checkout/objects/checkout.mdx) object, use the [`checkoutCreate`](api-reference/checkout/mutations/checkout-create.mdx) mutation.
 
-This mutation takes the following [input](docs/api-reference/checkout/inputs/checkout-create-input.mdx):
+This mutation takes the following [input](api-reference/checkout/inputs/checkout-create-input.mdx):
 
 - `channel`: Slug of a channel in which to create checkout.
 - `email`: the user's email address.
@@ -64,7 +64,7 @@ This mutation takes the following [input](docs/api-reference/checkout/inputs/che
 - `lines`: a list of checkout lines, each checkout line contains a product variant ID and its quantity.
 - `validationRules`: the checkout validation rules that can be changed.
 
-The resulting [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object contains the following fields:
+The resulting [`Checkout`](api-reference/checkout/objects/checkout.mdx) object contains the following fields:
 
 - `id`: a unique checkout ID.
 - `totalPrice`: the total price of the checkout lines and shipping costs.
@@ -78,7 +78,7 @@ In addition, the following fields are available in the mutation results:
 - `created`: a boolean flag indicating whether a new checkout object was created, or an existing one was used.
 - `errors`: a list of errors that occurred during mutation execution.
 
-The following example shows how the [`checkoutCreate`](docs/api-reference/checkout/mutations/checkout-create.mdx) mutation creates the [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object and returns the checkout information:
+The following example shows how the [`checkoutCreate`](api-reference/checkout/mutations/checkout-create.mdx) mutation creates the [`Checkout`](api-reference/checkout/objects/checkout.mdx) object and returns the checkout information:
 
 ```graphql {2-25}
 mutation {
@@ -211,11 +211,11 @@ We get a newly created checkout object for which we return the ID, total price, 
 ## Checkout email
 
 When anonymous checkout without user email has been created, the email must be set before creating payment and completing checkout.
-Use the [`CheckoutEmailUpdate`](docs/api-reference/checkout/mutations/checkout-email-update.mdx) mutation to update checkout `email`.
+Use the [`CheckoutEmailUpdate`](api-reference/checkout/mutations/checkout-email-update.mdx) mutation to update checkout `email`.
 
 The operation requires the following inputs:
 
-- `id`: the checkout ID (the `id` field of the [`Checkout`](docs/api-reference/checkout/objects/checkout.mdx) object),
+- `id`: the checkout ID (the `id` field of the [`Checkout`](api-reference/checkout/objects/checkout.mdx) object),
 - `email`: the user email.
 
 ```graphql {2-4}

--- a/versioned_docs/version-3.x/developer/community/contributing.mdx
+++ b/versioned_docs/version-3.x/developer/community/contributing.mdx
@@ -265,7 +265,7 @@ Use relative imports.
 ### Migrations
 
 Try to combine multiple migrations into one, but remember not to mix changes on the database with updating rows in migrations. In other words, operations that alter tables and use `RunPython` to run methods on existing data should be in separate files.
-From Saleor version 3.13 forward follow [zero-downtime policy](docs/developer/community/zero-downtime-migrations.mdx) when writing migrations.
+From Saleor version 3.13 forward follow [zero-downtime policy](developer/community/zero-downtime-migrations.mdx) when writing migrations.
 
 ### Handling migrations between versions
 

--- a/versioned_docs/version-3.x/developer/community/zero-downtime-migrations.mdx
+++ b/versioned_docs/version-3.x/developer/community/zero-downtime-migrations.mdx
@@ -2,7 +2,7 @@
 title: Zero downtime migrations
 ---
 
-Following page contains information about writing zero-downtime migrations. If you are interested in section about upgrading Saleor, please visit [upgrading guide](docs/setup/upgrading.mdx).
+Following page contains information about writing zero-downtime migrations. If you are interested in section about upgrading Saleor, please visit [upgrading guide](setup/upgrading.mdx).
 
 ## The problem
 

--- a/versioned_docs/version-3.x/developer/discounts.mdx
+++ b/versioned_docs/version-3.x/developer/discounts.mdx
@@ -138,7 +138,7 @@ If the voucher specifies certain products, the discount will be applied only to
 the cheapest item included in the discount. If the voucher applies to all products,
 the discount will be applied only to the cheapest item overall.
 
-To apply the voucher on checkout use [checkoutAddPromoCode](docs/api-reference/checkout/mutations/checkout-add-promo-code.mdx)
+To apply the voucher on checkout use [checkoutAddPromoCode](api-reference/checkout/mutations/checkout-add-promo-code.mdx)
 mutation. The discount will be visible both in the line prices and in the `checkout.discount` field. Let's see the examples.
 
 ### Applying the entire order voucher
@@ -823,7 +823,7 @@ will be visible on the order and order line prices. Additionally, the sum of vou
 discounts will be reflected in the `order.discounts` field. This behavior is consistent
 across all voucher types.
 
-The following example shows the response from the [checkoutComplete](docs/api-reference/checkout/mutations/checkout-complete.mdx)
+The following example shows the response from the [checkoutComplete](api-reference/checkout/mutations/checkout-complete.mdx)
 mutation for a checkout that includes **two items** of the same variant with a **10% voucher discount** applied.
 
 ```json {42,57-75}

--- a/versioned_docs/version-3.x/developer/extending/apollo-federation.mdx
+++ b/versioned_docs/version-3.x/developer/extending/apollo-federation.mdx
@@ -6,7 +6,7 @@ title: Apollo Federation
 
 ## Federation support in Saleor
 
-Saleor supports Apollo Federation. Types that can be used in federated relations are part of the [`_Entity` union](docs/api-reference/miscellaneous/unions/entity.mdx).
+Saleor supports Apollo Federation. Types that can be used in federated relations are part of the [`_Entity` union](api-reference/miscellaneous/unions/entity.mdx).
 
 Most types in the schema use their ID attribute as a key, but the `User` type supports both `id` and `email` while `Product`, `ProductVariant`, and `Collection` use composite keys made of `id` and `channel` slug:
 

--- a/versioned_docs/version-3.x/developer/extending/apps/developing-apps/app-sdk/api-handlers.md
+++ b/versioned_docs/version-3.x/developer/extending/apps/developing-apps/app-sdk/api-handlers.md
@@ -8,8 +8,8 @@ Currently, Saleor heavily relies on Next.js, but other platforms will be support
 
 Saleor requires two endpoints to be available for a standalone app:
 
-- Manifest endpoint - Returns JSON object with app properties, like its name or permissions. [Read more](docs/developer/extending/apps/architecture/manifest.mdx)
-- Register endpoint - During installation, Saleor sends a `POST` request with auth token to this endpoint. [Read more](docs/developer/extending/apps/installing-apps.mdx#installation-using-graphql-api)
+- Manifest endpoint - Returns JSON object with app properties, like its name or permissions. [Read more](developer/extending/apps/architecture/manifest.mdx)
+- Register endpoint - During installation, Saleor sends a `POST` request with auth token to this endpoint. [Read more](developer/extending/apps/installing-apps.mdx#installation-using-graphql-api)
 
 ## Built-in API handlers
 

--- a/versioned_docs/version-3.x/developer/extending/apps/developing-apps/app-sdk/saleor-webhook.md
+++ b/versioned_docs/version-3.x/developer/extending/apps/developing-apps/app-sdk/saleor-webhook.md
@@ -236,13 +236,13 @@ export const orderCalculateTaxesWebhook = new SaleorAsyncWebhook<Payload>({
 
 ### Resources
 
-- Check available events [here](docs/developer/extending/webhooks/asynchronous-events.mdx#available-webhook-events)
+- Check available events [here](developer/extending/webhooks/asynchronous-events.mdx#available-webhook-events)
 - [Read more about APLs](./apl.md)
-- [Subscription query documentation](docs/developer/extending/webhooks/subscription-webhook-payloads.mdx)
+- [Subscription query documentation](developer/extending/webhooks/subscription-webhook-payloads.mdx)
 
 ### Extending app manifest
 
-Webhooks are created in Saleor when the App is installed. Saleor uses [AppManifest](docs/developer/extending/apps/architecture/manifest.mdx) to get information about webhooks to create.  
+Webhooks are created in Saleor when the App is installed. Saleor uses [AppManifest](developer/extending/apps/architecture/manifest.mdx) to get information about webhooks to create.
 `SaleorSyncWebhook` & `SaleorAsyncWebhook` utility can generate this manifest:
 
 ```typescript

--- a/versioned_docs/version-3.x/developer/extending/apps/developing-apps/app-sdk/settings-manager.md
+++ b/versioned_docs/version-3.x/developer/extending/apps/developing-apps/app-sdk/settings-manager.md
@@ -39,7 +39,7 @@ For values that should not be migrated during environment cloning (as private ke
 
 # MetadataManager
 
-Default manager used by the [App Template](docs/developer/extending/apps/developing-apps/app-template.mdx). Uses the app metadata as storage. Since the app developer can use any GraphQL client, the constructor must be parametrized with fetch and mutate functions:
+Default manager used by the [App Template](developer/extending/apps/developing-apps/app-template.mdx). Uses the app metadata as storage. Since the app developer can use any GraphQL client, the constructor must be parametrized with fetch and mutate functions:
 
 ```ts
 import { MetadataEntry } from "@saleor/app-sdk/settings-manager";

--- a/versioned_docs/version-3.x/developer/extending/apps/developing-apps/apps-patterns/persistence-with-metadata-manager.mdx
+++ b/versioned_docs/version-3.x/developer/extending/apps/developing-apps/apps-patterns/persistence-with-metadata-manager.mdx
@@ -16,7 +16,7 @@ A solution built-in in Saleor is [`privateMetadata`](developer/metadata.mdx).
 
 ## What is Metadata and what are its features
 
-Apps are one of the classes implementing [ObjectWithMetadata](docs/api-reference/miscellaneous/interfaces/object-with-metadata.mdx) interface, which can be used to store additional data in the Saleor database.
+Apps are one of the classes implementing [ObjectWithMetadata](api-reference/miscellaneous/interfaces/object-with-metadata.mdx) interface, which can be used to store additional data in the Saleor database.
 
 `privateMetadata` field in the `app` object can be accessed only by the app itself or the users with `MANAGE_APPS` permission. The field returns a list of key and value pairs that can contain any string, including stringified JSON.
 
@@ -98,7 +98,7 @@ Entries in the manager are stored using the structure:
 ```
 
 :::note Optional `domain` field
-Since metadata will be copied if you clone the database of your Saleor instance, we recommend adding the parameter `domain` to prevent misusing secret keys from different domains.  
+Since metadata will be copied if you clone the database of your Saleor instance, we recommend adding the parameter `domain` to prevent misusing secret keys from different domains.
 :::
 
 Interacting with the API is done with the methods:

--- a/versioned_docs/version-3.x/developer/gift-cards.mdx
+++ b/versioned_docs/version-3.x/developer/gift-cards.mdx
@@ -435,12 +435,12 @@ And we get an active gift card with a new `ACTIVATED` event:
 }
 ```
 
-For bulk activation, use [giftCardBulkActivate](docs/api-reference/gift-cards/mutations/gift-card-bulk-activate.mdx)
-and for bulk deactivation use [giftCardBulkDeactivate](docs/api-reference/gift-cards/mutations/gift-card-bulk-deactivate.mdx) mutation.
+For bulk activation, use [giftCardBulkActivate](api-reference/gift-cards/mutations/gift-card-bulk-activate.mdx)
+and for bulk deactivation use [giftCardBulkDeactivate](api-reference/gift-cards/mutations/gift-card-bulk-deactivate.mdx) mutation.
 
 ## Creating gift card products
 
-To allow customers to purchase gift cards, you have to [create a product type](docs/api-reference/products/mutations/product-type-create.mdx) with `GIFT_CARD` kind and use it to [create a product](docs/api-reference/products/mutations/product-create.mdx).
+To allow customers to purchase gift cards, you have to [create a product type](api-reference/products/mutations/product-type-create.mdx) with `GIFT_CARD` kind and use it to [create a product](api-reference/products/mutations/product-create.mdx).
 
 :::note
 If you want to have an unlimited number of gift cards in your shop you should create a stock in a chosen channel with at least one quantity and unset track inventory flag.
@@ -451,12 +451,12 @@ If you want to have an unlimited number of gift cards in your shop you should cr
 The `automaticallyFulfillNonShippableGiftCard` order setting defines when the bought gift cards will be created. If this flag is set to `True`, a gift card will be created during checkout completion.
 The fulfillment will be created automatically, and a gift card will be generated and sent to the customer.
 If this option is unset, the gift card will be created during order fulfillment and, after that, also sent to the customer.
-The value of this option can be changed with use of [orderSettingsUpdate](docs/api-reference/orders/mutations/order-settings-update.mdx) mutation.
+The value of this option can be changed with use of [orderSettingsUpdate](api-reference/orders/mutations/order-settings-update.mdx) mutation.
 
 The created gift card expiry date is set based on gift card settings.
 Gift card settings can be set never to expire or set to an expiry period, based on which the card expiry date is calculated.
 
-The gift card settings are set as never expiry by default and can be changed with use of [giftCardSettingsUpdate](docs/api-reference/gift-cards/mutations/gift-card-settings-update.mdx).
+The gift card settings are set as never expiry by default and can be changed with use of [giftCardSettingsUpdate](api-reference/gift-cards/mutations/gift-card-settings-update.mdx).
 In the following example, the gif card settings are set to 12 months.
 
 ```graphql {2-7}
@@ -498,7 +498,7 @@ As a result, we get the expiry settings updated.
 
 ## Using gift card in checkout
 
-To use a gift card in the checkout just run [checkoutAddPromoCode](docs/api-reference/checkout/mutations/checkout-add-promo-code.mdx)
+To use a gift card in the checkout just run [checkoutAddPromoCode](api-reference/checkout/mutations/checkout-add-promo-code.mdx)
 mutation with the gift card code.
 When the gift card is used for the first time, it will be assigned to the checkout user.
 If the card was already used, the checkout user will be compared with the gift card user. When the users differ, a validation error is raised.

--- a/versioned_docs/version-3.x/developer/payments.mdx
+++ b/versioned_docs/version-3.x/developer/payments.mdx
@@ -10,20 +10,20 @@ deliver a base reference for the user to work with.
 
 Saleor distinguishes two different approaches to processing a payment:
 
-- By using a [Saleor App](docs/developer/extending/apps/overview.mdx).
-- By using a [plugin](docs/developer/extending/plugins/overview.mdx) embedded in the Saleor code.
+- By using a [Saleor App](developer/extending/apps/overview.mdx).
+- By using a [plugin](developer/extending/plugins/overview.mdx) embedded in the Saleor code.
 
 ## Saleor App
 
 Saleor offers two ways to process payments using the Saleor app:
 
-- [Saleor payment app](docs/developer/payments.mdx#processing-a-payment-with-payment-app) - The communication between the storefront and payment app goes through Saleor.
+- [Saleor payment app](developer/payments.mdx#processing-a-payment-with-payment-app) - The communication between the storefront and payment app goes through Saleor.
   Saleor allows the storefront to provide and receive data directly from the app. Based on the response received from the app,
   Saleor can determine the current status of the payment and update it on its side.
-- [Saleor app with existing checkout app](docs/developer/payments.mdx#processing-a-payment-with-checkout-app): This is recommended for more advanced use cases when a shop owner needs to provide more
+- [Saleor app with existing checkout app](developer/payments.mdx#processing-a-payment-with-checkout-app): This is recommended for more advanced use cases when a shop owner needs to provide more
   validation before finalizing the checkout or to cover specific cases. The `CheckoutApp` handles the payment process on its side
   and uses Saleor's mutation to report any changes that happen for a specific `transactionItem`.
-  The order can be created by protected mutation [orderCreateFromCheckout](docs/api-reference/orders/mutations/order-create-from-checkout.mdx).
+  The order can be created by protected mutation [orderCreateFromCheckout](api-reference/orders/mutations/order-create-from-checkout.mdx).
 
 ### Processing a payment with the Payment App
 

--- a/versioned_docs/version-3.x/developer/permissions.mdx
+++ b/versioned_docs/version-3.x/developer/permissions.mdx
@@ -16,7 +16,7 @@ The channel restriction affects the access to data restricted by the following p
 - `MANAGE_ORDERS`
 
 Instead of assigning permissions directly to the user, we define them on a group basis.
-Organizing access rights in [Groups](docs/api-reference/users/objects/group.mdx) helps in determining the roles of team members.
+Organizing access rights in [Groups](api-reference/users/objects/group.mdx) helps in determining the roles of team members.
 
 Examples of groups:
 
@@ -32,7 +32,7 @@ they will have access to data from all channels.
 
 ### Creating and removing groups
 
-To create a new group, use the [permissionGroupCreate](docs/api-reference/users/mutations/permission-group-create.mdx) mutation.
+To create a new group, use the [permissionGroupCreate](api-reference/users/mutations/permission-group-create.mdx) mutation.
 
 #### Creating the group without channel restriction
 
@@ -170,7 +170,7 @@ in `addChannels` field will be ignored.
 
 #### Removing a group
 
-To remove a group, use the [permissionGroupDelete](docs/api-reference/users/mutations/permission-group-delete.mdx) mutation:
+To remove a group, use the [permissionGroupDelete](api-reference/users/mutations/permission-group-delete.mdx) mutation:
 
 ```graphql
 mutation {
@@ -187,7 +187,7 @@ mutation {
 
 #### Managing the group members
 
-The [permissionGroupUpdate](docs/api-reference/users/mutations/permission-group-update.mdx) mutation takes a list of user IDs you would like to add or remove from the group. Having the same user in both lists will result in an error.
+The [permissionGroupUpdate](api-reference/users/mutations/permission-group-update.mdx) mutation takes a list of user IDs you would like to add or remove from the group. Having the same user in both lists will result in an error.
 
 Example request:
 
@@ -212,7 +212,7 @@ mutation {
 
 #### Managing the group channels
 
-The [permissionGroupUpdate](docs/api-reference/users/mutations/permission-group-update.mdx)
+The [permissionGroupUpdate](api-reference/users/mutations/permission-group-update.mdx)
 mutation takes a list of channel IDs you would like to add or remove from the group.
 Having the same channels in both lists will result in an error.
 
@@ -245,7 +245,7 @@ in `addChannels` and `removeChannels` fields will be ignored.
 
 ## App permissions
 
-App permissions are defined on a per-app basis. Access can be assigned during the app installation and modified later using the [appUpdate](docs/api-reference/apps/mutations/app-update.mdx) mutation.
+App permissions are defined on a per-app basis. Access can be assigned during the app installation and modified later using the [appUpdate](api-reference/apps/mutations/app-update.mdx) mutation.
 The apps don't have channel restrictions, so all channels data can be visible by the app with the proper permission.
 
 ## JWT token and permissions
@@ -279,7 +279,7 @@ Since Saleor reads permissions from the JWT token, generating a new token is nec
 
 ## Available permissions
 
-Available permissions are kept in the [PermissionEnum](docs/api-reference/users/enums/permission-enum.mdx).
+Available permissions are kept in the [PermissionEnum](api-reference/users/enums/permission-enum.mdx).
 
 | Name                                | Description                         |
 | ----------------------------------- | ----------------------------------- |

--- a/versioned_docs/version-3.x/developer/products.mdx
+++ b/versioned_docs/version-3.x/developer/products.mdx
@@ -11,7 +11,7 @@ You can either retrieve a single product or a list of products. You may require 
 ## Multiple channels and products
 
 Customers can only fetch products from available channels. Because listing channels is only available for staff users, you will need to provide channel slugs to your storefront.
-Besides availability, you can define more parameters on a channel basis using [ProductChannelListing](docs/api-reference/products/objects/product-channel-listing.mdx):
+Besides availability, you can define more parameters on a channel basis using [ProductChannelListing](api-reference/products/objects/product-channel-listing.mdx):
 
 - `publicationDate`
 - `isPublished`
@@ -19,7 +19,7 @@ Besides availability, you can define more parameters on a channel basis using [P
 - `availableForPurchase`
 - `isAvailableForPurchase`
 
-For variants, there's [ProductVariantChannelListing](docs/api-reference/products/objects/product-variant-channel-listing.mdx):
+For variants, there's [ProductVariantChannelListing](api-reference/products/objects/product-variant-channel-listing.mdx):
 
 - `price`
 - `costPrice`
@@ -80,7 +80,7 @@ The `channel` argument can be skipped only if a user has `is_staff` flag.
 
 ### Filtering
 
-The [`products`](docs/api-reference/products/queries/products.mdx) query gives the ability to filter the results. Use the optional [`filter`](docs/api-reference/products/inputs/product-filter-input.mdx) argument. Some of the filters that are available here are:
+The [`products`](api-reference/products/queries/products.mdx) query gives the ability to filter the results. Use the optional [`filter`](api-reference/products/inputs/product-filter-input.mdx) argument. Some of the filters that are available here are:
 
 - `search: String`: search by name or part of the description.
 - `price: ...`: filter by base price:
@@ -137,7 +137,7 @@ Response:
 
 ### Sorting
 
-In [`products`](docs/api-reference/products/queries/products.mdx) you can also sort the results using two [`sortBy`](docs/api-reference/products/inputs/product-order.mdx) arguments:
+In [`products`](api-reference/products/queries/products.mdx) you can also sort the results using two [`sortBy`](api-reference/products/inputs/product-order.mdx) arguments:
 
 - `field`: the field to use for sorting the results from several predefined choices:
   - `DATE`: sort products by last update.
@@ -207,7 +207,7 @@ Response:
 
 ## Retrieving a single product
 
-To fetch a single product, use the [`product`](docs/api-reference/products/queries/product.mdx) query, which requires only one input field:
+To fetch a single product, use the [`product`](api-reference/products/queries/product.mdx) query, which requires only one input field:
 
 - `id`: the unique product ID.
 
@@ -395,7 +395,7 @@ The tax equals 1.15, which is 23% of the net price. The gross price is the sum o
 The `address` parameter is optional. If it's not provided, Saleor will use the default country code configured in the backend settings (see [DEFAULT_COUNTRY](setup/configuration.mdx#default_country)).
 :::
 
-Learn more about [Taxes](docs/developer/taxes.mdx)
+Learn more about [Taxes](developer/taxes.mdx)
 
 ## Stock availability for customers
 
@@ -465,7 +465,7 @@ To avoid leaking precise stock information, the `quantityAvailable` field will n
 For creating integrations with an external stock management system, you will need to use stock values not restricted by [`MAX_CHECKOUT_LINE_QUANTITY`](setup/configuration.mdx#max_checkout_line_quantity).
 
 :::note
-`stocks` field in the [`ProductVariant`](docs/api-reference/products/objects/product-variant.mdx) object require `MANAGE_PRODUCTS` permission.
+`stocks` field in the [`ProductVariant`](api-reference/products/objects/product-variant.mdx) object require `MANAGE_PRODUCTS` permission.
 :::
 
 To clarify the difference between `quantityAvailable` and stocks, we will query both for the product variant:

--- a/versioned_docs/version-3.x/developer/stock-allocation.mdx
+++ b/versioned_docs/version-3.x/developer/stock-allocation.mdx
@@ -74,7 +74,7 @@ allocation. At this moment, two possible options are available:
   the remaining quantity is allocated in the next warehouse on the list
   and repeated if necessary.
   To change the warehouses' order within the channel, use
-  [`channelReorderWarehouses`](docs/api-reference/channels/mutations/channel-reorder-warehouses.mdx) mutation.
+  [`channelReorderWarehouses`](api-reference/channels/mutations/channel-reorder-warehouses.mdx) mutation.
 - Prioritize warehouses with the highest stock (`PRIORITIZE_HIGH_STOCK`) - allocate stock
   in a warehouse with the most stock. If not enough stock is available in a single
   warehouse, the remaining quantity is allocated in the next warehouse on the list
@@ -86,7 +86,7 @@ allocation. At this moment, two possible options are available:
 ### Warehouse creation
 
 Firstly we need to create the warehouse with the use of
-[`createWarehouse`](docs/api-reference/products/mutations/create-warehouse.mdx) mutation.
+[`createWarehouse`](api-reference/products/mutations/create-warehouse.mdx) mutation.
 In the following example, we are specifying `name`, `slug`, `email` and `address` of a warehouse.
 
 ```graphql
@@ -144,7 +144,7 @@ As a response we get the newly created warehouse:
 ```
 
 After the warehouse is created it can be changed with the use of
-the [`updateWarehouse`](docs/api-reference/products/mutations/update-warehouse.mdx) mutation.
+the [`updateWarehouse`](api-reference/products/mutations/update-warehouse.mdx) mutation.
 There is an option to change the following warehouse fields: `name`, `slug`, `email`, `address` and
 also define privacy and `click and collect` options.
 
@@ -181,7 +181,7 @@ the stocks are allocated from the next warehouse with the highest available quan
 
 To allow assigning the warehouse to the shipping zone we need to have at least one common
 channel with this zone. So firstly, we need to assign warehouses to channels with the use of
-[`channelUpdate`](docs/api-reference/channels/mutations/channel-update.mdx) mutation.
+[`channelUpdate`](api-reference/channels/mutations/channel-update.mdx) mutation.
 See the example below:
 
 ```graphql
@@ -239,7 +239,7 @@ Shipping zones are required to sell physical products to given countries.
 
 ### Shipping zone creation and update
 
-To create the shipping zone use [`shippingZoneCreate`](docs/api-reference/shipping/mutations/shipping-zone-create.mdx) mutation.
+To create the shipping zone use [`shippingZoneCreate`](api-reference/shipping/mutations/shipping-zone-create.mdx) mutation.
 You can specify such fields as `name`, `description`, `countries`, `warehouses`, `channels` and
 decide if you want to use it as the default one for all countries
 that are not covered by other zones.
@@ -329,7 +329,7 @@ As a result, we get the newly created shipping zone.
 }
 ```
 
-To update the shipping zone use [`shippingZoneUpdate`](docs/api-reference/shipping/mutations/shipping-zone-update.mdx) mutation.
+To update the shipping zone use [`shippingZoneUpdate`](api-reference/shipping/mutations/shipping-zone-update.mdx) mutation.
 You can change all fields you defined during the creation process and unlink the channels and warehouses. Be aware that removing the channel may cause unlinking warehouses if it was the only common channel between zone and warehouse.
 As before, adding warehouses must have a common channel with the shipping zone.
 

--- a/versioned_docs/version-3.x/developer/taxes.mdx
+++ b/versioned_docs/version-3.x/developer/taxes.mdx
@@ -10,7 +10,7 @@ You can configure the tax calculation method per channel and override the config
 
 ## Tax Configuration
 
-The tax configuration object defines various configuration options for a channel. This includes the tax calculation method, whether to charge taxes in the channel, or whether the entered prices include the tax. The configuration object is created automatically for each sales channel. In the API, it is represented by the [`TaxConfiguration`](docs/api-reference/taxes/objects/tax-configuration.mdx) object.
+The tax configuration object defines various configuration options for a channel. This includes the tax calculation method, whether to charge taxes in the channel, or whether the entered prices include the tax. The configuration object is created automatically for each sales channel. In the API, it is represented by the [`TaxConfiguration`](api-reference/taxes/objects/tax-configuration.mdx) object.
 
 The tax configuration object has several properties, including:
 
@@ -18,9 +18,9 @@ The tax configuration object has several properties, including:
 - `taxCalculationStrategy` - The strategy for tax calculation in the channel. There are two strategies available:
   - flat rates - the default strategy
   - dynamic taxes (tax apps)
-- `displayGrossPrices` - Determines whether prices displayed in a storefront should include taxes. Note that this setting doesn’t affect internal calculations in Saleor, and it’s only meant for the storefront to decide if it should display `TaxedMoney.net` or `TaxedMoney.gross` price (see [TaxedMoney API reference](docs/api-reference/miscellaneous/objects/taxed-money.mdx)). For storefront queries, this property can be fetched at two levels:
-  - product level in the [ProductPricingInfo.displayGrossPrices](docs/api-reference/products/objects/product-pricing-info.mdx) field - use it when rendering product listings or product details pages
-  - checkout level in the [Checkout.displayGrossPrices](docs/api-reference/checkout/objects/checkout.mdx) field - use it when rendering the cart or checkout pages
+- `displayGrossPrices` - Determines whether prices displayed in a storefront should include taxes. Note that this setting doesn’t affect internal calculations in Saleor, and it’s only meant for the storefront to decide if it should display `TaxedMoney.net` or `TaxedMoney.gross` price (see [TaxedMoney API reference](api-reference/miscellaneous/objects/taxed-money.mdx)). For storefront queries, this property can be fetched at two levels:
+  - product level in the [ProductPricingInfo.displayGrossPrices](api-reference/products/objects/product-pricing-info.mdx) field - use it when rendering product listings or product details pages
+  - checkout level in the [Checkout.displayGrossPrices](api-reference/checkout/objects/checkout.mdx) field - use it when rendering the cart or checkout pages
 - `pricesEnteredWithTax` - Determine whether product prices are entered with tax included (typical for B2C in EU) or not (typical for US and B2B).
 
 Additionally, the following properties can be overridden for specific countries within the channel: `chargeTaxes`, `taxCalculationStrategy`, `displayGrossPrices`. This allows for handling various situations where a store operates in different countries with different tax rules.
@@ -273,7 +273,7 @@ mutation {
 
 ### Querying products with taxed prices for a specific country
 
-When using flat rates, the API can list products with prices that include tax rates for different countries. To do this, pass the country code for which you have flat rate configurations available. If the `country` argument is not specified, the default country for the channel is assumed. (See [Channel.defaultCountry](docs/api-reference/channels/objects/channel.mdx).)
+When using flat rates, the API can list products with prices that include tax rates for different countries. To do this, pass the country code for which you have flat rate configurations available. If the `country` argument is not specified, the default country for the channel is assumed. (See [Channel.defaultCountry](api-reference/channels/objects/channel.mdx).)
 
 In this example, we are fetching a product list with prices for Poland.
 
@@ -344,7 +344,7 @@ mutation {
 
 ## Tax exemption
 
-The [Tax Exemption API](docs/api-reference/taxes/mutations/tax-exemption-manage.mdx) allows you to exempt checkouts or orders from taxes, regardless of any channel or country-specific configuration. Note that this API is restricted to users with the `MANAGE_TAXES` permission.
+The [Tax Exemption API](api-reference/taxes/mutations/tax-exemption-manage.mdx) allows you to exempt checkouts or orders from taxes, regardless of any channel or country-specific configuration. Note that this API is restricted to users with the `MANAGE_TAXES` permission.
 
 To exempt a checkout from taxes, use the following mutation:
 

--- a/versioned_docs/version-3.x/setup/upgrading.mdx
+++ b/versioned_docs/version-3.x/setup/upgrading.mdx
@@ -30,7 +30,7 @@ For instructions specific to upgrading between particular versions, see the [upg
 
 ## Upgrading with zero-downtime
 
-For general knowledge of how zero-downtime migrations work, please check [writing zero-downtime migrations](docs/developer/community/zero-downtime-migrations.mdx).
+For general knowledge of how zero-downtime migrations work, please check [writing zero-downtime migrations](developer/community/zero-downtime-migrations.mdx).
 
 Zero-downtime migrations can only be achieved by upgrading Saleor minor version by minor version, that means, to upgrade Saleor from version 3.11 to 3.13, you need first upgrade your workers
 to version 3.12, then proceed with upgrading to version 3.13. By upgrading from version 3.11 directly to 3.13 you will not follow zero-downtime policy.

--- a/versioned_docs/version-3.x/upgrade-guides/2-11-to-3-0.mdx
+++ b/versioned_docs/version-3.x/upgrade-guides/2-11-to-3-0.mdx
@@ -35,16 +35,16 @@ Besides the impact on fetching the data, you'll be required to specify the chann
 
 ### Editing channel related fields
 
-If you use the API to modify objects (for example, with an external app), please note that channel-depending fields have dedicated mutations. Updating product price requires using the [productChannelListingUpdate](docs/api-reference/products/mutations/product-channel-listing-update.mdx) mutation.
+If you use the API to modify objects (for example, with an external app), please note that channel-depending fields have dedicated mutations. Updating product price requires using the [productChannelListingUpdate](api-reference/products/mutations/product-channel-listing-update.mdx) mutation.
 
 Object attributes that can be defined on a channel basis can be referenced.
 
-- [Collection Channel Listing](docs/api-reference/products/objects/collection-channel-listing.mdx)
-- [Product Channel Listing](docs/api-reference/products/objects/product-channel-listing.mdx)
-- [ProductVariant Channel Listing](docs/api-reference/products/objects/product-variant-channel-listing.mdx)
-- [Sale Channel Listing](docs/api-reference/discounts/objects/sale-channel-listing.mdx)
-- [ShippingMethod Channel Listing](docs/api-reference/shipping/objects/shipping-method-channel-listing.mdx)
-- [Voucher Channel Listing](docs/api-reference/discounts/objects/voucher-channel-listing.mdx)
+- [Collection Channel Listing](api-reference/products/objects/collection-channel-listing.mdx)
+- [Product Channel Listing](api-reference/products/objects/product-channel-listing.mdx)
+- [ProductVariant Channel Listing](api-reference/products/objects/product-variant-channel-listing.mdx)
+- [Sale Channel Listing](api-reference/discounts/objects/sale-channel-listing.mdx)
+- [ShippingMethod Channel Listing](api-reference/shipping/objects/shipping-method-channel-listing.mdx)
+- [Voucher Channel Listing](api-reference/discounts/objects/voucher-channel-listing.mdx)
 
 ## Email templates
 

--- a/versioned_docs/version-3.x/upgrade-guides/3-1-to-3-2.mdx
+++ b/versioned_docs/version-3.x/upgrade-guides/3-1-to-3-2.mdx
@@ -9,7 +9,7 @@ Version 3.2 introduces some breaking changes necessary to ensure the highest qua
 
 ## JWT token expiration
 
-Since Saleor 3.2, JWT token expiration time is set to 5 minutes and can be controlled server-side with `JWT_TTL_ACCESS` environment variable. See [Refreshing an access token](docs/api-usage/authentication.mdx#refreshing-the-access-token) to learn how to refresh the token in your client app.
+Since Saleor 3.2, JWT token expiration time is set to 5 minutes and can be controlled server-side with `JWT_TTL_ACCESS` environment variable. See [Refreshing an access token](api-usage/authentication.mdx#refreshing-the-access-token) to learn how to refresh the token in your client app.
 
 ## Saleor Apps inside Dashboard
 


### PR DESCRIPTION
This PR fixes paths starting with `docs/` which made links to redirect to `Canary` version only

Closes #905