### PR TITLE
Add info about externalReferences

### DIFF
--- a/docs/api-usage/external-references.mdx
+++ b/docs/api-usage/external-references.mdx
@@ -7,7 +7,7 @@ sidebar_label: External References
 This can be particularly useful when incorporating Saleor with other services.
 
 For example, suppose we aim to synchronize Saleor with a CMS. If a product is introduced in Saleor, we would also want to generate a corresponding product in the CMS.
-Upon creation of a product in the CMS, an id is assigned. This id can then be used to update the `externalReference` of the product in Saleor:
+Upon creation of a product in the CMS, an ID is assigned. This ID can then be used to update the `externalReference` of the product in Saleor:
 
 ```graphql
 mutation {
@@ -20,7 +20,7 @@ mutation {
 }
 ```
 
-`externalReference` is available in following types:
+`externalReference` is available in the following types:
 
 - [Order](api-reference/orders/objects/order.mdx#orderexternalreferencestring-) - starting from version 3.19, the [MANAGE_ORDERS](api-reference/users/enums/permission-enum.mdx#permissionenummanage_orders) permission is required to use [order](api-reference/orders/queries/order.mdx#orderexternalreferencestring-) query.
 - [Product](api-reference/products/objects/product.mdx#productexternalreferencestring-)

--- a/docs/api-usage/external-references.mdx
+++ b/docs/api-usage/external-references.mdx
@@ -1,0 +1,35 @@
+---
+title: External References
+sidebar_label: External References
+---
+
+`externalReference` is a feature designed to link an object to an ID from an external system.
+This can be particularly useful when incorporating Saleor with other services.
+
+For example, suppose we aim to synchronize Saleor with a CMS. If a product is introduced in Saleor, we would also want to generate a corresponding product in the CMS.
+Upon creation of a product in the CMS, an id is assigned. This id can then be used to update the `externalReference` of the product in Saleor:
+
+```graphql
+mutation {
+  productUpdate(externalReference: "CMS_ID", input: { name: "New name" }) {
+    errors {
+      field
+      message
+    }
+  }
+}
+```
+
+`externalReference` is available in following types:
+
+- [Order](api-reference/orders/objects/order.mdx#orderexternalreferencestring-) - starting from version 3.19, the [MANAGE_ORDERS](api-reference/users/enums/permission-enum.mdx#permissionenummanage_orders) permission is required to use [order](api-reference/orders/queries/order.mdx#orderexternalreferencestring-) query.
+- [Product](api-reference/products/objects/product.mdx#productexternalreferencestring-)
+- [ProductVariant](api-reference/products/objects/product-variant.mdx#productvariantexternalreferencestring-)
+- [Attribute](api-reference/attributes/objects/attribute.mdx#attributeexternalreferencestring-)
+- [AttributeValue](api-reference/attributes/objects/attribute-value.mdx#attributevalueexternalreferencestring-)
+- [Warehouse](api-reference/products/objects/warehouse.mdx#warehouseexternalreferencestring-)
+- [User](api-reference/users/objects/user.mdx#userexternalreferencestring-)
+
+:::note
+The `externalReference` value must be unique across a single type. The maximum length is 250 characters.
+:::

--- a/docs/api-usage/external-references.mdx
+++ b/docs/api-usage/external-references.mdx
@@ -22,7 +22,7 @@ mutation {
 
 `externalReference` is available in the following types:
 
-- [Order](api-reference/orders/objects/order.mdx#orderexternalreferencestring-) - starting from version 3.19, the [MANAGE_ORDERS](api-reference/users/enums/permission-enum.mdx#permissionenummanage_orders) permission is required to use [order](api-reference/orders/queries/order.mdx#orderexternalreferencestring-) query.
+- [Order](api-reference/orders/objects/order.mdx#orderexternalreferencestring-) - starting from version 3.19, the [MANAGE_ORDERS](api-reference/users/enums/permission-enum.mdx#permissionenummanage_orders) permission is required to use `externalReference` with [order](api-reference/orders/queries/order.mdx#orderexternalreferencestring-) query.
 - [Product](api-reference/products/objects/product.mdx#productexternalreferencestring-)
 - [ProductVariant](api-reference/products/objects/product-variant.mdx#productvariantexternalreferencestring-)
 - [Attribute](api-reference/attributes/objects/attribute.mdx#attributeexternalreferencestring-)

--- a/docs/upgrade-guides/3-18-to-3-19.mdx
+++ b/docs/upgrade-guides/3-18-to-3-19.mdx
@@ -80,3 +80,21 @@ To achieve the same discount, the multiple rules should be converted into one ru
   }
 }
 ```
+
+## External reference
+
+To retrieve order details using the `order` query with `externalReference` as input, you need the `MANAGE_ORDERS` permission:
+
+- Ensure that apps or staff users, who utilize the `order` query with `externalReference` as input, have the `MANAGE_ORDERS` permission assigned.
+- If customers use the `query` with `externalReference`, the GraphQL query must be processed via the custom app that
+  has the appropriate permissions.
+
+The chart below provides an example of fetching an order with `externalReference` as a user without any permissions.
+
+```mermaid
+sequenceDiagram
+    Customer->>+App: Fetch order details<br>with externalReference
+    App ->>+ Saleor: Fetch order<br>with MANAGE_ORDERS
+    Saleor -->>- App: Order details
+    App -->- Customer: Order details
+```

--- a/versioned_docs/version-3.x/api-usage/external-references.mdx
+++ b/versioned_docs/version-3.x/api-usage/external-references.mdx
@@ -1,0 +1,35 @@
+---
+title: External References
+sidebar_label: External References
+---
+
+`externalReference` is a feature designed to link an object to an ID from an external system.
+This can be particularly useful when incorporating Saleor with other services.
+
+For example, suppose we aim to synchronize Saleor with a CMS. If a product is introduced in Saleor, we would also want to generate a corresponding product in the CMS.
+Upon creation of a product in the CMS, an ID is assigned. This ID can then be used to update the `externalReference` of the product in Saleor:
+
+```graphql
+mutation {
+  productUpdate(externalReference: "CMS_ID", input: { name: "New name" }) {
+    errors {
+      field
+      message
+    }
+  }
+}
+```
+
+`externalReference` is available in the following types:
+
+- [Order](api-reference/orders/objects/order.mdx#orderexternalreferencestring-) - starting from version 3.19, the [MANAGE_ORDERS](api-reference/users/enums/permission-enum.mdx#permissionenummanage_orders) permission is required to use [order](api-reference/orders/queries/order.mdx#orderexternalreferencestring-) query.
+- [Product](api-reference/products/objects/product.mdx#productexternalreferencestring-)
+- [ProductVariant](api-reference/products/objects/product-variant.mdx#productvariantexternalreferencestring-)
+- [Attribute](api-reference/attributes/objects/attribute.mdx#attributeexternalreferencestring-)
+- [AttributeValue](api-reference/attributes/objects/attribute-value.mdx#attributevalueexternalreferencestring-)
+- [Warehouse](api-reference/products/objects/warehouse.mdx#warehouseexternalreferencestring-)
+- [User](api-reference/users/objects/user.mdx#userexternalreferencestring-)
+
+:::note
+The `externalReference` value must be unique across a single type. The maximum length is 250 characters.
+:::

--- a/versioned_docs/version-3.x/api-usage/external-references.mdx
+++ b/versioned_docs/version-3.x/api-usage/external-references.mdx
@@ -22,7 +22,7 @@ mutation {
 
 `externalReference` is available in the following types:
 
-- [Order](api-reference/orders/objects/order.mdx#orderexternalreferencestring-) - starting from version 3.19, the [MANAGE_ORDERS](api-reference/users/enums/permission-enum.mdx#permissionenummanage_orders) permission is required to use [order](api-reference/orders/queries/order.mdx#orderexternalreferencestring-) query.
+- [Order](api-reference/orders/objects/order.mdx#orderexternalreferencestring-) - starting from version 3.19, the [MANAGE_ORDERS](api-reference/users/enums/permission-enum.mdx#permissionenummanage_orders) permission is required to use `externalReference` with [order](api-reference/orders/queries/order.mdx#orderexternalreferencestring-) query.
 - [Product](api-reference/products/objects/product.mdx#productexternalreferencestring-)
 - [ProductVariant](api-reference/products/objects/product-variant.mdx#productvariantexternalreferencestring-)
 - [Attribute](api-reference/attributes/objects/attribute.mdx#attributeexternalreferencestring-)

--- a/versioned_docs/version-3.x/upgrade-guides/3-18-to-3-19.mdx
+++ b/versioned_docs/version-3.x/upgrade-guides/3-18-to-3-19.mdx
@@ -80,3 +80,21 @@ To achieve the same discount, the multiple rules should be converted into one ru
   }
 }
 ```
+
+## External reference
+
+To retrieve order details using the `order` query with `externalReference` as input, you need the `MANAGE_ORDERS` permission:
+
+- Ensure that apps or staff users, who utilize the `order` query with `externalReference` as input, have the `MANAGE_ORDERS` permission assigned.
+- If customers use the `query` with `externalReference`, the GraphQL query must be processed via the custom app that
+  has the appropriate permissions.
+
+The chart below provides an example of fetching an order with `externalReference` as a user without any permissions.
+
+```mermaid
+sequenceDiagram
+    Customer->>+App: Fetch order details<br>with externalReference
+    App ->>+ Saleor: Fetch order<br>with MANAGE_ORDERS
+    Saleor -->>- App: Order details
+    App -->- Customer: Order details
+```


### PR DESCRIPTION
This PR introduces the section for `externalReference`. It also extends the migration-guide about using `externalReference` without proper permissions. 

> [!NOTE]  
> ~After applying review comments, I will also move the changes to versioned-docs~ Done!
