### PR TITLE
Fix stylistic mistakes in payments docs

### DIFF
--- a/versioned_docs/version-3.x/developer/payments.mdx
+++ b/versioned_docs/version-3.x/developer/payments.mdx
@@ -62,7 +62,7 @@ sequenceDiagram
   par For each payment gateway
     Saleor ->>+ PaymentApp: payment-gateway-initialize-session<br>webhook
     PaymentApp ->>+ PaymentProvider: Initialize payment gateway
-    PaymentProvider -->>- PaymentApp: Data mandatory to<br>initialize the payment<br>on fronted
+    PaymentProvider -->>- PaymentApp: Data mandatory to<br>initialize the payment<br>on frontend
     PaymentApp -->>- Saleor: PaymentGateway data with config
   end
   Saleor -->>- Storefront: List of PaymentGateway data and configs

--- a/versioned_docs/version-3.x/developer/payments.mdx
+++ b/versioned_docs/version-3.x/developer/payments.mdx
@@ -66,7 +66,7 @@ sequenceDiagram
     PaymentApp -->>- Saleor: PaymentGateway data with config
   end
   Saleor -->>- Storefront: List of PaymentGateway data and configs
-  Storefront ->>+ Saleor: TransactionInitialize<br> with amount and<br>payment gateway ID, data
+  Storefront ->>+ Saleor: Mutation transactionInitialize<br> with amount and<br>payment gateway ID, data
   Saleor ->> Saleor: Create TransactionItem
   Saleor ->> Saleor: Request TransactionEvent created
   Saleor ->>+ PaymentApp: webhook transaction-initialize-session

--- a/versioned_docs/version-3.x/developer/payments.mdx
+++ b/versioned_docs/version-3.x/developer/payments.mdx
@@ -8,7 +8,7 @@ The process below describes the key milestones in the Saleor payment flow.
 Additional steps may also occur along the way; however, the purpose of this instruction is to
 deliver a base reference for the user to work with.
 
-Saleor distinguishes two different approaches to processing payments:
+Saleor distinguishes three different approaches to processing payments:
 
 - By using a [Payment App](#payment-app).
 - By using a [Custom App](#custom-app).


### PR DESCRIPTION
One approach is deprecated, but there are three nevertheless