### PR TITLE
Disable breadcrumbs in docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -195,6 +195,7 @@ module.exports = {
           customCss: [require.resolve("./src/css/theme.css")],
         },
         docs: {
+          breadcrumbs: false,
           async sidebarItemsGenerator({
             defaultSidebarItemsGenerator,
             ...args


### PR DESCRIPTION
They are mostly useless (i.e. they cannot be used to navigate) and add visual noise to the page header.