### PR TITLE
Update PostgreSQL version in Windows installation instructions

### DIFF
--- a/docs/setup/windows.mdx
+++ b/docs/setup/windows.mdx
@@ -24,7 +24,7 @@ Saleor requires **Node.js 10.0** or later. Go to the [Node.js downloads page](ht
 
 ### PostgreSQL
 
-You will need **PostgreSQL** version **12.x**. Get the Windows installer from the [project’s download page](https://www.postgresql.org/download/windows/).
+You will need **PostgreSQL** version **15.x**. Get the Windows installer from the [project’s download page](https://www.postgresql.org/download/windows/).
 
 :::note
 Remember the password you chose for the administrator account during the installation process.
@@ -68,7 +68,7 @@ poetry install
 4.  Create a database user using the command line tools that came with your PostgreSQL installation:
 
     ```shell
-    C:\"Program Files"\PostgreSQL\12\bin\createuser.exe --username=postgres --superuser --pwprompt saleor
+    C:\"Program Files"\PostgreSQL\15\bin\createuser.exe --username=postgres --superuser --pwprompt saleor
     ```
 
     Please correct the path if your installation path or PostgreSQL version are different.
@@ -82,7 +82,7 @@ poetry install
 5.  Create a database:
 
     ```shell
-    C:\"Program Files"\PostgreSQL\12\bin\createdb.exe --username=postgres --owner=saleor saleor
+    C:\"Program Files"\PostgreSQL\15\bin\createdb.exe --username=postgres --owner=saleor saleor
     ```
 
 6.  Migrate the database:

--- a/versioned_docs/version-3.x/setup/windows.mdx
+++ b/versioned_docs/version-3.x/setup/windows.mdx
@@ -24,7 +24,7 @@ Saleor requires **Node.js 10.0** or later. Go to the [Node.js downloads page](ht
 
 ### PostgreSQL
 
-You will need **PostgreSQL** version **12.x**. Get the Windows installer from the [project’s download page](https://www.postgresql.org/download/windows/).
+You will need **PostgreSQL** version **15.x**. Get the Windows installer from the [project’s download page](https://www.postgresql.org/download/windows/).
 
 :::note
 Remember the password you chose for the administrator account during the installation process.
@@ -68,7 +68,7 @@ poetry install
 4.  Create a database user using the command line tools that came with your PostgreSQL installation:
 
     ```shell
-    C:\"Program Files"\PostgreSQL\12\bin\createuser.exe --username=postgres --superuser --pwprompt saleor
+    C:\"Program Files"\PostgreSQL\15\bin\createuser.exe --username=postgres --superuser --pwprompt saleor
     ```
 
     Please correct the path if your installation path or PostgreSQL version are different.
@@ -82,7 +82,7 @@ poetry install
 5.  Create a database:
 
     ```shell
-    C:\"Program Files"\PostgreSQL\12\bin\createdb.exe --username=postgres --owner=saleor saleor
+    C:\"Program Files"\PostgreSQL\15\bin\createdb.exe --username=postgres --owner=saleor saleor
     ```
 
 6.  Migrate the database:


### PR DESCRIPTION
This changes the PostgreSQL version from v12 to v15 in the Windows manual (non-containerized) installation instructions as we no longer actively maintain v12, only v15.

Acts as a follow-up to:
- https://github.com/saleor/saleor-platform/pull/309
- https://github.com/saleor/saleor/pull/16055