### PR TITLE
Expandable/collapslible CodeBlock/Content

### DIFF
--- a/src/theme/CodeBlock/Content/Element.js
+++ b/src/theme/CodeBlock/Content/Element.js
@@ -1,0 +1,18 @@
+import React from "react";
+import clsx from "clsx";
+import Container from "@theme/CodeBlock/Container";
+import styles from "./styles.module.css";
+// <pre> tags in markdown map to CodeBlocks. They may contain JSX children. When
+// the children is not a simple string, we just return a styled block without
+// actually highlighting.
+export default function CodeBlockJSX({ children, className }) {
+  return (
+    <Container
+      as="pre"
+      tabIndex={0}
+      className={clsx(styles.codeBlockStandalone, "thin-scrollbar", className)}
+    >
+      <code className={styles.codeBlockLines}>{children}</code>
+    </Container>
+  );
+}

--- a/src/theme/CodeBlock/Content/String.js
+++ b/src/theme/CodeBlock/Content/String.js
@@ -1,0 +1,125 @@
+import React, { useState } from "react";
+import clsx from "clsx";
+import { useThemeConfig, usePrismTheme } from "@docusaurus/theme-common";
+import {
+  parseCodeBlockTitle,
+  parseLanguage,
+  parseLines,
+  containsLineNumbers,
+  useCodeWordWrap,
+} from "@docusaurus/theme-common/internal";
+import Highlight, { defaultProps } from "prism-react-renderer";
+import Line from "@theme/CodeBlock/Line";
+import CopyButton from "@theme/CodeBlock/CopyButton";
+import WordWrapButton from "@theme/CodeBlock/WordWrapButton";
+import Container from "@theme/CodeBlock/Container";
+import styles from "./styles.module.css";
+export default function CodeBlockString({
+  children,
+  className: blockClassName = "",
+  metastring,
+  title: titleProp,
+  showLineNumbers: showLineNumbersProp,
+  language: languageProp,
+}) {
+  const {
+    prism: { defaultLanguage, magicComments },
+  } = useThemeConfig();
+  const language =
+    languageProp ?? parseLanguage(blockClassName) ?? defaultLanguage;
+  const prismTheme = usePrismTheme();
+  const wordWrap = useCodeWordWrap();
+  // We still parse the metastring in case we want to support more syntax in the
+  // future. Note that MDX doesn't strip quotes when parsing metastring:
+  // "title=\"xyz\"" => title: "\"xyz\""
+  const title = parseCodeBlockTitle(metastring) || titleProp;
+  const { lineClassNames, code } = parseLines(children, {
+    metastring,
+    language,
+    magicComments,
+  });
+  const showLineNumbers =
+    showLineNumbersProp ?? containsLineNumbers(metastring);
+
+  const [codeBlockExpanded, setCodeBlockExpanded] = useState(false);
+
+  const handleExpand = (e) => {
+    e.preventDefault();
+    setCodeBlockExpanded(!codeBlockExpanded);
+  };
+
+  const expandContent = codeBlockExpanded ? "Collapse ▲" : "Expand ▼";
+
+  const longCode = code.split(/\r\n|\r|\n/).length > 18;
+
+  return (
+    <Container
+      as="div"
+      className={clsx(
+        blockClassName,
+        language &&
+          !blockClassName.includes(`language-${language}`) &&
+          `language-${language}`
+      )}
+    >
+      {title && <div className={styles.codeBlockTitle}>{title}</div>}
+      <div
+        className={clsx(
+          styles.codeBlockContent,
+          codeBlockExpanded && styles.expanded
+        )}
+      >
+        <Highlight
+          {...defaultProps}
+          theme={prismTheme}
+          code={code}
+          language={language ?? "text"}
+        >
+          {({ className, tokens, getLineProps, getTokenProps }) => (
+            <pre
+              /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+              tabIndex={0}
+              ref={wordWrap.codeBlockRef}
+              className={clsx(className, styles.codeBlock, "thin-scrollbar")}
+            >
+              <code
+                className={clsx(
+                  styles.codeBlockLines,
+                  showLineNumbers && styles.codeBlockLinesWithNumbering
+                )}
+              >
+                {tokens.map((line, i) => (
+                  <Line
+                    key={i}
+                    line={line}
+                    getLineProps={getLineProps}
+                    getTokenProps={getTokenProps}
+                    classNames={lineClassNames[i]}
+                    showLineNumbers={showLineNumbers}
+                  />
+                ))}
+              </code>
+            </pre>
+          )}
+        </Highlight>
+        <div className={styles.buttonGroup}>
+          {(wordWrap.isEnabled || wordWrap.isCodeScrollable) && (
+            <WordWrapButton
+              className={styles.codeButton}
+              onClick={() => wordWrap.toggle()}
+              isEnabled={wordWrap.isEnabled}
+            />
+          )}
+          <CopyButton className={styles.codeButton} code={code} />
+          {/* <button onClick={toggleMaxHeight}>Toggle Max Height</button> */}
+        </div>
+
+        {longCode && (
+          <div className={styles.slidingBox} onClick={handleExpand}>
+            {expandContent}
+          </div>
+        )}
+      </div>
+    </Container>
+  );
+}

--- a/src/theme/CodeBlock/Content/styles.module.css
+++ b/src/theme/CodeBlock/Content/styles.module.css
@@ -1,0 +1,107 @@
+.codeBlockContent {
+  position: relative;
+  /* rtl:ignore */
+  direction: ltr;
+  border-radius: inherit;
+  overflow-y: scroll;
+  max-height: 400px;
+}
+
+.codeBlockTitle {
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  font-size: var(--ifm-code-font-size);
+  font-weight: 500;
+  padding: 0.75rem var(--ifm-pre-padding);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+
+.codeBlock {
+  --ifm-pre-background: var(--prism-background-color);
+  margin: 0;
+  padding: 0;
+}
+
+.codeBlockTitle + .codeBlockContent .codeBlock {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.codeBlockStandalone {
+  padding: 0;
+}
+
+.codeBlockLines {
+  font: inherit;
+  /* rtl:ignore */
+  float: left;
+  min-width: 100%;
+  padding: var(--ifm-pre-padding);
+}
+
+.codeBlockLinesWithNumbering {
+  display: table;
+  padding: var(--ifm-pre-padding) 0;
+}
+
+@media print {
+  .codeBlockLines {
+    white-space: pre-wrap;
+  }
+}
+
+.buttonGroup {
+  display: flex;
+  column-gap: 0.2rem;
+  position: absolute;
+  /* rtl:ignore */
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+}
+
+.buttonGroup button {
+  display: flex;
+  align-items: center;
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  line-height: 0;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
+  opacity: 0;
+}
+
+.buttonGroup button:focus-visible,
+.buttonGroup button:hover {
+  opacity: 1 !important;
+}
+
+:global(.theme-code-block:hover) .buttonGroup button {
+  opacity: 0.4;
+}
+
+.slidingBox {
+  position: sticky;
+  left: 0;
+  right: 0;
+  bottom: -100%;
+  background-color: #3498db;
+  color: --ifm-background-color;
+  opacity: 0;
+  padding: 10px;
+  transition: transform 0.3s, opacity 0.3s;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.codeBlockContent:hover .slidingBox {
+  bottom: 0;
+  opacity: 1;
+  cursor: pointer;
+}
+
+.expanded {
+  max-height: unset;
+}

--- a/src/theme/CodeBlock/Content/styles.module.css
+++ b/src/theme/CodeBlock/Content/styles.module.css
@@ -86,7 +86,7 @@
   left: 0;
   right: 0;
   bottom: -100%;
-  background-color: #3498db;
+  background-color: var(--prism-background-color);
   color: --ifm-background-color;
   opacity: 0;
   padding: 10px;


### PR DESCRIPTION
This PR intoduces expandable/collapslible CodeBlock/Content. It's enabled when the code contains more than 18 lines.

 #923 

![Sep-07-2023 12-10-23](https://github.com/saleor/saleor-docs/assets/779644/b5c7ccfe-fd02-4d7f-8e60-20530fcbf7d7)

