### PR TITLE
Remove shadows from cards

### DIFF
--- a/components/CardGrid/styles.module.css
+++ b/components/CardGrid/styles.module.css
@@ -8,7 +8,6 @@
 .cardGrid a:not(.card) {
   border: solid 1px var(--ifm-color-emphasis-200);
   border-radius: var(--ifm-card-border-radius);
-  box-shadow: 0 1.5px 3px 0 rgb(0 0 0 / 15%);
   color: inherit;
   display: block;
   font-size: 0.8rem;


### PR DESCRIPTION
Without shadows cards are more unified to the rest of Saleor brand

![CleanShot 2024-06-10 at 09 39 09](https://github.com/saleor/saleor-docs/assets/9268745/6f3a4308-dde2-44ec-9505-8ffd0d0c78e5)
![CleanShot 2024-06-10 at 09 39 04](https://github.com/saleor/saleor-docs/assets/9268745/1eb517c1-8623-4c5f-bffd-b056532ff119)
