### PR TITLE
Delete mention of removing `ORDER_CLOSED` evnet in Adyen app

### DIFF
--- a/docs/developer/app-store/apps/adyen.mdx
+++ b/docs/developer/app-store/apps/adyen.mdx
@@ -94,7 +94,7 @@ In the **Server configuration** section provide URL the Saleor Adyen app has gen
 
 In **Merchant accounts** select **Include only specific merchant accounts** and choose the merchant account you would like to use.
 
-In **Events**, apart from events selected by default, select `EXPIRE`. Deselect `ORDER_CLOSED` and `ORDER_OPENED` events.
+In **Events**, apart from events selected by default, select `EXPIRE`. Deselect `ORDER_OPENED` event.
 
 In **Additional settings -> Risk** select `Include the originalReference for CHARGEBACK_REVERSED events`.
 


### PR DESCRIPTION
This PR removes the mention of removing `ORDER_CLOSED` in Adyen webhook configuration
