### PR TITLE
Add additional info on external shipping method response fields

### DIFF
--- a/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
@@ -183,7 +183,7 @@ Where:
 
 :::info
 
-Fields: `minimum_delivery_days`, `description`,`metadata` were added to response in **Saleor 3.19**.
+Fields: `minimum_delivery_days`, `description` and `metadata` were added to the response in **Saleor 3.19**.
 
 :::
 

--- a/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
@@ -181,6 +181,12 @@ Where:
 - `description` is additional description of external shipping method.
 - `metadata` is additional shipping method metadata in a form of a dict with strings as keys and values.
 
+:::info
+
+Fields: `minimum_delivery_days`, `description`,`metadata` were added response in **Saleor 3.19**.
+
+:::
+
 #### Selecting shipping methods
 
 External shipping methods have an ID of the following format: `app:<app-database-id>:<id-returned-by-webhook>` encoded in Base64.

--- a/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
@@ -162,7 +162,10 @@ This is an example response from the application:
     "name": "Standard Delivery",
     "amount": 0.0,
     "currency": "USD",
-    "maximum_delivery_days": 14
+    "maximum_delivery_days": 14,
+    "minimum_delivery_days": 4,
+    "description": "Delivery description",
+    "metadata": { "key": "value", "key_2": "value_2" }
   }
 ]
 ```
@@ -174,6 +177,9 @@ Where:
 - `amount` **(required)** is price that customer needs to pay for delivery with shipping method.
 - `currency` **(required)** is ISO currency code for amount.
 - `maximum_delivery_days` is maximum delivery days for delivery promise of shipping carrier.
+- `minimum_delivery_days` is minimum delivery days for delivery promise of shipping carrier.
+- `description` is additional description of external shipping method.
+- `metadata` is additional shipping method metadata in a form of a dict with strings as keys and values.
 
 #### Selecting shipping methods
 

--- a/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
@@ -183,7 +183,7 @@ Where:
 
 :::info
 
-Fields: `minimum_delivery_days`, `description`,`metadata` were added response in **Saleor 3.19**.
+Fields: `minimum_delivery_days`, `description`,`metadata` were added to response in **Saleor 3.19**.
 
 :::
 

--- a/versioned_docs/version-3.x/developer/extending/webhooks/synchronous-events/shipping.mdx
+++ b/versioned_docs/version-3.x/developer/extending/webhooks/synchronous-events/shipping.mdx
@@ -183,7 +183,7 @@ Where:
 
 :::info
 
-Fields: `minimum_delivery_days`, `description`,`metadata` were added to response in **Saleor 3.19**.
+Fields: `minimum_delivery_days`, `description` and `metadata` were added to the response in **Saleor 3.19**.
 
 :::
 

--- a/versioned_docs/version-3.x/developer/extending/webhooks/synchronous-events/shipping.mdx
+++ b/versioned_docs/version-3.x/developer/extending/webhooks/synchronous-events/shipping.mdx
@@ -162,7 +162,10 @@ This is an example response from the application:
     "name": "Standard Delivery",
     "amount": 0.0,
     "currency": "USD",
-    "maximum_delivery_days": 14
+    "maximum_delivery_days": 14,
+    "minimum_delivery_days": 4,
+    "description": "Delivery description",
+    "metadata": { "key": "value", "key_2": "value_2" }
   }
 ]
 ```
@@ -174,6 +177,15 @@ Where:
 - `amount` **(required)** is price that customer needs to pay for delivery with shipping method.
 - `currency` **(required)** is ISO currency code for amount.
 - `maximum_delivery_days` is maximum delivery days for delivery promise of shipping carrier.
+- `minimum_delivery_days` is minimum delivery days for delivery promise of shipping carrier.
+- `description` is additional description of external shipping method.
+- `metadata` is additional shipping method metadata in a form of a dict with strings as keys and values.
+
+:::info
+
+Fields: `minimum_delivery_days`, `description`,`metadata` were added to response in **Saleor 3.19**.
+
+:::
 
 #### Selecting shipping methods
 


### PR DESCRIPTION
Add info on extended fields from external shipping method response that are parsed by Saleor. 
It documents changes from [15935](https://github.com/saleor/saleor/pull/15935)