### PR TITLE
Remove rank medatada from config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -330,8 +330,6 @@ module.exports = {
       },
     },
 
-    metadata: [{ name: "rank", content: "1" }],
-
     navbar: {
       hideOnScroll: true,
       logo: {


### PR DESCRIPTION
With the changes to the Algolia Crawler, the default value is not needed. 