### PR TITLE
Add GTM container to config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -264,6 +264,9 @@ module.exports = {
           },
           sidebarPath: "sidebars.js",
         },
+        googleTagManager: {
+          containerId: "GTM-WC5R92LK",
+        },
         // Google Analytics tracking ID to track page views.
         googleAnalytics: {
           trackingID: "UA-10159761-25",


### PR DESCRIPTION
It adds GTM setup to the config to use a common container among saleor.io subdomains