### PR TITLE
Update CLI docs in `3.x`

### DIFF
--- a/versioned_docs/version-3.x/cli/commands/environment.mdx
+++ b/versioned_docs/version-3.x/cli/commands/environment.mdx
@@ -150,19 +150,20 @@ Positionals:
   name  name for the new environment  [string]
 
 Options:
-      --json             Output the data as JSON  [boolean] [default: false]
-      --short            Output data as text  [boolean] [default: false]
-  -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
-      --project          create this environment in this project  [string]
-      --database         specify how to populate the database  [string]
-      --saleor           specify the Saleor version  [string]
-      --domain           specify the domain for the environment  [string]
-      --login            specify the API Basic Auth login  [string]
-      --pass             specify the API Basic Auth password  [string]
-      --restore-from     specify snapshot id to restore the database from  [string]
-      --skip-restrict    skip Basic Auth restriction prompt  [boolean]
-  -V, --version          Show version number  [boolean]
-  -h, --help             Show help  [boolean]
+      --json                  Output the data as JSON  [boolean] [default: false]
+      --short                 Output data as text  [boolean] [default: false]
+  -u, --instance, --url       Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
+      --project               create this environment in this project  [string]
+      --database              specify how to populate the database  [string]
+      --saleor                specify the Saleor version  [string]
+      --domain                specify the domain for the environment  [string]
+      --login                 specify the API Basic Auth login  [string]
+      --pass                  specify the API Basic Auth password  [string]
+      --restore-from          specify snapshot id to restore the database from  [string]
+      --skip-webhooks-update  use with `restore-from` option, skip webhooks update prompt when restoring from snapshot  [boolean]
+      --skip-restrict         skip Basic Auth restriction prompt  [boolean]
+  -V, --version               Show version number  [boolean]
+  -h, --help                  Show help  [boolean]
 
 Examples:
   saleor env create my-environment

--- a/versioned_docs/version-3.x/cli/commands/storefront.mdx
+++ b/versioned_docs/version-3.x/cli/commands/storefront.mdx
@@ -17,7 +17,6 @@ Create a Next.js Storefront
 
 Commands:
   saleor storefront create [name]  Bootstrap example [name]
-  saleor storefront deploy         Deploy this `react-storefront` to Vercel
 
 Options:
       --json             Output the data as JSON  [boolean] [default: false]
@@ -53,31 +52,4 @@ Options:
   -b, --branch  [string] [default: "canary"]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
-```
-
-#### storefront deploy
-
-```sh
-$ saleor storefront deploy --help
-```
-
-Help output:
-
-```
-saleor storefront deploy
-
-Deploy this `react-storefront` to Vercel
-
-Options:
-      --json             Output the data as JSON  [boolean] [default: false]
-      --short            Output data as text  [boolean] [default: false]
-  -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
-      --dispatch         dispatch deployment and don't wait till it ends  [boolean] [default: false]
-      --github-prompt    specify prompt presence for repository creation on Github  [boolean] [default: "true"]
-  -V, --version          Show version number  [boolean]
-  -h, --help             Show help  [boolean]
-
-Examples:
-  saleor storefront deploy --no-github-prompt
-  saleor storefront deploy --organization=organization-slug --environment=env-id-or-name --no-github-prompt
 ```

--- a/versioned_docs/version-3.x/cli/overview.mdx
+++ b/versioned_docs/version-3.x/cli/overview.mdx
@@ -143,7 +143,6 @@ saleor --version
   - [project show](./commands/project.mdx#project-show)
 - [storefront](./commands/storefront.mdx#storefront)
   - [storefront create](./commands/storefront.mdx#storefront-create)
-  - [storefront deploy](./commands/storefront.mdx#storefront-deploy)
 - [telemetry](./commands/telemetry.mdx#telemetry)
   - [telemetry disable](./commands/telemetry.mdx#telemetry-disable)
   - [telemetry enable](./commands/telemetry.mdx#telemetry-enable)


### PR DESCRIPTION
This PR updates CLI docs in the `3.x` version after CLI v1.39.0 release https://github.com/saleor/cli/releases/tag/1.39.0