### PR TITLE
Add MacawUI docs

### DIFF
--- a/docs/developer/extending/apps/developing-apps/macaw-ui.mdx
+++ b/docs/developer/extending/apps/developing-apps/macaw-ui.mdx
@@ -1,0 +1,69 @@
+---
+title: MacawUI
+---
+
+You can use Saleor official UI design kit - [MacawUI](https://github.com/saleor/macaw-ui) for creating UI of your apps.
+Visit our [Storybook](https://macaw-ui.vercel.app) to explore token values and component usage.
+
+## Installation and usage
+
+```bash
+npm i @saleor/macaw-ui
+```
+
+You need to import the styles into your app. You can do it in your main entry point, for example `index.tsx`:
+
+```tsx
+import "@saleor/macaw-ui/style";
+```
+
+Next, add the `ThemeProvider` to your app. It will provide the theme to the components:
+
+```tsx
+import { ThemeProvider } from "@saleor/macaw-ui";
+
+const App = () => (
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+);
+```
+
+## Usage with Next.js
+
+If you need to render styles on the server we recommend that you use `getCSSVariables` helper to get the CSS variables that can be injected in `_document.tsx`:
+
+```tsx
+import { getCSSVariables } from "@saleor/macaw-ui";
+import Document, { Head, Html, Main, NextScript } from "next/document";
+
+const css = getCSSVariables("defaultLight"); // or "defaultDark"
+
+export default class AppDocument extends Document {
+  render() {
+    return (
+      <Html style={css}>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+```
+
+## Usage with react-hook-form
+
+You need to wrap the MacawUI component with [Controller](https://react-hook-form.com/docs/usecontroller/controller). For example:
+
+```tsx
+import { Input } from "@saleor/macaw-ui";
+
+<Controller
+  control={control}
+  name="name-input"
+  render={({ field }) => <Input {...field} />}
+/>;
+```

--- a/docs/developer/extending/apps/developing-apps/macaw-ui.mdx
+++ b/docs/developer/extending/apps/developing-apps/macaw-ui.mdx
@@ -2,7 +2,8 @@
 title: MacawUI
 ---
 
-You can use Saleor official UI design kit - [MacawUI](https://github.com/saleor/macaw-ui) for creating UI of your apps.
+Official React UI components kit for Saleor. You can find most of the elements used in the creation of Saleor's dashboard interface and use it to create Saleor Apps. Have a great time working on your projects and empowering your users. If you have any questions, feel free to let us know on GitHub [Discussions](https://github.com/saleor/macaw-ui/discussions).
+
 Visit our [Storybook](https://macaw-ui.vercel.app) to explore token values and component usage.
 
 ## Installation and usage

--- a/sidebars/apps-sidebar.js
+++ b/sidebars/apps-sidebar.js
@@ -47,6 +47,7 @@ module.exports = {
         "developer/extending/apps/developing-apps/app-template",
         "developer/extending/apps/developing-apps/app-examples",
         "developer/extending/apps/developing-apps/troubleshooting",
+        "developer/extending/apps/developing-apps/macaw-ui",
         {
           type: "category",
           label: "Patterns",

--- a/versioned_docs/version-3.x/developer/extending/apps/developing-apps/macaw-ui.mdx
+++ b/versioned_docs/version-3.x/developer/extending/apps/developing-apps/macaw-ui.mdx
@@ -1,0 +1,69 @@
+---
+title: MacawUI
+---
+
+You can use Saleor official UI design kit - [MacawUI](https://github.com/saleor/macaw-ui) for creating UI of your apps.
+Visit our [Storybook](https://macaw-ui.vercel.app) to explore token values and component usage.
+
+## Installation and usage
+
+```bash
+npm i @saleor/macaw-ui
+```
+
+You need to import the styles into your app. You can do it in your main entry point, for example `index.tsx`:
+
+```tsx
+import "@saleor/macaw-ui/style";
+```
+
+Next, add the `ThemeProvider` to your app. It will provide the theme to the components:
+
+```tsx
+import { ThemeProvider } from "@saleor/macaw-ui";
+
+const App = () => (
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+);
+```
+
+## Usage with Next.js
+
+If you need to render styles on the server we recommend that you use `getCSSVariables` helper to get the CSS variables that can be injected in `_document.tsx`:
+
+```tsx
+import { getCSSVariables } from "@saleor/macaw-ui";
+import Document, { Head, Html, Main, NextScript } from "next/document";
+
+const css = getCSSVariables("defaultLight"); // or "defaultDark"
+
+export default class AppDocument extends Document {
+  render() {
+    return (
+      <Html style={css}>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+```
+
+## Usage with react-hook-form
+
+You need to wrap the MacawUI component with [Controller](https://react-hook-form.com/docs/usecontroller/controller). For example:
+
+```tsx
+import { Input } from "@saleor/macaw-ui";
+
+<Controller
+  control={control}
+  name="name-input"
+  render={({ field }) => <Input {...field} />}
+/>;
+```

--- a/versioned_docs/version-3.x/developer/extending/apps/developing-apps/macaw-ui.mdx
+++ b/versioned_docs/version-3.x/developer/extending/apps/developing-apps/macaw-ui.mdx
@@ -2,7 +2,8 @@
 title: MacawUI
 ---
 
-You can use Saleor official UI design kit - [MacawUI](https://github.com/saleor/macaw-ui) for creating UI of your apps.
+Official React UI components kit for Saleor. You can find most of the elements used in the creation of Saleor's dashboard interface and use it to create Saleor Apps. Have a great time working on your projects and empowering your users. If you have any questions, feel free to let us know on GitHub [Discussions](https://github.com/saleor/macaw-ui/discussions).
+
 Visit our [Storybook](https://macaw-ui.vercel.app) to explore token values and component usage.
 
 ## Installation and usage

--- a/versioned_sidebars/version-3.x-sidebars.json
+++ b/versioned_sidebars/version-3.x-sidebars.json
@@ -219,6 +219,7 @@
                 "developer/extending/apps/developing-apps/app-template",
                 "developer/extending/apps/developing-apps/app-examples",
                 "developer/extending/apps/developing-apps/troubleshooting",
+                "developer/extending/apps/developing-apps/macaw-ui",
                 {
                   "type": "category",
                   "label": "Patterns",


### PR DESCRIPTION
Added new guide under:

* https://saleor-docs-git-add-macaw-ui-docs-saleorcommerce.vercel.app/docs/3.x/developer/extending/apps/developing-apps/macaw-ui