### PR TITLE
Add docs for IP filtering feature

### DIFF
--- a/docs/setup/configuration.mdx
+++ b/docs/setup/configuration.mdx
@@ -172,7 +172,7 @@ Controls [Django's internal IPs setting](https://docs.djangoproject.com/en/3.0/r
 
 Multiple values should be separated with a comma.
 
-### HTTP_IP_FILTER_ENABLED
+### `HTTP_IP_FILTER_ENABLED`
 
 _Added in v3.16_
 
@@ -180,12 +180,12 @@ A boolean setting that controls whether or not to enable IP filtering in HTTP(S)
 (webhooks, OIDC, etc.).
 
 When set to `True` (default) it will reject private and loopback IP address ranges
-(see also [`HTTP_IP_FILTER_ALLOW_LOCALHOST`](#HTTP_IP_FILTER_ALLOW_LOCALHOST)).
+(see also [`HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS`](#HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS)).
 
 It defaults to `True`, and is recommended to be enabled on environments where staff users
 are untrusted, and thus could lead to [SSRF attacks](https://cwe.mitre.org/data/definitions/918.html).
 
-### HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS
+### `HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS`
 
 _Added in v3.16_
 

--- a/docs/setup/configuration.mdx
+++ b/docs/setup/configuration.mdx
@@ -172,6 +172,26 @@ Controls [Django's internal IPs setting](https://docs.djangoproject.com/en/3.0/r
 
 Multiple values should be separated with a comma.
 
+### HTTP_IP_FILTER_ENABLED
+
+_Added in v3.16_
+
+A boolean setting that controls whether or not to enable IP filtering in HTTP(S) network calls
+(webhooks, OIDC, etc.).
+
+When set to `True` (default) it will reject private and loopback IP address ranges
+(see also [`HTTP_IP_FILTER_ALLOW_LOCALHOST`](#HTTP_IP_FILTER_ALLOW_LOCALHOST)).
+
+It defaults to `True`, and is recommended to be enabled on environments where staff users
+are untrusted, and thus could lead to [SSRF attacks](https://cwe.mitre.org/data/definitions/918.html).
+
+### HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS
+
+_Added in v3.16_
+
+When set to `False` (default), the HTTP IP filter will reject loopback IP addresses
+(127.0.0.0 to 127.255.255.255 range).
+
 ### `JWT_TTL_ACCESS`
 
 The time until JWT access tokens expire. The value should be a time expression like `5m`, `5 minutes`, `5d`, `5 days`, `1w`, or `1 week`. Defaults to `5 minutes`.

--- a/docs/setup/configuration.mdx
+++ b/docs/setup/configuration.mdx
@@ -180,7 +180,7 @@ A boolean setting that controls whether or not to enable IP filtering in HTTP(S)
 (webhooks, OIDC, etc.).
 
 When set to `True` (default) it will reject private and loopback IP address ranges
-(see also [`HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS`](#HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS)).
+(see also [`HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS`](#http_ip_filter_allow_loopback_ips)).
 
 It defaults to `True`, and is recommended to be enabled on environments where staff users
 are untrusted, and thus could lead to [SSRF attacks](https://cwe.mitre.org/data/definitions/918.html).


### PR DESCRIPTION
This adds documentation for the new IP filtering feature of v3.16 https://github.com/saleor/saleor/pull/13891.