### PR TITLE
Update docs about voucher usage with draft orders.

### DIFF
--- a/docs/developer/bulks/bulk-orders.mdx
+++ b/docs/developer/bulks/bulk-orders.mdx
@@ -394,7 +394,7 @@ mutation OrderBulkCreate(
         }
       ],
       "giftCards": ["Gift_card_1"],
-      "voucher": "FREESHIPPING",
+      "voucherCode": "FREESHIPPING",
       "weight": "10.15",
       "trackingClientId": "tracking-id-123",
       "metadata": [
@@ -686,7 +686,7 @@ The input allows to provide a custom list of events that would be saved as `Orde
 
 #### Gift cards and vouchers
 
-The input accepts a list of gift card codes and a single voucher code that should be associated with the order, but it doesn’t trigger any price recalculation. Prices are based only on line totals.
+The input accepts a list of gift card codes and a single voucher code that should be associated with the order, but it doesn’t trigger any price recalculation. Prices are based only on line totals. Please note, that the voucher is not validated during import, therefore code usage will not be counted.
 
 #### CreatedAt fields
 

--- a/docs/developer/discounts/vouchers.mdx
+++ b/docs/developer/discounts/vouchers.mdx
@@ -44,17 +44,17 @@ Those limitation options can be combined. For example, if `usageLimit` is set to
 
 ### Voucher usage in draft orders
 
-Since version 3.18, Saleor is able to calculate voucher usage in draft orders. To turn on such a behavior, `includeDraftOrderInVoucherUsage` flag for given `Channel` must be set to `true`. Use [channelUpdate](api-reference/channels/mutations/channel-update.mdx) mutation to switch the flag.
+Since version 3.18, Saleor is able to calculate voucher usage in draft orders. To turn on such a behavior, `includeDraftOrderInVoucherUsage` flag for the given `Channel` must be set to `true`. Use [channelUpdate](api-reference/channels/mutations/channel-update.mdx) mutation to switch the flag.
 
 When the `includeDraftOrderInVoucherUsage` flag is changed from `false` to `true`, **vouchers will be disconnected from all draft orders.**
 
 When the `includeDraftOrderInVoucherUsage` flag is changed from `true` to `false`, all vouchers will be released. It means:
 
 - multiple-use voucher codes will reduce their usage by one (`VoucherCode.used` field)
-- single-use voucher codes will became active again (`VoucherCode.isActive` field)
+- single-use voucher codes will become active again (`VoucherCode.isActive` field)
 - in case of `applyOncePerCustomer` setting on, the usage will be dissociated from users (`VoucherCustomer` entry)
 
-Voucher code will be also released, after the draft order deletion.
+Voucher code will also be released, after the draft order deletion.
 
 When importing a draft order using [bulkOrderCreate](developer/bulks/bulk-orders.mdx) mutation, the voucher is not validated, therefore code usage will not be counted.
 

--- a/docs/developer/discounts/vouchers.mdx
+++ b/docs/developer/discounts/vouchers.mdx
@@ -42,6 +42,22 @@ The voucher can be also set as single-use, when `singleUse` flag is set to `true
 
 Those limitation options can be combined. For example, if `usageLimit` is set to `10` and `applyOncePerCustomer` is set to `true`, the voucher can be used by the first 10 users.
 
+### Voucher usage in draft orders
+
+Since version 3.18, Saleor is able to calculate voucher usage in draft orders. To turn on such a behavior, `includeDraftOrderInVoucherUsage` flag for given `Channel` must be set to `true`. Use [channelUpdate](api-reference/channels/mutations/channel-update.mdx) mutation to switch the flag.
+
+When the `includeDraftOrderInVoucherUsage` flag is changed from `false` to `true`, **vouchers will be disconnected from all draft orders.**
+
+When the `includeDraftOrderInVoucherUsage` flag is changed from `true` to `false`, all vouchers will be released. It means:
+
+- multiple-use voucher codes will reduce their usage by one (`VoucherCode.used` field)
+- single-use voucher codes will became active again (`VoucherCode.isActive` field)
+- in case of `applyOncePerCustomer` setting on, the usage will be dissociated from users (`VoucherCustomer` entry)
+
+Voucher code will be also released, after the draft order deletion.
+
+When importing a draft order using [bulkOrderCreate](developer/bulks/bulk-orders.mdx) mutation, the voucher is not validated, therefore code usage will not be counted.
+
 ### Permissions
 
 Managing promotions is available for users and apps with the `MANAGE_DISCOUNTS` permission.


### PR DESCRIPTION
It adds chapter about voucher usage in draft orders.
RFC: https://github.com/saleor/saleor/issues/13713