### PR TITLE
Update app-sdk guide with schema version field

### DIFF
--- a/docs/developer/extending/apps/developing-apps/app-sdk/api-handlers.mdx
+++ b/docs/developer/extending/apps/developing-apps/app-sdk/api-handlers.mdx
@@ -46,11 +46,14 @@ type CreateManifestHandlerOptions = {
   manifestFactory(context: {
     appBaseUrl: string;
     request: NextApiRequest;
+    schemaVersion: number | null;
   }): AppManifest;
 };
 ```
 
-You can use `NextApiRequest` to read additional parameters from the request. An example use case would be enabling some features based on the Saleor version.
+You can use `NextApiRequest` to read additional parameters from the request.
+
+Field `schemaVersion` can be used to enable some feature based on the Saleor version. It will be `null` if app is being installed in Saleor version below 3.15.0.
 
 See [`createManifestHandler`](https://github.com/saleor/saleor-app-sdk/blob/5c56cf566d2cc6e4a075c8c619f174fa43aad6c9/src/handlers/next/create-manifest-handler.ts#L18) for more details. See [manifest](https://github.com/saleor/saleor-app-sdk/blob/5c56cf566d2cc6e4a075c8c619f174fa43aad6c9/src/types.ts#L223) too.
 

--- a/docs/developer/extending/apps/developing-apps/app-sdk/saleor-webhook.mdx
+++ b/docs/developer/extending/apps/developing-apps/app-sdk/saleor-webhook.mdx
@@ -350,3 +350,33 @@ export const productUpdatedWebhook =
     query: ExampleProductUpdatedSubscription, // Or use plain string
   });
 ```
+
+### Saleor schema version inside context
+
+From version 0.50.0 of `@saleor-sdk` have new field: `schemaVersion` inside context for `createHandler`:
+
+```ts
+export default orderCreatedWebhook.createHandler((req, res, context) => {
+  const { schemaVersion } = context;
+
+  console.log(schemaVersion);
+
+  // End with status 200
+  return res.status(200).end();
+});
+```
+
+This field can be used to enable some feature based on the Saleor version. Before you use it make sure that your subscription have `version` field defined. If not `schemaVersion` will be `null`:
+
+```diff
+subscription {
+  event {
++   version
+    ... on CalculateTaxes {
+      taxBase {
+        currency
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
As we have v0.50.0 with new `schemaVersion` I added docs as well: https://github.com/saleor/app-sdk/releases/tag/v0.50.0