### PR TITLE
Update outdated APL docs 

### DIFF
--- a/docs/developer/extending/apps/architecture/apl.mdx
+++ b/docs/developer/extending/apps/architecture/apl.mdx
@@ -51,11 +51,11 @@ We recommend writing apps in a multi-tenant manner. That means a single deployme
 
 There are several implementations of APL, including:
 
-- local filesystem (single tenant)
+- FileAPL (single tenant)
+- EnvAPL (single tenant)
 - [Upstash](https://upstash.com/) (multi-tenant)
-- [Firestore](https://firebase.google.com/products/firestore) (multi-tenant)
 
-You can find an updated list of APLs [here](https://github.com/saleor/saleor-app-sdk/blob/main/docs/apl.md#available-apls).
+You can find an updated list of APLs [here](developer/extending/apps/developing-apps/app-sdk/apl.md#available-apls).
 
 ## Development
 
@@ -106,7 +106,7 @@ You can find the [APL shape in app-sdk](https://github.com/saleor/saleor-app-sdk
 
 You are free to write your own APL but you need to make sure it follows the `APL` TypeScript interface from [app-sdk](https://github.com/saleor/saleor-app-sdk).
 
-Please proceed [here](https://github.com/saleor/saleor-app-sdk/blob/main/docs/apl.md#example-implementation) to see an example of building one with Redis.
+Please proceed [here](developer/extending/apps/developing-apps/app-sdk/apl.md#example-implementation) to see an example of building one with Redis.
 
 ### Developing an App without APL
 

--- a/versioned_docs/version-3.x/developer/extending/apps/architecture/apl.mdx
+++ b/versioned_docs/version-3.x/developer/extending/apps/architecture/apl.mdx
@@ -51,11 +51,11 @@ We recommend writing apps in a multi-tenant manner. That means a single deployme
 
 There are several implementations of APL, including:
 
-- local filesystem (single tenant)
+- FileAPL (single tenant)
+- EnvAPL (single tenant)
 - [Upstash](https://upstash.com/) (multi-tenant)
-- [Firestore](https://firebase.google.com/products/firestore) (multi-tenant)
 
-You can find an updated list of APLs [here](https://github.com/saleor/saleor-app-sdk/blob/main/docs/apl.md#available-apls).
+You can find an updated list of APLs [here](developer/extending/apps/developing-apps/app-sdk/apl.md#available-apls).
 
 ## Development
 
@@ -106,7 +106,7 @@ You can find the [APL shape in app-sdk](https://github.com/saleor/saleor-app-sdk
 
 You are free to write your own APL but you need to make sure it follows the `APL` TypeScript interface from [app-sdk](https://github.com/saleor/saleor-app-sdk).
 
-Please proceed [here](https://github.com/saleor/saleor-app-sdk/blob/main/docs/apl.md#example-implementation) to see an example of building one with Redis.
+Please proceed [here](developer/extending/apps/developing-apps/app-sdk/apl.md#example-implementation) to see an example of building one with Redis.
 
 ### Developing an App without APL
 


### PR DESCRIPTION
This PR updates list of available APLs in https://docs.saleor.io/docs/3.x/developer/extending/apps/architecture/apl#available-apl-clients

It also updates dead links in that docs page
