### PR TITLE
Restricting Saleor Cloud API access article

### DIFF
--- a/docs/cloud.mdx
+++ b/docs/cloud.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 Saleor is an open-source project which means all of its code is [publicly available](https://github.com/saleor).

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -9,31 +9,25 @@ Below, we explore two ways Saleor Cloud allows you to restrict access to the API
 
 ## Allowed API origins
 
-Most times, the list of the origins you expect to call your API is known in advance. By specifying the allowed origins, you can prevent unauthorized access to your API.
+If the list of the origins you expect to call your API is known in advance, you can automatically reject the unknown ones.
 
-In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all", but you can also specify a list of origins or set it to "Dashboard only".
+In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all" but you can also specify a list of origins or set it to "Dashboard only".
 
 :::info
 
-Changing the settings to only allow the selected origins can affect the installed apps. If you want your app to call the Saleor API from the client, you need to add the app's origin to the list of allowed origins. You can read more about app's access scopes in the [App permissions](developer/extending/apps/architecture/app-permissions.mdx#access-scopes) document.
+Changing the settings to only allow the selected origins can affect the installed apps. If you want your app to call the Saleor API from the client, you need to add the app's origin to the list of allowed origins. You can read more about the app's access scopes in the [App permissions](developer/extending/apps/architecture/app-permissions.mdx#access-scopes) document.
 
 :::
-
-Here is how an example list of allowed origins may look:
-
-- `https://your-storefront.com` - your storefront
-- `https://your-app-1.com` - your first app (if it is calling the Saleor API from the client)
-- `https://your-app-2.com` - your second app (if it is calling the Saleor API from the client)
 
 You don't need to specify the Saleor Cloud dashboard origin, as it is always allowed to call the Saleor API.
 
 ## API Password Protection
 
-Another way to restrict access to your Saleor Cloud instance is to protect it with a password through [Basic Auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). This way, you can ensure that only those who know the credentials can access the API.
+Another way to restrict access to your Saleor Cloud instance is to protect it with a password through [Basic Auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). This way, you can ensure that only those with the credentials can access the API.
 
 :::important
 
-After enabling password protection, users trying to open the Saleor Dashboard will be prompted to enter the Basic Auth username and password, besides their own Saleor Cloud credentials.
+After enabling password protection, users trying to open the Saleor Dashboard will be prompted to enter the Basic Auth username and password besides their own Saleor Cloud credentials.
 
 :::
 
@@ -43,15 +37,11 @@ Combined with a server-side proxy, this can be a powerful tool to obscure the Sa
 
 ### Overview
 
-Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, most checkout actions don't require the user to be authenticated. It is done so by design - you want to allow users to manage their cart without being logged in.
+By default, Saleor exposes some parts of its API publicly, like products catalog or checkout. This behavior doesn't have to align with the requirements of your business. However, Saleor Cloud allows you to restrict access to the API by setting up a Basic Auth.
 
-After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize either the synchronous (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing) or asynchronous (e.g., the [checkout events](/api-reference/webhooks/enums/webhook-event-type-async-enum.mdx#code-style-fontweight-normal-webhookeventtypeasyncenumbcheckout_createdbcode)) webhooks. However, let's assume your use case doesn't fit into the webhooks model. You need to execute the logic "aside" from the Saleor checkout flow.
+Imagine you don't want your products to be publicly accessible. To achieve this, we will create a proxy server that will know the credentials and the API URL and thus be able to access the Saleor API. The only way to get to the Saleor API will be through that proxy server.
 
-By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the [Checkout API](developer/checkout/overview.mdx), the user can just call the API directly and bypass your custom logic.
-
-To prevent this, you can obstruct access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and thus, will be able to access the Saleor API. The only way to get to the Saleor API will be through the proxy server.
-
-Here is how it may look in practice on the example of a simple Next.js application. At the moment, it calls the Saleor API directly:
+Here is how it may look in practice in the example of a simple Next.js application. At the moment, it calls the Saleor API directly:
 
 ### Implementation
 
@@ -65,7 +55,7 @@ In the current implementation, your Next.js application calls the Saleor API dir
 
 :::note
 
-In a production-grade Next.js application, you most likely would use some GraphQL client (like [Apollo Client](https://www.apollographql.com/docs/react/)) to fetch the data from the Saleor API. However, for the sake of simplicity, we will use the native `fetch` API in this example.
+In a production-grade Next.js application, you most likely would use some GraphQL client (like [Apollo Client](https://www.apollographql.com/docs/react/)) to fetch the data from the Saleor API. However, for simplicity, we will use the native `fetch` API in this example.
 
 :::
 
@@ -112,11 +102,9 @@ Our goal is to change the code above as little as possible when introducing the 
 
 #### Step 3: Create a proxy API route
 
-In most cases, you would call the Saleor GraphQL API straight from the React component. However, given that we want to obscure the Saleor API behind a basic auth, we can't just pass the credentials to the client. They would be easily accessible to anyone who inspects the code.
+In most cases, you would call the Saleor GraphQL API straight from the React component. However, given that we want to obscure the Saleor API behind Basic Auth, we can't just pass the credentials to the client. They would be easily accessible to anyone who inspects the code.
 
-Instead, we will create a proxy API route that will know the credentials and the address of our GraphQL endpoint. As long as we don't expose the credentials to the client, we can ensure that our proxy server is the only one that can access the Saleor API directly.
-
-What's more is that inside the API route, we can further execute the custom logic that we needed to introduce in the first place.
+Instead, we will create a proxy API route that will know our GraphQL endpoint's credentials and address. As long as we don't expose the credentials to the client, we are sure that our proxy server is the only one that can access the Saleor API directly.
 
 Here is how the proxy API route may look:
 
@@ -126,8 +114,6 @@ export default async (req, res) => {
   const username = process.env.SALEOR_API_USERNAME; // Take the Basic Auth username from an environment variable
   const password = process.env.SALEOR_API_PASSWORD; // Take the Basic Auth password from an environment variable
   const token = Buffer.from(`${username}:${password}`).toString("base64"); // Encode the credentials to Base64
-
-  // 👉 You can execute the custom logic here 👈
 
   const response = await fetch("https://your-store.saleor.cloud/graphql", {
     method: "POST",
@@ -166,4 +152,4 @@ async function getProducts() {
 
 #### Further considerations
 
-This is a simple example of how you can use a proxy server to obscure the Saleor API behind a basic auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.
+That was a simple example of using a proxy server to obscure the Saleor API behind a basic auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -49,6 +49,14 @@ Imagine you don't want your products to be publicly accessible. To achieve this,
 
 Here is how it may look in practice in the example of a simple Next.js application. At the moment, it calls the Saleor API directly:
 
+:::info
+
+Next.js gives you the ability to create [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes), which are server-side endpoints that must be created in the `pages/api` directory.
+
+While we chose to use Next.js in this example, you can use any server-side technology to create the proxy server.
+
+:::
+
 ### Implementation
 
 #### Step 1: Protect the Saleor API with a password
@@ -112,7 +120,7 @@ In most cases, you would call the Saleor GraphQL API straight from the React com
 
 Instead, we will create a proxy API route that will know our GraphQL endpoint's credentials and address. As long as we don't expose the credentials to the client, we are sure that our proxy server is the only one that can access the Saleor API directly.
 
-Here is how the proxy API route may look:
+Here is what the proxy API route may look like:
 
 ```jsx
 // pages/api/saleor.js

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -165,7 +165,3 @@ async function getProducts() {
   // ...
 }
 ```
-
-#### Further considerations
-
-That was a simple example of using a proxy server to obscure the Saleor API behind Basic Auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -19,21 +19,21 @@ Another way to restrict access to your Saleor Cloud instance is to protect it wi
 
 :::important
 
-The users trying to open the Saleor Dashboard will be prompted to enter the username and password as well.
+Users trying to open the Saleor Dashboard will be prompted to enter their username and password.
 
 :::
 
-## Example: Password protected API proxy
+## Example: Password-protected API proxy
 
 ### Overview
 
 Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, some checkout actions don't require an authenticated user. It is done so by design - you want to allow users to add items to their cart without being logged in.
 
-After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize the synchronous webhooks executed during the checkout (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing). However, for some reason, your use-case doesn't fit into the synchronous webhooks model. You need to execute it "aside" from the Saleor checkout flow.
+After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize the synchronous webhooks executed during the checkout (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing). However, for some reason, your use case doesn't fit into the synchronous webhooks model. You need to execute it "aside" from the Saleor checkout flow.
 
 By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the [Checkout API](developer/checkout/overview.mdx), the user can just call the API directly and bypass your custom logic.
 
-To prevent this, you can obstruct the access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
+To prevent this, you can obstruct access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
 
 Here is how it may look in practice on the example of a simple Next.js Apollo application that used to call the Saleor API directly:
 
@@ -75,13 +75,13 @@ async function getProducts() {
 }
 ```
 
-Our goal is to change as little as possible in the code above when introducing the proxy server.
+Our goal is to change the code above as little as possible when introducing the proxy server.
 
 #### Step 3: Create a proxy API route
 
 In most cases, you would call the Saleor GraphQL API straight from the React component. However, given that we want to obscure the Saleor API behind a basic auth, we can't just pass the credentials to the client. They would be easily accessible to anyone who inspects the code.
 
-Instead, we will create a proxy API route that will know the credentials and the address and will be able to access the Saleor API. This way, we can ensure that only our proxy server can access the Saleor API.
+Instead, we will create a proxy API route that will know the credentials and the address and allow access to the Saleor API. This way, we can ensure that only our proxy server can access the Saleor API.
 
 Inside the API route, we can further execute the custom logic that we need to introduce.
 
@@ -129,7 +129,5 @@ async function getProducts() {
   // ...
 }
 ```
-
-TODO: check if it works or do you need more for an endpoint to be GraphQL endpoint
 
 #### Further considerations

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -1,0 +1,123 @@
+---
+title: Restricting API access
+sidebar_position: 2
+---
+
+Even though Saleor [implements complex authorization and authentication](/api-usage/authentication.mdx) mechanisms, you might want to restrict access to the API for specific use cases.
+
+Below, we explore two ways Saleor Cloud allows you to restrict access to the API, as well as a practical example of how to use them.
+
+## Allowed API origins
+
+Most times, the list of the origins you expect to call your API is known in advance (and it includes your storefronts). By specifying the allowed origins, you can prevent unauthorized access to your API.
+
+In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all", but you can also specify a list of origins or set it to "Dashboard only".
+
+## API Password Protection
+
+TODO
+
+## Example: Password protected API proxy
+
+### Overview
+
+Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, creating and managing a checkout doesn't require an authenticated user. It is done so by design - you want to allow users to add items to their cart without being logged in.
+
+After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize the synchronous webhooks executed during the checkout (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing). However, for some reason, your use-case doesn't fit into the synchronous webhooks model. You need to execute it "aside" from the Saleor checkout flow.
+
+By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the Checkout API, the user can just call the API directly and bypass your custom logic.
+
+To prevent this, you can obstruct the access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the password and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
+
+Here is how it may look in practice on the example of a simple Next.js Apollo application that used to call the Saleor API directly:
+
+### Implementation
+
+#### Step 1: Protect the Saleor API with a password
+
+Set up "API Password Protection" in the Saleor Cloud dashboard as described above.
+
+#### Step 2: Visit your current implementation
+
+In the current implementation, your Next.js application directly calls the Saleor API through an Apollo GraphQL client.
+
+The queries may look like this:
+
+```jsx
+import { ApolloClient, InMemoryCache, gql, useQuery } from "@apollo/client";
+
+const client = new ApolloClient({
+  uri: "https://your-store.saleor.cloud/graphql/", // Calling the Saleor API directly
+  cache: new InMemoryCache(),
+});
+
+const GET_PRODUCTS = gql`
+  query GetProducts {
+    products(first: 10) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`;
+
+const Home = ({ products }) => {
+  const { data, loading, error } = useQuery(GET_PRODUCTS);
+
+  return (
+    <div>
+      <h1>Products</h1>
+      <ul>
+        {products.map((product) => (
+          <li key={product.id}>{product.id}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+```
+
+Our goal is to change as little as possible in the code above when introducing the proxy server.
+
+#### Step 3: Create a proxy API route
+
+```jsx
+// pages/api/saleor.js
+
+import { ApolloClient, InMemoryCache, gql } from "@apollo/client";
+
+export default async (req, res) => {
+  const username = process.env.SALEOR_API_USERNAME; // Using the Basic Auth username
+  const password = process.env.SALEOR_API_PASSWORD; // Using the Basic Auth password
+  const token = Buffer.from(`${username}:${password}`).toString("base64");
+
+  const client = new ApolloClient({
+    uri: "https://your-store.saleor.cloud/graphql/",
+    cache: new InMemoryCache(),
+    headers: {
+      Authorization: `Basic ${token}`, // Using the Basic Auth header to authenticate the Saleor API
+    },
+  });
+
+  const { data } = await client.query({
+    query: gql`
+      # Read the query from the request body
+    `,
+  });
+
+  res.status(200).json(data);
+};
+```
+
+#### Step 4: Update the Next.js application to use the proxy
+
+```jsx
+import { ApolloClient, InMemoryCache, gql, useQuery } from "@apollo/client";
+
+const client = new ApolloClient({
+  uri: "/api/saleor", // Calling the proxy server
+  cache: new InMemoryCache(),
+});
+```

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -43,7 +43,7 @@ Combined with a server-side proxy, this can be a useful tool to obscure the Sale
 
 ### Overview
 
-By default, Saleor exposes some parts of its API publicly, like products catalog or checkout. This behavior doesn't have to align with the requirements of your business. However, Saleor Cloud allows you to restrict access to the API by setting up a Basic Auth.
+By default, Saleor exposes some parts of its API publicly, like product catalog or checkout. This behavior doesn't have to align with the requirements of your business. However, Saleor Cloud allows you to restrict access to the API by setting up a Basic Auth.
 
 Imagine you don't want your products to be publicly accessible. To achieve this, we will create a proxy server that will know the credentials and the API URL and thus be able to access the Saleor API. The only way to get to the Saleor API will be through that proxy server.
 

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -31,7 +31,7 @@ After enabling password protection, users trying to open the Saleor Dashboard wi
 
 :::
 
-Combined with a server-side proxy, this can be a powerful tool to obscure the Saleor API from unauthorized access. We will explore this in more detail in the example below.
+Combined with a server-side proxy, this can be a useful tool to obscure the Saleor API from unauthorized access. We will explore this in more detail in the example below.
 
 ## Example: Password-protected API proxy
 
@@ -152,4 +152,4 @@ async function getProducts() {
 
 #### Further considerations
 
-That was a simple example of using a proxy server to obscure the Saleor API behind a basic auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.
+That was a simple example of using a proxy server to obscure the Saleor API behind Basic Auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -5,13 +5,27 @@ sidebar_position: 2
 
 Even though Saleor [implements complex authorization and authentication](/api-usage/authentication.mdx) mechanisms, you might want to restrict access to your Saleor Cloud instance for specific use cases.
 
-Below, we explore two ways Saleor Cloud allows you to restrict access to the API, as well as a practical example of how to use them.
+Below, we explore two ways Saleor Cloud allows you to restrict access to the API, as well as a practical example of how to use one of them.
 
 ## Allowed API origins
 
-Most times, the list of the origins you expect to call your API is known in advance (and it includes your storefront/-s). By specifying the allowed origins, you can prevent unauthorized access to your API.
+Most times, the list of the origins you expect to call your API is known in advance. By specifying the allowed origins, you can prevent unauthorized access to your API.
 
 In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all", but you can also specify a list of origins or set it to "Dashboard only".
+
+:::info
+
+Changing the settings to only allow the selected origins can affect the installed apps. If you want your app to call the Saleor API from the client, you need to add the app's origin to the list of allowed origins. You can read more about app's access scopes in the [App permissions](developer/extending/apps/architecture/app-permissions.mdx#access-scopes) document.
+
+:::
+
+Here is how an example list of allowed origins may look:
+
+- `https://your-storefront.com` - your storefront
+- `https://your-app-1.com` - your first app (if it is calling the Saleor API from the client)
+- `https://your-app-2.com` - your second app (if it is calling the Saleor API from the client)
+
+You don't need to specify the Saleor Cloud dashboard origin, as it is always allowed to call the Saleor API.
 
 ## API Password Protection
 
@@ -19,23 +33,25 @@ Another way to restrict access to your Saleor Cloud instance is to protect it wi
 
 :::important
 
-Users trying to open the Saleor Dashboard will be prompted to enter their username and password.
+After enabling password protection, users trying to open the Saleor Dashboard will be prompted to enter the Basic Auth username and password, besides their own Saleor Cloud credentials.
 
 :::
+
+Combined with a server-side proxy, this can be a powerful tool to obscure the Saleor API from unauthorized access. We will explore this in more detail in the example below.
 
 ## Example: Password-protected API proxy
 
 ### Overview
 
-Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, some checkout actions don't require an authenticated user. It is done so by design - you want to allow users to add items to their cart without being logged in.
+Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, most checkout actions don't require the user to be authenticated. It is done so by design - you want to allow users to manage their cart without being logged in.
 
-After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize the synchronous webhooks executed during the checkout (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing). However, for some reason, your use case doesn't fit into the synchronous webhooks model. You need to execute it "aside" from the Saleor checkout flow.
+After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize either the synchronous (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing) or asynchronous (e.g., the [checkout events](/api-reference/webhooks/enums/webhook-event-type-async-enum.mdx#code-style-fontweight-normal-webhookeventtypeasyncenumbcheckout_createdbcode)) webhooks. However, let's assume your use case doesn't fit into the webhooks model. You need to execute the logic "aside" from the Saleor checkout flow.
 
 By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the [Checkout API](developer/checkout/overview.mdx), the user can just call the API directly and bypass your custom logic.
 
-To prevent this, you can obstruct access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
+To prevent this, you can obstruct access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and thus, will be able to access the Saleor API. The only way to get to the Saleor API will be through the proxy server.
 
-Here is how it may look in practice on the example of a simple Next.js Apollo application that used to call the Saleor API directly:
+Here is how it may look in practice on the example of a simple Next.js application. At the moment, it calls the Saleor API directly:
 
 ### Implementation
 
@@ -47,14 +63,21 @@ Set up "API Password Protection" in the Saleor Cloud dashboard as [described abo
 
 In the current implementation, your Next.js application calls the Saleor API directly:
 
+:::note
+
+In a production-grade Next.js application, you most likely would use some GraphQL client (like [Apollo Client](https://www.apollographql.com/docs/react/)) to fetch the data from the Saleor API. However, for the sake of simplicity, we will use the native `fetch` API in this example.
+
+:::
+
 ```jsx
 async function getProducts() {
-  const response = await fetch("https://your-store.saleor.cloud/graphql", {
+  const response = await fetch("https://your-store.saleor.cloud/graphql", { // The URL of your Saleor instance
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
+      // The GraphQL query you want to execute
       query: `
           query GetProducts {
             products(first: 10) {
@@ -71,7 +94,17 @@ async function getProducts() {
 
   const data = await response.json();
 
-  return data;
+  // ...
+}
+
+const ProductList = () => {
+    useEffect(() => {
+        getProducts();
+    }, []);
+
+    return (
+        // ...
+    );
 }
 ```
 
@@ -81,9 +114,9 @@ Our goal is to change the code above as little as possible when introducing the 
 
 In most cases, you would call the Saleor GraphQL API straight from the React component. However, given that we want to obscure the Saleor API behind a basic auth, we can't just pass the credentials to the client. They would be easily accessible to anyone who inspects the code.
 
-Instead, we will create a proxy API route that will know the credentials and the address and allow access to the Saleor API. This way, we can ensure that only our proxy server can access the Saleor API.
+Instead, we will create a proxy API route that will know the credentials and the address of our GraphQL endpoint. As long as we don't expose the credentials to the client, we can ensure that our proxy server is the only one that can access the Saleor API directly.
 
-Inside the API route, we can further execute the custom logic that we need to introduce.
+What's more is that inside the API route, we can further execute the custom logic that we needed to introduce in the first place.
 
 Here is how the proxy API route may look:
 
@@ -94,7 +127,8 @@ export default async (req, res) => {
   const password = process.env.SALEOR_API_PASSWORD; // Take the Basic Auth password from an environment variable
   const token = Buffer.from(`${username}:${password}`).toString("base64"); // Encode the credentials to Base64
 
-  // You can execute the custom logic here
+  // 👉 You can execute the custom logic here 👈
+
   const response = await fetch("https://your-store.saleor.cloud/graphql", {
     method: "POST",
     headers: {
@@ -131,3 +165,5 @@ async function getProducts() {
 ```
 
 #### Further considerations
+
+This is a simple example of how you can use a proxy server to obscure the Saleor API behind a basic auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -3,31 +3,37 @@ title: Restricting API access
 sidebar_position: 2
 ---
 
-Even though Saleor [implements complex authorization and authentication](/api-usage/authentication.mdx) mechanisms, you might want to restrict access to the API for specific use cases.
+Even though Saleor [implements complex authorization and authentication](/api-usage/authentication.mdx) mechanisms, you might want to restrict access to your Saleor Cloud instance for specific use cases.
 
 Below, we explore two ways Saleor Cloud allows you to restrict access to the API, as well as a practical example of how to use them.
 
 ## Allowed API origins
 
-Most times, the list of the origins you expect to call your API is known in advance (and it includes your storefronts). By specifying the allowed origins, you can prevent unauthorized access to your API.
+Most times, the list of the origins you expect to call your API is known in advance (and it includes your storefront/-s). By specifying the allowed origins, you can prevent unauthorized access to your API.
 
 In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all", but you can also specify a list of origins or set it to "Dashboard only".
 
 ## API Password Protection
 
-TODO
+Another way to restrict access to your Saleor Cloud instance is to protect it with a password through [Basic Auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). This way, you can ensure that only those who know the credentials can access the API.
+
+:::important
+
+The users trying to open the Saleor Dashboard will be prompted to enter the username and password as well.
+
+:::
 
 ## Example: Password protected API proxy
 
 ### Overview
 
-Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, creating and managing a checkout doesn't require an authenticated user. It is done so by design - you want to allow users to add items to their cart without being logged in.
+Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, some checkout actions don't require an authenticated user. It is done so by design - you want to allow users to add items to their cart without being logged in.
 
 After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize the synchronous webhooks executed during the checkout (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing). However, for some reason, your use-case doesn't fit into the synchronous webhooks model. You need to execute it "aside" from the Saleor checkout flow.
 
-By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the Checkout API, the user can just call the API directly and bypass your custom logic.
+By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the [Checkout API](developer/checkout/overview.mdx), the user can just call the API directly and bypass your custom logic.
 
-To prevent this, you can obstruct the access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the password and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
+To prevent this, you can obstruct the access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
 
 Here is how it may look in practice on the example of a simple Next.js Apollo application that used to call the Saleor API directly:
 
@@ -35,76 +41,71 @@ Here is how it may look in practice on the example of a simple Next.js Apollo ap
 
 #### Step 1: Protect the Saleor API with a password
 
-Set up "API Password Protection" in the Saleor Cloud dashboard as described above.
+Set up "API Password Protection" in the Saleor Cloud dashboard as [described above](#api-password-protection).
 
 #### Step 2: Visit your current implementation
 
-In the current implementation, your Next.js application directly calls the Saleor API through an Apollo GraphQL client.
-
-The queries may look like this:
+In the current implementation, your Next.js application calls the Saleor API directly:
 
 ```jsx
-import { ApolloClient, InMemoryCache, gql, useQuery } from "@apollo/client";
+async function getProducts() {
+  const response = await fetch("https://your-store.saleor.cloud/graphql", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: `
+          query GetProducts {
+            products(first: 10) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+      `,
+    }),
+  });
 
-const client = new ApolloClient({
-  uri: "https://your-store.saleor.cloud/graphql/", // Calling the Saleor API directly
-  cache: new InMemoryCache(),
-});
+  const data = await response.json();
 
-const GET_PRODUCTS = gql`
-  query GetProducts {
-    products(first: 10) {
-      edges {
-        node {
-          id
-        }
-      }
-    }
-  }
-`;
-
-const Home = ({ products }) => {
-  const { data, loading, error } = useQuery(GET_PRODUCTS);
-
-  return (
-    <div>
-      <h1>Products</h1>
-      <ul>
-        {products.map((product) => (
-          <li key={product.id}>{product.id}</li>
-        ))}
-      </ul>
-    </div>
-  );
-};
+  return data;
+}
 ```
 
 Our goal is to change as little as possible in the code above when introducing the proxy server.
 
 #### Step 3: Create a proxy API route
 
+In most cases, you would call the Saleor GraphQL API straight from the React component. However, given that we want to obscure the Saleor API behind a basic auth, we can't just pass the credentials to the client. They would be easily accessible to anyone who inspects the code.
+
+Instead, we will create a proxy API route that will know the credentials and the address and will be able to access the Saleor API. This way, we can ensure that only our proxy server can access the Saleor API.
+
+Inside the API route, we can further execute the custom logic that we need to introduce.
+
+Here is how the proxy API route may look:
+
 ```jsx
 // pages/api/saleor.js
-
-import { ApolloClient, InMemoryCache, gql } from "@apollo/client";
-
 export default async (req, res) => {
-  const username = process.env.SALEOR_API_USERNAME; // Using the Basic Auth username
-  const password = process.env.SALEOR_API_PASSWORD; // Using the Basic Auth password
-  const token = Buffer.from(`${username}:${password}`).toString("base64");
+  const username = process.env.SALEOR_API_USERNAME; // Take the Basic Auth username from an environment variable
+  const password = process.env.SALEOR_API_PASSWORD; // Take the Basic Auth password from an environment variable
+  const token = Buffer.from(`${username}:${password}`).toString("base64"); // Encode the credentials to Base64
 
-  const client = new ApolloClient({
-    uri: "https://your-store.saleor.cloud/graphql/",
-    cache: new InMemoryCache(),
+  // You can execute the custom logic here
+  const response = await fetch("https://your-store.saleor.cloud/graphql", {
+    method: "POST",
     headers: {
+      "Content-Type": "application/json",
       Authorization: `Basic ${token}`, // Using the Basic Auth header to authenticate the Saleor API
     },
-  });
-
-  const { data } = await client.query({
-    query: gql`
-      # Read the query from the request body
-    `,
+    body: JSON.stringify({
+      query: `
+        // Read the query from the request body
+      `,
+    }),
   });
 
   res.status(200).json(data);
@@ -113,11 +114,22 @@ export default async (req, res) => {
 
 #### Step 4: Update the Next.js application to use the proxy
 
-```jsx
-import { ApolloClient, InMemoryCache, gql, useQuery } from "@apollo/client";
+Our last step will be to update the Next.js application to use the proxy server instead of calling the Saleor API directly:
 
-const client = new ApolloClient({
-  uri: "/api/saleor", // Calling the proxy server
-  cache: new InMemoryCache(),
-});
+```jsx
+async function getProducts() {
+  // highlight-next-line
+  const response = await fetch("/api/saleor", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    // ...
+  });
+  // ...
+}
 ```
+
+TODO: check if it works or do you need more for an endpoint to be GraphQL endpoint
+
+#### Further considerations

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -148,7 +148,7 @@ export default async (req, res) => {
 
 #### Step 4: Update the Next.js application to use the proxy
 
-Our last step will be to update the Next.js application to use the proxy server instead of calling the Saleor API directly:
+Our last step will be to update the client-side code to fetch products via the route we just implemented:
 
 ```jsx
 async function getProducts() {

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -11,11 +11,17 @@ Below, we explore two ways Saleor Cloud allows you to restrict access to the API
 
 If the list of the origins you expect to call your API is known in advance, you can automatically reject the unknown ones.
 
-In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all" but you can also specify a list of origins or set it to "Dashboard only".
+In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow All" but you can also specify a list of origins or set it to "Dashboard only".
+
+:::warning
+
+We don't recommend using the "Allow All" setting on production environments. It's a good practice to restrict the access to the API to only the origins you expect.
+
+:::
 
 :::info
 
-Changing the settings to only allow the selected origins can affect the installed apps. If you want your app to call the Saleor API from the client, you need to add the app's origin to the list of allowed origins. You can read more about the app's access scopes in the [App permissions](developer/extending/apps/architecture/app-permissions.mdx#access-scopes) document.
+Changing the settings to only allow the selected origins can affect the installed apps. If you want your app to **call the Saleor API from the client**, you need to add the app's origin to the list of allowed origins. You can read more about the app's access scopes in the [App permissions](developer/extending/apps/architecture/app-permissions.mdx#access-scopes) document.
 
 :::
 

--- a/docs/restricting-api-access.mdx
+++ b/docs/restricting-api-access.mdx
@@ -138,8 +138,10 @@ Our last step will be to update the Next.js application to use the proxy server 
 
 ```jsx
 async function getProducts() {
-  // highlight-next-line
+  // highlight-start
+  // Using the proxy API route instead of the Saleor API directly
   const response = await fetch("/api/saleor", {
+    // highlight-end
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/sidebars.js
+++ b/sidebars.js
@@ -81,7 +81,7 @@ module.exports = {
     {
       type: "category",
       label: "Saleor Cloud",
-      items: ["cloud"],
+      items: ["cloud", "restricting-api-access"],
     },
     {
       type: "category",

--- a/versioned_docs/version-3.x/cloud.mdx
+++ b/versioned_docs/version-3.x/cloud.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 Saleor is an open-source project which means all of its code is [publicly available](https://github.com/saleor).

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -9,31 +9,25 @@ Below, we explore two ways Saleor Cloud allows you to restrict access to the API
 
 ## Allowed API origins
 
-Most times, the list of the origins you expect to call your API is known in advance. By specifying the allowed origins, you can prevent unauthorized access to your API.
+If the list of the origins you expect to call your API is known in advance, you can automatically reject the unknown ones.
 
-In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all", but you can also specify a list of origins or set it to "Dashboard only".
+In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all" but you can also specify a list of origins or set it to "Dashboard only".
 
 :::info
 
-Changing the settings to only allow the selected origins can affect the installed apps. If you want your app to call the Saleor API from the client, you need to add the app's origin to the list of allowed origins. You can read more about app's access scopes in the [App permissions](developer/extending/apps/architecture/app-permissions.mdx#access-scopes) document.
+Changing the settings to only allow the selected origins can affect the installed apps. If you want your app to call the Saleor API from the client, you need to add the app's origin to the list of allowed origins. You can read more about the app's access scopes in the [App permissions](developer/extending/apps/architecture/app-permissions.mdx#access-scopes) document.
 
 :::
-
-Here is how an example list of allowed origins may look:
-
-- `https://your-storefront.com` - your storefront
-- `https://your-app-1.com` - your first app (if it is calling the Saleor API from the client)
-- `https://your-app-2.com` - your second app (if it is calling the Saleor API from the client)
 
 You don't need to specify the Saleor Cloud dashboard origin, as it is always allowed to call the Saleor API.
 
 ## API Password Protection
 
-Another way to restrict access to your Saleor Cloud instance is to protect it with a password through [Basic Auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). This way, you can ensure that only those who know the credentials can access the API.
+Another way to restrict access to your Saleor Cloud instance is to protect it with a password through [Basic Auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). This way, you can ensure that only those with the credentials can access the API.
 
 :::important
 
-After enabling password protection, users trying to open the Saleor Dashboard will be prompted to enter the Basic Auth username and password, besides their own Saleor Cloud credentials.
+After enabling password protection, users trying to open the Saleor Dashboard will be prompted to enter the Basic Auth username and password besides their own Saleor Cloud credentials.
 
 :::
 
@@ -43,15 +37,11 @@ Combined with a server-side proxy, this can be a powerful tool to obscure the Sa
 
 ### Overview
 
-Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, most checkout actions don't require the user to be authenticated. It is done so by design - you want to allow users to manage their cart without being logged in.
+By default, Saleor exposes some parts of its API publicly, like products catalog or checkout. This behavior doesn't have to align with the requirements of your business. However, Saleor Cloud allows you to restrict access to the API by setting up a Basic Auth.
 
-After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize either the synchronous (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing) or asynchronous (e.g., the [checkout events](/api-reference/webhooks/enums/webhook-event-type-async-enum.mdx#code-style-fontweight-normal-webhookeventtypeasyncenumbcheckout_createdbcode)) webhooks. However, let's assume your use case doesn't fit into the webhooks model. You need to execute the logic "aside" from the Saleor checkout flow.
+Imagine you don't want your products to be publicly accessible. To achieve this, we will create a proxy server that will know the credentials and the API URL and thus be able to access the Saleor API. The only way to get to the Saleor API will be through that proxy server.
 
-By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the [Checkout API](developer/checkout/overview.mdx), the user can just call the API directly and bypass your custom logic.
-
-To prevent this, you can obstruct access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and thus, will be able to access the Saleor API. The only way to get to the Saleor API will be through the proxy server.
-
-Here is how it may look in practice on the example of a simple Next.js application. At the moment, it calls the Saleor API directly:
+Here is how it may look in practice in the example of a simple Next.js application. At the moment, it calls the Saleor API directly:
 
 ### Implementation
 
@@ -65,7 +55,7 @@ In the current implementation, your Next.js application calls the Saleor API dir
 
 :::note
 
-In a production-grade Next.js application, you most likely would use some GraphQL client (like [Apollo Client](https://www.apollographql.com/docs/react/)) to fetch the data from the Saleor API. However, for the sake of simplicity, we will use the native `fetch` API in this example.
+In a production-grade Next.js application, you most likely would use some GraphQL client (like [Apollo Client](https://www.apollographql.com/docs/react/)) to fetch the data from the Saleor API. However, for simplicity, we will use the native `fetch` API in this example.
 
 :::
 
@@ -112,11 +102,9 @@ Our goal is to change the code above as little as possible when introducing the 
 
 #### Step 3: Create a proxy API route
 
-In most cases, you would call the Saleor GraphQL API straight from the React component. However, given that we want to obscure the Saleor API behind a basic auth, we can't just pass the credentials to the client. They would be easily accessible to anyone who inspects the code.
+In most cases, you would call the Saleor GraphQL API straight from the React component. However, given that we want to obscure the Saleor API behind Basic Auth, we can't just pass the credentials to the client. They would be easily accessible to anyone who inspects the code.
 
-Instead, we will create a proxy API route that will know the credentials and the address of our GraphQL endpoint. As long as we don't expose the credentials to the client, we can ensure that our proxy server is the only one that can access the Saleor API directly.
-
-What's more is that inside the API route, we can further execute the custom logic that we needed to introduce in the first place.
+Instead, we will create a proxy API route that will know our GraphQL endpoint's credentials and address. As long as we don't expose the credentials to the client, we are sure that our proxy server is the only one that can access the Saleor API directly.
 
 Here is how the proxy API route may look:
 
@@ -126,8 +114,6 @@ export default async (req, res) => {
   const username = process.env.SALEOR_API_USERNAME; // Take the Basic Auth username from an environment variable
   const password = process.env.SALEOR_API_PASSWORD; // Take the Basic Auth password from an environment variable
   const token = Buffer.from(`${username}:${password}`).toString("base64"); // Encode the credentials to Base64
-
-  // 👉 You can execute the custom logic here 👈
 
   const response = await fetch("https://your-store.saleor.cloud/graphql", {
     method: "POST",
@@ -166,4 +152,4 @@ async function getProducts() {
 
 #### Further considerations
 
-This is a simple example of how you can use a proxy server to obscure the Saleor API behind a basic auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.
+That was a simple example of using a proxy server to obscure the Saleor API behind a basic auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -49,6 +49,14 @@ Imagine you don't want your products to be publicly accessible. To achieve this,
 
 Here is how it may look in practice in the example of a simple Next.js application. At the moment, it calls the Saleor API directly:
 
+:::info
+
+Next.js gives you the ability to create [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes), which are server-side endpoints that must be created in the `pages/api` directory.
+
+While we chose to use Next.js in this example, you can use any server-side technology to create the proxy server.
+
+:::
+
 ### Implementation
 
 #### Step 1: Protect the Saleor API with a password
@@ -112,7 +120,7 @@ In most cases, you would call the Saleor GraphQL API straight from the React com
 
 Instead, we will create a proxy API route that will know our GraphQL endpoint's credentials and address. As long as we don't expose the credentials to the client, we are sure that our proxy server is the only one that can access the Saleor API directly.
 
-Here is how the proxy API route may look:
+Here is what the proxy API route may look like:
 
 ```jsx
 // pages/api/saleor.js

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -165,7 +165,3 @@ async function getProducts() {
   // ...
 }
 ```
-
-#### Further considerations
-
-That was a simple example of using a proxy server to obscure the Saleor API behind Basic Auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -19,21 +19,21 @@ Another way to restrict access to your Saleor Cloud instance is to protect it wi
 
 :::important
 
-The users trying to open the Saleor Dashboard will be prompted to enter the username and password as well.
+Users trying to open the Saleor Dashboard will be prompted to enter their username and password.
 
 :::
 
-## Example: Password protected API proxy
+## Example: Password-protected API proxy
 
 ### Overview
 
 Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, some checkout actions don't require an authenticated user. It is done so by design - you want to allow users to add items to their cart without being logged in.
 
-After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize the synchronous webhooks executed during the checkout (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing). However, for some reason, your use-case doesn't fit into the synchronous webhooks model. You need to execute it "aside" from the Saleor checkout flow.
+After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize the synchronous webhooks executed during the checkout (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing). However, for some reason, your use case doesn't fit into the synchronous webhooks model. You need to execute it "aside" from the Saleor checkout flow.
 
 By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the [Checkout API](developer/checkout/overview.mdx), the user can just call the API directly and bypass your custom logic.
 
-To prevent this, you can obstruct the access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
+To prevent this, you can obstruct access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
 
 Here is how it may look in practice on the example of a simple Next.js Apollo application that used to call the Saleor API directly:
 
@@ -75,13 +75,13 @@ async function getProducts() {
 }
 ```
 
-Our goal is to change as little as possible in the code above when introducing the proxy server.
+Our goal is to change the code above as little as possible when introducing the proxy server.
 
 #### Step 3: Create a proxy API route
 
 In most cases, you would call the Saleor GraphQL API straight from the React component. However, given that we want to obscure the Saleor API behind a basic auth, we can't just pass the credentials to the client. They would be easily accessible to anyone who inspects the code.
 
-Instead, we will create a proxy API route that will know the credentials and the address and will be able to access the Saleor API. This way, we can ensure that only our proxy server can access the Saleor API.
+Instead, we will create a proxy API route that will know the credentials and the address and allow access to the Saleor API. This way, we can ensure that only our proxy server can access the Saleor API.
 
 Inside the API route, we can further execute the custom logic that we need to introduce.
 
@@ -129,7 +129,5 @@ async function getProducts() {
   // ...
 }
 ```
-
-TODO: check if it works or do you need more for an endpoint to be GraphQL endpoint
 
 #### Further considerations

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -1,0 +1,123 @@
+---
+title: Restricting API access
+sidebar_position: 2
+---
+
+Even though Saleor [implements complex authorization and authentication](/api-usage/authentication.mdx) mechanisms, you might want to restrict access to the API for specific use cases.
+
+Below, we explore two ways Saleor Cloud allows you to restrict access to the API, as well as a practical example of how to use them.
+
+## Allowed API origins
+
+Most times, the list of the origins you expect to call your API is known in advance (and it includes your storefronts). By specifying the allowed origins, you can prevent unauthorized access to your API.
+
+In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all", but you can also specify a list of origins or set it to "Dashboard only".
+
+## API Password Protection
+
+TODO
+
+## Example: Password protected API proxy
+
+### Overview
+
+Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, creating and managing a checkout doesn't require an authenticated user. It is done so by design - you want to allow users to add items to their cart without being logged in.
+
+After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize the synchronous webhooks executed during the checkout (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing). However, for some reason, your use-case doesn't fit into the synchronous webhooks model. You need to execute it "aside" from the Saleor checkout flow.
+
+By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the Checkout API, the user can just call the API directly and bypass your custom logic.
+
+To prevent this, you can obstruct the access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the password and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
+
+Here is how it may look in practice on the example of a simple Next.js Apollo application that used to call the Saleor API directly:
+
+### Implementation
+
+#### Step 1: Protect the Saleor API with a password
+
+Set up "API Password Protection" in the Saleor Cloud dashboard as described above.
+
+#### Step 2: Visit your current implementation
+
+In the current implementation, your Next.js application directly calls the Saleor API through an Apollo GraphQL client.
+
+The queries may look like this:
+
+```jsx
+import { ApolloClient, InMemoryCache, gql, useQuery } from "@apollo/client";
+
+const client = new ApolloClient({
+  uri: "https://your-store.saleor.cloud/graphql/", // Calling the Saleor API directly
+  cache: new InMemoryCache(),
+});
+
+const GET_PRODUCTS = gql`
+  query GetProducts {
+    products(first: 10) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`;
+
+const Home = ({ products }) => {
+  const { data, loading, error } = useQuery(GET_PRODUCTS);
+
+  return (
+    <div>
+      <h1>Products</h1>
+      <ul>
+        {products.map((product) => (
+          <li key={product.id}>{product.id}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+```
+
+Our goal is to change as little as possible in the code above when introducing the proxy server.
+
+#### Step 3: Create a proxy API route
+
+```jsx
+// pages/api/saleor.js
+
+import { ApolloClient, InMemoryCache, gql } from "@apollo/client";
+
+export default async (req, res) => {
+  const username = process.env.SALEOR_API_USERNAME; // Using the Basic Auth username
+  const password = process.env.SALEOR_API_PASSWORD; // Using the Basic Auth password
+  const token = Buffer.from(`${username}:${password}`).toString("base64");
+
+  const client = new ApolloClient({
+    uri: "https://your-store.saleor.cloud/graphql/",
+    cache: new InMemoryCache(),
+    headers: {
+      Authorization: `Basic ${token}`, // Using the Basic Auth header to authenticate the Saleor API
+    },
+  });
+
+  const { data } = await client.query({
+    query: gql`
+      # Read the query from the request body
+    `,
+  });
+
+  res.status(200).json(data);
+};
+```
+
+#### Step 4: Update the Next.js application to use the proxy
+
+```jsx
+import { ApolloClient, InMemoryCache, gql, useQuery } from "@apollo/client";
+
+const client = new ApolloClient({
+  uri: "/api/saleor", // Calling the proxy server
+  cache: new InMemoryCache(),
+});
+```

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -43,7 +43,7 @@ Combined with a server-side proxy, this can be a useful tool to obscure the Sale
 
 ### Overview
 
-By default, Saleor exposes some parts of its API publicly, like products catalog or checkout. This behavior doesn't have to align with the requirements of your business. However, Saleor Cloud allows you to restrict access to the API by setting up a Basic Auth.
+By default, Saleor exposes some parts of its API publicly, like product catalog or checkout. This behavior doesn't have to align with the requirements of your business. However, Saleor Cloud allows you to restrict access to the API by setting up a Basic Auth.
 
 Imagine you don't want your products to be publicly accessible. To achieve this, we will create a proxy server that will know the credentials and the API URL and thus be able to access the Saleor API. The only way to get to the Saleor API will be through that proxy server.
 

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -31,7 +31,7 @@ After enabling password protection, users trying to open the Saleor Dashboard wi
 
 :::
 
-Combined with a server-side proxy, this can be a powerful tool to obscure the Saleor API from unauthorized access. We will explore this in more detail in the example below.
+Combined with a server-side proxy, this can be a useful tool to obscure the Saleor API from unauthorized access. We will explore this in more detail in the example below.
 
 ## Example: Password-protected API proxy
 
@@ -152,4 +152,4 @@ async function getProducts() {
 
 #### Further considerations
 
-That was a simple example of using a proxy server to obscure the Saleor API behind a basic auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.
+That was a simple example of using a proxy server to obscure the Saleor API behind Basic Auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -5,13 +5,27 @@ sidebar_position: 2
 
 Even though Saleor [implements complex authorization and authentication](/api-usage/authentication.mdx) mechanisms, you might want to restrict access to your Saleor Cloud instance for specific use cases.
 
-Below, we explore two ways Saleor Cloud allows you to restrict access to the API, as well as a practical example of how to use them.
+Below, we explore two ways Saleor Cloud allows you to restrict access to the API, as well as a practical example of how to use one of them.
 
 ## Allowed API origins
 
-Most times, the list of the origins you expect to call your API is known in advance (and it includes your storefront/-s). By specifying the allowed origins, you can prevent unauthorized access to your API.
+Most times, the list of the origins you expect to call your API is known in advance. By specifying the allowed origins, you can prevent unauthorized access to your API.
 
 In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all", but you can also specify a list of origins or set it to "Dashboard only".
+
+:::info
+
+Changing the settings to only allow the selected origins can affect the installed apps. If you want your app to call the Saleor API from the client, you need to add the app's origin to the list of allowed origins. You can read more about app's access scopes in the [App permissions](developer/extending/apps/architecture/app-permissions.mdx#access-scopes) document.
+
+:::
+
+Here is how an example list of allowed origins may look:
+
+- `https://your-storefront.com` - your storefront
+- `https://your-app-1.com` - your first app (if it is calling the Saleor API from the client)
+- `https://your-app-2.com` - your second app (if it is calling the Saleor API from the client)
+
+You don't need to specify the Saleor Cloud dashboard origin, as it is always allowed to call the Saleor API.
 
 ## API Password Protection
 
@@ -19,23 +33,25 @@ Another way to restrict access to your Saleor Cloud instance is to protect it wi
 
 :::important
 
-Users trying to open the Saleor Dashboard will be prompted to enter their username and password.
+After enabling password protection, users trying to open the Saleor Dashboard will be prompted to enter the Basic Auth username and password, besides their own Saleor Cloud credentials.
 
 :::
+
+Combined with a server-side proxy, this can be a powerful tool to obscure the Saleor API from unauthorized access. We will explore this in more detail in the example below.
 
 ## Example: Password-protected API proxy
 
 ### Overview
 
-Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, some checkout actions don't require an authenticated user. It is done so by design - you want to allow users to add items to their cart without being logged in.
+Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, most checkout actions don't require the user to be authenticated. It is done so by design - you want to allow users to manage their cart without being logged in.
 
-After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize the synchronous webhooks executed during the checkout (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing). However, for some reason, your use case doesn't fit into the synchronous webhooks model. You need to execute it "aside" from the Saleor checkout flow.
+After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize either the synchronous (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing) or asynchronous (e.g., the [checkout events](/api-reference/webhooks/enums/webhook-event-type-async-enum.mdx#code-style-fontweight-normal-webhookeventtypeasyncenumbcheckout_createdbcode)) webhooks. However, let's assume your use case doesn't fit into the webhooks model. You need to execute the logic "aside" from the Saleor checkout flow.
 
 By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the [Checkout API](developer/checkout/overview.mdx), the user can just call the API directly and bypass your custom logic.
 
-To prevent this, you can obstruct access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
+To prevent this, you can obstruct access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and thus, will be able to access the Saleor API. The only way to get to the Saleor API will be through the proxy server.
 
-Here is how it may look in practice on the example of a simple Next.js Apollo application that used to call the Saleor API directly:
+Here is how it may look in practice on the example of a simple Next.js application. At the moment, it calls the Saleor API directly:
 
 ### Implementation
 
@@ -47,14 +63,21 @@ Set up "API Password Protection" in the Saleor Cloud dashboard as [described abo
 
 In the current implementation, your Next.js application calls the Saleor API directly:
 
+:::note
+
+In a production-grade Next.js application, you most likely would use some GraphQL client (like [Apollo Client](https://www.apollographql.com/docs/react/)) to fetch the data from the Saleor API. However, for the sake of simplicity, we will use the native `fetch` API in this example.
+
+:::
+
 ```jsx
 async function getProducts() {
-  const response = await fetch("https://your-store.saleor.cloud/graphql", {
+  const response = await fetch("https://your-store.saleor.cloud/graphql", { // The URL of your Saleor instance
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
+      // The GraphQL query you want to execute
       query: `
           query GetProducts {
             products(first: 10) {
@@ -71,7 +94,17 @@ async function getProducts() {
 
   const data = await response.json();
 
-  return data;
+  // ...
+}
+
+const ProductList = () => {
+    useEffect(() => {
+        getProducts();
+    }, []);
+
+    return (
+        // ...
+    );
 }
 ```
 
@@ -81,9 +114,9 @@ Our goal is to change the code above as little as possible when introducing the 
 
 In most cases, you would call the Saleor GraphQL API straight from the React component. However, given that we want to obscure the Saleor API behind a basic auth, we can't just pass the credentials to the client. They would be easily accessible to anyone who inspects the code.
 
-Instead, we will create a proxy API route that will know the credentials and the address and allow access to the Saleor API. This way, we can ensure that only our proxy server can access the Saleor API.
+Instead, we will create a proxy API route that will know the credentials and the address of our GraphQL endpoint. As long as we don't expose the credentials to the client, we can ensure that our proxy server is the only one that can access the Saleor API directly.
 
-Inside the API route, we can further execute the custom logic that we need to introduce.
+What's more is that inside the API route, we can further execute the custom logic that we needed to introduce in the first place.
 
 Here is how the proxy API route may look:
 
@@ -94,7 +127,8 @@ export default async (req, res) => {
   const password = process.env.SALEOR_API_PASSWORD; // Take the Basic Auth password from an environment variable
   const token = Buffer.from(`${username}:${password}`).toString("base64"); // Encode the credentials to Base64
 
-  // You can execute the custom logic here
+  // 👉 You can execute the custom logic here 👈
+
   const response = await fetch("https://your-store.saleor.cloud/graphql", {
     method: "POST",
     headers: {
@@ -131,3 +165,5 @@ async function getProducts() {
 ```
 
 #### Further considerations
+
+This is a simple example of how you can use a proxy server to obscure the Saleor API behind a basic auth. In a real-world scenario, you would most likely use a GraphQL client to fetch the data from the Saleor API. In that case, the effort to introduce the proxy server without modifying too much of the client code could be substantial.

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -3,31 +3,37 @@ title: Restricting API access
 sidebar_position: 2
 ---
 
-Even though Saleor [implements complex authorization and authentication](/api-usage/authentication.mdx) mechanisms, you might want to restrict access to the API for specific use cases.
+Even though Saleor [implements complex authorization and authentication](/api-usage/authentication.mdx) mechanisms, you might want to restrict access to your Saleor Cloud instance for specific use cases.
 
 Below, we explore two ways Saleor Cloud allows you to restrict access to the API, as well as a practical example of how to use them.
 
 ## Allowed API origins
 
-Most times, the list of the origins you expect to call your API is known in advance (and it includes your storefronts). By specifying the allowed origins, you can prevent unauthorized access to your API.
+Most times, the list of the origins you expect to call your API is known in advance (and it includes your storefront/-s). By specifying the allowed origins, you can prevent unauthorized access to your API.
 
 In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all", but you can also specify a list of origins or set it to "Dashboard only".
 
 ## API Password Protection
 
-TODO
+Another way to restrict access to your Saleor Cloud instance is to protect it with a password through [Basic Auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). This way, you can ensure that only those who know the credentials can access the API.
+
+:::important
+
+The users trying to open the Saleor Dashboard will be prompted to enter the username and password as well.
+
+:::
 
 ## Example: Password protected API proxy
 
 ### Overview
 
-Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, creating and managing a checkout doesn't require an authenticated user. It is done so by design - you want to allow users to add items to their cart without being logged in.
+Let's imagine you have a storefront that communicates with Saleor API. Your storefront, naturally, implements some sort of a checkout flow. In Saleor, some checkout actions don't require an authenticated user. It is done so by design - you want to allow users to add items to their cart without being logged in.
 
 After some time, you realize your checkout flow requires some custom logic. Normally, you would utilize the synchronous webhooks executed during the checkout (e.g., the [transaction events](/developer/extending/webhooks/synchronous-events/transaction.mdx) for payment processing). However, for some reason, your use-case doesn't fit into the synchronous webhooks model. You need to execute it "aside" from the Saleor checkout flow.
 
-By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the Checkout API, the user can just call the API directly and bypass your custom logic.
+By introducing this custom piece of code, Saleor is no longer the source of truth for the checkout process. Given the open access to the [Checkout API](developer/checkout/overview.mdx), the user can just call the API directly and bypass your custom logic.
 
-To prevent this, you can obstruct the access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the password and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
+To prevent this, you can obstruct the access to the Saleor API by protecting it with a password. You can then create a proxy server that will know the credentials and the address and will be able to access the Saleor API. This way, you can ensure that only your proxy server can access the Saleor API.
 
 Here is how it may look in practice on the example of a simple Next.js Apollo application that used to call the Saleor API directly:
 
@@ -35,76 +41,71 @@ Here is how it may look in practice on the example of a simple Next.js Apollo ap
 
 #### Step 1: Protect the Saleor API with a password
 
-Set up "API Password Protection" in the Saleor Cloud dashboard as described above.
+Set up "API Password Protection" in the Saleor Cloud dashboard as [described above](#api-password-protection).
 
 #### Step 2: Visit your current implementation
 
-In the current implementation, your Next.js application directly calls the Saleor API through an Apollo GraphQL client.
-
-The queries may look like this:
+In the current implementation, your Next.js application calls the Saleor API directly:
 
 ```jsx
-import { ApolloClient, InMemoryCache, gql, useQuery } from "@apollo/client";
+async function getProducts() {
+  const response = await fetch("https://your-store.saleor.cloud/graphql", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: `
+          query GetProducts {
+            products(first: 10) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+      `,
+    }),
+  });
 
-const client = new ApolloClient({
-  uri: "https://your-store.saleor.cloud/graphql/", // Calling the Saleor API directly
-  cache: new InMemoryCache(),
-});
+  const data = await response.json();
 
-const GET_PRODUCTS = gql`
-  query GetProducts {
-    products(first: 10) {
-      edges {
-        node {
-          id
-        }
-      }
-    }
-  }
-`;
-
-const Home = ({ products }) => {
-  const { data, loading, error } = useQuery(GET_PRODUCTS);
-
-  return (
-    <div>
-      <h1>Products</h1>
-      <ul>
-        {products.map((product) => (
-          <li key={product.id}>{product.id}</li>
-        ))}
-      </ul>
-    </div>
-  );
-};
+  return data;
+}
 ```
 
 Our goal is to change as little as possible in the code above when introducing the proxy server.
 
 #### Step 3: Create a proxy API route
 
+In most cases, you would call the Saleor GraphQL API straight from the React component. However, given that we want to obscure the Saleor API behind a basic auth, we can't just pass the credentials to the client. They would be easily accessible to anyone who inspects the code.
+
+Instead, we will create a proxy API route that will know the credentials and the address and will be able to access the Saleor API. This way, we can ensure that only our proxy server can access the Saleor API.
+
+Inside the API route, we can further execute the custom logic that we need to introduce.
+
+Here is how the proxy API route may look:
+
 ```jsx
 // pages/api/saleor.js
-
-import { ApolloClient, InMemoryCache, gql } from "@apollo/client";
-
 export default async (req, res) => {
-  const username = process.env.SALEOR_API_USERNAME; // Using the Basic Auth username
-  const password = process.env.SALEOR_API_PASSWORD; // Using the Basic Auth password
-  const token = Buffer.from(`${username}:${password}`).toString("base64");
+  const username = process.env.SALEOR_API_USERNAME; // Take the Basic Auth username from an environment variable
+  const password = process.env.SALEOR_API_PASSWORD; // Take the Basic Auth password from an environment variable
+  const token = Buffer.from(`${username}:${password}`).toString("base64"); // Encode the credentials to Base64
 
-  const client = new ApolloClient({
-    uri: "https://your-store.saleor.cloud/graphql/",
-    cache: new InMemoryCache(),
+  // You can execute the custom logic here
+  const response = await fetch("https://your-store.saleor.cloud/graphql", {
+    method: "POST",
     headers: {
+      "Content-Type": "application/json",
       Authorization: `Basic ${token}`, // Using the Basic Auth header to authenticate the Saleor API
     },
-  });
-
-  const { data } = await client.query({
-    query: gql`
-      # Read the query from the request body
-    `,
+    body: JSON.stringify({
+      query: `
+        // Read the query from the request body
+      `,
+    }),
   });
 
   res.status(200).json(data);
@@ -113,11 +114,22 @@ export default async (req, res) => {
 
 #### Step 4: Update the Next.js application to use the proxy
 
-```jsx
-import { ApolloClient, InMemoryCache, gql, useQuery } from "@apollo/client";
+Our last step will be to update the Next.js application to use the proxy server instead of calling the Saleor API directly:
 
-const client = new ApolloClient({
-  uri: "/api/saleor", // Calling the proxy server
-  cache: new InMemoryCache(),
-});
+```jsx
+async function getProducts() {
+  // highlight-next-line
+  const response = await fetch("/api/saleor", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    // ...
+  });
+  // ...
+}
 ```
+
+TODO: check if it works or do you need more for an endpoint to be GraphQL endpoint
+
+#### Further considerations

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -148,7 +148,7 @@ export default async (req, res) => {
 
 #### Step 4: Update the Next.js application to use the proxy
 
-Our last step will be to update the Next.js application to use the proxy server instead of calling the Saleor API directly:
+Our last step will be to update the client-side code to fetch products via the route we just implemented:
 
 ```jsx
 async function getProducts() {

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -11,11 +11,17 @@ Below, we explore two ways Saleor Cloud allows you to restrict access to the API
 
 If the list of the origins you expect to call your API is known in advance, you can automatically reject the unknown ones.
 
-In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow all" but you can also specify a list of origins or set it to "Dashboard only".
+In the project view of your Saleor Cloud dashboard, you can customize the allowed origins. The default option is to "Allow All" but you can also specify a list of origins or set it to "Dashboard only".
+
+:::warning
+
+We don't recommend using the "Allow All" setting on production environments. It's a good practice to restrict the access to the API to only the origins you expect.
+
+:::
 
 :::info
 
-Changing the settings to only allow the selected origins can affect the installed apps. If you want your app to call the Saleor API from the client, you need to add the app's origin to the list of allowed origins. You can read more about the app's access scopes in the [App permissions](developer/extending/apps/architecture/app-permissions.mdx#access-scopes) document.
+Changing the settings to only allow the selected origins can affect the installed apps. If you want your app to **call the Saleor API from the client**, you need to add the app's origin to the list of allowed origins. You can read more about the app's access scopes in the [App permissions](developer/extending/apps/architecture/app-permissions.mdx#access-scopes) document.
 
 :::
 

--- a/versioned_docs/version-3.x/restricting-api-access.mdx
+++ b/versioned_docs/version-3.x/restricting-api-access.mdx
@@ -138,8 +138,10 @@ Our last step will be to update the Next.js application to use the proxy server 
 
 ```jsx
 async function getProducts() {
-  // highlight-next-line
+  // highlight-start
+  // Using the proxy API route instead of the Saleor API directly
   const response = await fetch("/api/saleor", {
+    // highlight-end
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/versioned_sidebars/version-3.x-sidebars.json
+++ b/versioned_sidebars/version-3.x-sidebars.json
@@ -81,7 +81,7 @@
     {
       "type": "category",
       "label": "Saleor Cloud",
-      "items": ["cloud"]
+      "items": ["cloud", "restricting-api-access"]
     },
     {
       "type": "category",


### PR DESCRIPTION
**Context**:
We often get questions about how our Cloud users can restrict access to Saleor API. This article goes through the possible options and describes an example use case.

**Preview:** https://saleor-docs-git-restrict-api-access-saleorcommerce.vercel.app/docs/3.x/restricting-api-access