### PR TITLE
Update a paragraph about Voucher usage in draft orders

### DIFF
--- a/docs/developer/discounts/vouchers.mdx
+++ b/docs/developer/discounts/vouchers.mdx
@@ -48,7 +48,7 @@ Those limitation options can be combined. For example, if `usageLimit` is set to
 
 ### Voucher usage in draft orders
 
-Since version 3.18, Saleor is able to calculate voucher usage in draft orders. To turn on such a behavior, `includeDraftOrderInVoucherUsage` flag for the given `Channel` must be set to `true`. Use [channelUpdate](api-reference/channels/mutations/channel-update.mdx) mutation to switch the flag.
+Saleor is able to calculate voucher usage in draft orders. To turn on such a behavior, `includeDraftOrderInVoucherUsage` flag for the given `Channel` must be set to `true`. Use [channelUpdate](api-reference/channels/mutations/channel-update.mdx) mutation to switch the flag.
 
 When the `includeDraftOrderInVoucherUsage` flag is changed from `false` to `true`, **vouchers will be disconnected from all draft orders.**
 


### PR DESCRIPTION
Update a paragraph about `Voucher usage in draft orders` to not mislead users since when the vouchers in draft orders are available.

Port of https://github.com/saleor/saleor-docs/pull/1210