### PR TITLE
Add section about releasing funds for abandoned checkouts

### DIFF
--- a/docs/developer/checkout/overview.mdx
+++ b/docs/developer/checkout/overview.mdx
@@ -249,8 +249,66 @@ As a result, we get an updated checkout object with the new checkout email set:
 
 ## Removing old checkouts
 
-To avoid overloading the database, unfinished checkouts are automatically deleted after a specified period from its last modification:
+To avoid overloading the database, unfinished & unpaid checkouts are automatically deleted after a specified period from its last modification:
 
 - anonymous checkouts (neither user nor email is set) after 30 days,
 - user checkouts (either user or email is set) after 90 days,
 - checkouts without lines after 6 hours.
+
+## Releasing funds for abandoned checkouts
+
+:::info
+
+This feature was introduced in **Saleor 3.14**.
+
+:::
+
+:::caution
+
+This feature is in the **Feature Preview** stage, which means that it is available for experimentation and
+feedback. However, it is still undergoing development and is subject to modifications.
+
+:::
+
+:::info
+
+This flow is only related to the checkouts processed with [Saleor App](developer/checkout/finalizing.mdx#finalizing-checkout-with-saleor-app).
+
+:::
+
+The payments for items left in the cart by a customer who did not complete the purchase will be refunded to the customer's account.
+
+Abandoned checkout is the checkout that hasn't been changed in a specific period. The TTL is controlled by the environment variable: [CHECKOUT_TTL_BEFORE_RELEASING_FUNDS](setup/configuration.mdx#checkout_ttl_before_releasing_funds), a default set to 6 hours.
+
+For any [transactionItem](api-reference/payments/objects/transaction-item.mdx) with processed funds (`authorizedAmount` or `chargeAmount`) assigned to abandoned checkout, Saleor will trigger the release action.
+
+The release action is:
+
+- webhook with the event:`TRANSACTION_CANCELATION_REQUESTED` triggered when [transactionItem](api-reference/payments/objects/transaction-item.mdx) contains authorized funds
+- webhook with the event: `TRANSACTION_REFUND_REQUESTED` triggered when [transactionItem](api-reference/payments/objects/transaction-item.mdx) contains charged funds.
+
+Release action is triggered only once. In case of a missing subscription for a release event or failure in processing the action by app. The release action needs to be handled manually.
+
+To fetch paid checkouts, use the below query:
+
+```graphql
+{
+  checkouts(first: 10, filter: { authorizeStatus: [PARTIAL, FULL] }) {
+    edges {
+      node {
+        id
+        authorizeStatus
+        chargeStatus
+        totalPrice {
+          gross {
+            amount
+          }
+        }
+        totalBalance {
+          amount
+        }
+      }
+    }
+  }
+}
+```

--- a/docs/setup/configuration.mdx
+++ b/docs/setup/configuration.mdx
@@ -105,6 +105,10 @@ Redis is recommended.
 
 Default task broker URL. You can read more about configuring this at [Celery Documentation.](https://docs.celeryproject.org/en/stable/userguide/configuration.html#broker-url)
 
+### `CHECKOUT_TTL_BEFORE_RELEASING_FUNDS`
+
+Defines the TTL of checkout before it is marked as abandoned, and assigned funds will be released. Setting related to processing payments with [Saleor App](developer/checkout/finalizing.mdx#finalizing-checkout-with-saleor-app). The value should be a time expression like `5m`, `5 minutes`, `5d`, `5 days`, `1w`, or `1 week`. Defaults to `6 hours`.
+
 ### `DATABASE_URL`
 
 The connection URL to a PostgreSQL database. Defaults to `postgres://saleor:saleor@localhost:5432/saleor`.

--- a/versioned_docs/version-3.x/developer/checkout/overview.mdx
+++ b/versioned_docs/version-3.x/developer/checkout/overview.mdx
@@ -249,8 +249,66 @@ As a result, we get an updated checkout object with the new checkout email set:
 
 ## Removing old checkouts
 
-To avoid overloading the database, unfinished checkouts are automatically deleted after a specified period from its last modification:
+To avoid overloading the database, unfinished & unpaid checkouts are automatically deleted after a specified period from its last modification:
 
 - anonymous checkouts (neither user nor email is set) after 30 days,
 - user checkouts (either user or email is set) after 90 days,
 - checkouts without lines after 6 hours.
+
+## Releasing funds for abandoned checkouts
+
+:::info
+
+This feature was introduced in **Saleor 3.14**.
+
+:::
+
+:::caution
+
+This feature is in the **Feature Preview** stage, which means that it is available for experimentation and
+feedback. However, it is still undergoing development and is subject to modifications.
+
+:::
+
+:::info
+
+This flow is only related to the checkouts processed with [Saleor App](developer/checkout/finalizing.mdx#finalizing-checkout-with-saleor-app).
+
+:::
+
+The payments for items left in the cart by a customer who did not complete the purchase will be refunded to the customer's account.
+
+Abandoned checkout is the checkout that hasn't been changed in a specific period. The TTL is controlled by the environment variable: [CHECKOUT_TTL_BEFORE_RELEASING_FUNDS](setup/configuration.mdx#checkout_ttl_before_releasing_funds), a default set to 6 hours.
+
+For any [transactionItem](api-reference/payments/objects/transaction-item.mdx) with processed funds (`authorizedAmount` or `chargeAmount`) assigned to abandoned checkout, Saleor will trigger the release action.
+
+The release action is:
+
+- webhook with the event:`TRANSACTION_CANCELATION_REQUESTED` triggered when [transactionItem](api-reference/payments/objects/transaction-item.mdx) contains authorized funds
+- webhook with the event: `TRANSACTION_REFUND_REQUESTED` triggered when [transactionItem](api-reference/payments/objects/transaction-item.mdx) contains charged funds.
+
+Release action is triggered only once. In case of a missing subscription for a release event or failure in processing the action by app. The release action needs to be handled manually.
+
+To fetch paid checkouts, use the below query:
+
+```graphql
+{
+  checkouts(first: 10, filter: { authorizeStatus: [PARTIAL, FULL] }) {
+    edges {
+      node {
+        id
+        authorizeStatus
+        chargeStatus
+        totalPrice {
+          gross {
+            amount
+          }
+        }
+        totalBalance {
+          amount
+        }
+      }
+    }
+  }
+}
+```

--- a/versioned_docs/version-3.x/setup/configuration.mdx
+++ b/versioned_docs/version-3.x/setup/configuration.mdx
@@ -105,6 +105,10 @@ Redis is recommended.
 
 Default task broker URL. You can read more about configuring this at [Celery Documentation.](https://docs.celeryproject.org/en/stable/userguide/configuration.html#broker-url)
 
+### `CHECKOUT_TTL_BEFORE_RELEASING_FUNDS`
+
+Defines the TTL of checkout before it is marked as abandoned, and assigned funds will be released. Setting related to processing payments with [Saleor App](developer/checkout/finalizing.mdx#finalizing-checkout-with-saleor-app). The value should be a time expression like `5m`, `5 minutes`, `5d`, `5 days`, `1w`, or `1 week`. Defaults to `6 hours`.
+
 ### `DATABASE_URL`
 
 The connection URL to a PostgreSQL database. Defaults to `postgres://saleor:saleor@localhost:5432/saleor`.


### PR DESCRIPTION
The section that describes how the release of funds works for abandoned checkouts, introduced here: https://github.com/saleor/saleor/pull/14823