### PR TITLE
Remove information about legacy plugins

### DIFF
--- a/docs/developer/app-store/apps/stripe.mdx
+++ b/docs/developer/app-store/apps/stripe.mdx
@@ -5,17 +5,19 @@ sidebar_position: 2
 
 # Stripe
 
+:::caution
+
+Stripe App is not yet available in Saleor App Store, but you can [fork it](https://github.com/saleor/saleor-app-payment-stripe).
+
+:::
+
 ## Overview
 
 Stripe App is a payment integration app that allows merchants to accept online payments from customers using Stripe as their payment processor. Stripe is a popular global payment provider that offers a range of payment methods, including credit cards, bank transfers, and digital wallets.
 
 You can find an example of using the Stripe App at [https://github.com/saleor/example-nextjs-stripe/](https://github.com/saleor/example-nextjs-stripe/).
 
-:::caution
-
 To configure the Stripe App, you must have an account with [Stripe](https://stripe.com).
-
-:::
 
 The Stripe App allows for integrations with [Stripe Payment Element](https://stripe.com/docs/payments/payment-element), meaning it can be used on [Web, iOS, Android, and React Native](https://stripe.com/docs/payments/accept-a-payment?platform=web). Under the hood, it creates Stripe [Payment Intents](https://stripe.com/docs/api/payment_intents) and handles calculations of total and balance in Saleor automatically.
 

--- a/docs/developer/app-store/legacy-plugins/stripe.mdx
+++ b/docs/developer/app-store/legacy-plugins/stripe.mdx
@@ -2,12 +2,6 @@
 title: Stripe
 ---
 
-:::warning
-This plugin is deprecated!
-
-If you plan on building a new integration with Saleor, we recommend using the [Stripe](../apps/stripe) app instead.
-:::
-
 Stripe plugin uses [custom payment flow](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements) to process customer transactions.
 
 :::note

--- a/docs/developer/app-store/legacy-plugins/user-emails.mdx
+++ b/docs/developer/app-store/legacy-plugins/user-emails.mdx
@@ -2,12 +2,6 @@
 title: User Emails
 ---
 
-:::warning
-This plugin is deprecated!
-
-If you plan on building a new integration with Saleor, we recommend using the [Emails and messages](../apps/emails-and-messages/overview) app instead.
-:::
-
 `UserEmails` plugin is responsible for sending emails to shop customers.
 
 After being called by [`PluginManager`](developer/extending/plugins/overview.mdx), the plugin will fill the template using event payload and send a message via SMTP.

--- a/versioned_docs/version-3.x/developer/app-store/apps/stripe.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/apps/stripe.mdx
@@ -5,17 +5,19 @@ sidebar_position: 2
 
 # Stripe
 
+:::caution
+
+Stripe App is not yet available in Saleor App Store, but you can [fork it](https://github.com/saleor/saleor-app-payment-stripe).
+
+:::
+
 ## Overview
 
 Stripe App is a payment integration app that allows merchants to accept online payments from customers using Stripe as their payment processor. Stripe is a popular global payment provider that offers a range of payment methods, including credit cards, bank transfers, and digital wallets.
 
 You can find an example of using the Stripe App at [https://github.com/saleor/example-nextjs-stripe/](https://github.com/saleor/example-nextjs-stripe/).
 
-:::caution
-
 To configure the Stripe App, you must have an account with [Stripe](https://stripe.com).
-
-:::
 
 The Stripe App allows for integrations with [Stripe Payment Element](https://stripe.com/docs/payments/payment-element), meaning it can be used on [Web, iOS, Android, and React Native](https://stripe.com/docs/payments/accept-a-payment?platform=web). Under the hood, it creates Stripe [Payment Intents](https://stripe.com/docs/api/payment_intents) and handles calculations of total and balance in Saleor automatically.
 

--- a/versioned_docs/version-3.x/developer/app-store/legacy-plugins/stripe.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/legacy-plugins/stripe.mdx
@@ -2,12 +2,6 @@
 title: Stripe
 ---
 
-:::warning
-This plugin is deprecated!
-
-If you plan on building a new integration with Saleor, we recommend using the [Stripe](../apps/stripe) app instead.
-:::
-
 Stripe plugin uses [custom payment flow](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements) to process customer transactions.
 
 :::note

--- a/versioned_docs/version-3.x/developer/app-store/legacy-plugins/user-emails.mdx
+++ b/versioned_docs/version-3.x/developer/app-store/legacy-plugins/user-emails.mdx
@@ -2,12 +2,6 @@
 title: User Emails
 ---
 
-:::warning
-This plugin is deprecated!
-
-If you plan on building a new integration with Saleor, we recommend using the [Emails and messages](../apps/emails-and-messages/overview) app instead.
-:::
-
 `UserEmails` plugin is responsible for sending emails to shop customers.
 
 After being called by [`PluginManager`](developer/extending/plugins/overview.mdx), the plugin will fill the template using event payload and send a message via SMTP.


### PR DESCRIPTION
1. Remove note that Emails and Stripe plugins are deprecated and should be replaced with apps (apps are not available yet)
2. Add note that stripe app can be forked