### PR TITLE
Remove roadmap links from docs

### DIFF
--- a/docs/developer/app-store/apps/TEMPLATE.mdx
+++ b/docs/developer/app-store/apps/TEMPLATE.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/labels/App%3A%20CRM"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/crm"
 />
 

--- a/docs/developer/app-store/apps/cms.mdx
+++ b/docs/developer/app-store/apps/cms.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/issues?q=is:issue+is:open+label:%22App:+CMS%22"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/cms-v2"
 />
 

--- a/docs/developer/app-store/apps/crm.mdx
+++ b/docs/developer/app-store/apps/crm.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/labels/App%3A%20CRM"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/crm"
 />
 

--- a/docs/developer/app-store/apps/emails-and-messages/overview.mdx
+++ b/docs/developer/app-store/apps/emails-and-messages/overview.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/issues?q=is:issue+is:open+label:%22App:+Emails+%26+Messages%22"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/emails-and-messages"
 />
 

--- a/docs/developer/app-store/apps/invoices.mdx
+++ b/docs/developer/app-store/apps/invoices.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/labels/App%3A%20Invoices"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/invoices"
 />
 

--- a/docs/developer/app-store/apps/search.mdx
+++ b/docs/developer/app-store/apps/search.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/labels/App%3A%20Search"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/search"
 />
 

--- a/docs/developer/app-store/apps/segment.mdx
+++ b/docs/developer/app-store/apps/segment.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.14"
-  roadmapUrl="https://github.com/saleor/apps/labels/App%3A%20Segment"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/segment"
 />
 
@@ -35,13 +34,13 @@ To save app configuration, staff users must have `MANAGE_APPS` permission.
 
 The app uses the following [events](../../../api-reference/webhooks/enums/webhook-event-type-async-enum#values) and maps them to Segment tracking events:
 
-| Saleor Event       | Segment event type |
-| ------------------ | ------------------ |
-| `ORDER_CREATED`    | "Saleor Order Created" |
-| `ORDER_FULLY_PAID` | "Saleor Order Completed"  |
-| `ORDER_REFUNDED`   | "Saleor Order Refunded"   |
-| `ORDER_UPDATED`    | "Saleor Order Updated"    |
-| `ORDER_CANCELLED`  | "Saleor Order Cancelled"  |
+| Saleor Event       | Segment event type       |
+| ------------------ | ------------------------ |
+| `ORDER_CREATED`    | "Saleor Order Created"   |
+| `ORDER_FULLY_PAID` | "Saleor Order Completed" |
+| `ORDER_REFUNDED`   | "Saleor Order Refunded"  |
+| `ORDER_UPDATED`    | "Saleor Order Updated"   |
+| `ORDER_CANCELLED`  | "Saleor Order Cancelled" |
 
 The event will contain properties mapped from the following GraphQL fragment:
 

--- a/docs/developer/app-store/apps/taxes/overview.mdx
+++ b/docs/developer/app-store/apps/taxes/overview.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.9"
-  roadmapUrl="https://github.com/saleor/apps/issues?q=is:open+label:%22App:+Taxes%22"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/taxes"
 />
 

--- a/versioned_docs/version-3.x/developer/app-store/apps/TEMPLATE.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/TEMPLATE.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/labels/App%3A%20CRM"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/crm"
 />
 

--- a/versioned_docs/version-3.x/developer/app-store/apps/cms.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/cms.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/issues?q=is:issue+is:open+label:%22App:+CMS%22"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/cms-v2"
 />
 

--- a/versioned_docs/version-3.x/developer/app-store/apps/crm.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/crm.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/labels/App%3A%20CRM"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/crm"
 />
 

--- a/versioned_docs/version-3.x/developer/app-store/apps/emails-and-messages/overview.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/emails-and-messages/overview.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/issues?q=is:issue+is:open+label:%22App:+Emails+%26+Messages%22"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/emails-and-messages"
 />
 

--- a/versioned_docs/version-3.x/developer/app-store/apps/invoices.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/invoices.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/labels/App%3A%20Invoices"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/invoices"
 />
 

--- a/versioned_docs/version-3.x/developer/app-store/apps/search.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/search.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.10"
-  roadmapUrl="https://github.com/saleor/apps/labels/App%3A%20Search"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/search"
 />
 

--- a/versioned_docs/version-3.x/developer/app-store/apps/segment.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/segment.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.14"
-  roadmapUrl="https://github.com/saleor/apps/labels/App%3A%20Segment"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/segment"
 />
 

--- a/versioned_docs/version-3.x/developer/app-store/apps/taxes/overview.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/taxes/overview.mdx
@@ -7,7 +7,6 @@ import { AppMetadata } from "/components/AppMetadata/AppMetadata.tsx";
 
 <AppMetadata
   minSaleorVersion="3.9"
-  roadmapUrl="https://github.com/saleor/apps/issues?q=is:open+label:%22App:+Taxes%22"
   githubUrl="https://github.com/saleor/apps/tree/main/apps/taxes"
 />
 


### PR DESCRIPTION
We are rebuilding how roadmaps will be exposed. The roadmap links from apps in docs didn't reflect actual plans and were outdated. To avoid confusion, they are removed.

In the future new roadmaps can be linked using the same component