### PR TITLE
Add docs about TRANSACTION_INITIALIZE_SESSION timeout in Adyen app

### DIFF
--- a/docs/developer/app-store/apps/adyen.mdx
+++ b/docs/developer/app-store/apps/adyen.mdx
@@ -51,7 +51,9 @@ If Adyen surpasses this limit, the App will return a FAILURE status with an appr
 
 ### Maximum timeout for Saleor API calls is 5 seconds
 
-The apps restricts Saleor API response time to 5 seconds for [`TRANSACTION_INITIALIZE_SESSION`](../../../api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#code-style-fontweight-normal-webhookeventtypesyncenumbtransaction_initialize_sessionbcode) sync webhook. If Saleor API surpasses this limit, the App will gracefully continue processing.
+The apps restricts Saleor API response time to 5 seconds for [`TransactionInitializeSession`](../../extending/webhooks/synchronous-events/transaction#initialize-transaction-session) and [`TransactionProcessSession`](../../extending/webhooks/synchronous-events/transaction#process-transaction-session) subscriptions. If Saleor API surpasses this limit, the App will gracefully continue processing.
+
+If such timeout happens, the created [`TransactionItem`](../../../api-reference/payments/objects/transaction-item) will not have the metadata from Adyen on `additionalDetails` object, that include payment method type, credit card brand, etc.
 
 ## Configuration
 

--- a/docs/developer/app-store/apps/adyen.mdx
+++ b/docs/developer/app-store/apps/adyen.mdx
@@ -49,6 +49,10 @@ This section contains known limitations of this App.
 Saleor synchronous webhooks have a maximum response time limit of 20 seconds. The app restricts Adyen response time to 15 seconds to allow graceful error handling.
 If Adyen surpasses this limit, the App will return a FAILURE status with an appropriate error message (Timeout Error).
 
+### Maximum timeout for Saleor API calls is 5 seconds
+
+The apps restricts Saleor API response time to 5 seconds for [`TRANSACTION_INITIALIZE_SESSION`](../../../api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#code-style-fontweight-normal-webhookeventtypesyncenumbtransaction_initialize_sessionbcode) sync webhook. If Saleor API surpasses this limit, the App will gracefully continue processing.
+
 ## Configuration
 
 For Adyen to appear as [available payment gateway](../../checkout/finalizing#listing-available-payment-gateways), you need to [install it in the Saleor Dashboard](../overview#usage). You must obtain the API key from Adyen and paste it into the Adyen App configuration form. Then, a wizard will guide you through the process of configuring the Adyen App, setting up the webhook to receive notifications from Adyen, generating the HMAC key, and adding allowed origins for the Client Key that's used on your Storefront.


### PR DESCRIPTION
This PR adds information about timeout (5s) for `TRANSACTION_INITIALIZE_SESSION` webhook for Adyen app.


Related ticket: https://linear.app/saleor/issue/SHOPX-138/update-documentation-with-new-timeout