### PR TITLE
Stop indexing canary docs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -540,5 +540,16 @@
       "source": "/docs/3.x/developer/app-store/apps/taxes/:slug",
       "destination": "/docs/3.x/developer/app-store/apps/avatax/:slug"
     }
+  ],
+  "headers": [
+    {
+      "source": "/docs/next/:path*",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
We identified that indexing the canary version impacts search results in a way we want to avoid. The main docs people should be landing on are the current released version, not the next version we plan to release. This PR is adding a change to stop indexing canary through Vercel directives.