### PR TITLE
Add section about filterable webhook subscription

### DIFF
--- a/docs/api-reference/miscellaneous/subscriptions/draft-order-created.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/draft-order-created.mdx
@@ -1,0 +1,100 @@
+---
+id: draft-order-created
+title: draftOrderCreated
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when new draft order is created.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+draftOrderCreated(
+  channels: [String!]
+): DraftOrderCreated
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>draftOrderCreated.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`DraftOrderCreated`](../../../api-reference/orders/objects/draft-order-created) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when new draft order is created.
+>
+> <Badge text="Added in Saleor 3.2" class="secondary margin-bottom--sm" />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/draft-order-deleted.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/draft-order-deleted.mdx
@@ -1,0 +1,100 @@
+---
+id: draft-order-deleted
+title: draftOrderDeleted
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when draft order is deleted.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+draftOrderDeleted(
+  channels: [String!]
+): DraftOrderDeleted
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>draftOrderDeleted.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`DraftOrderDeleted`](../../../api-reference/orders/objects/draft-order-deleted) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when draft order is deleted.
+>
+> <Badge text="Added in Saleor 3.2" class="secondary margin-bottom--sm" />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/draft-order-updated.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/draft-order-updated.mdx
@@ -1,0 +1,100 @@
+---
+id: draft-order-updated
+title: draftOrderUpdated
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when draft order is updated.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+draftOrderUpdated(
+  channels: [String!]
+): DraftOrderUpdated
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>draftOrderUpdated.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`DraftOrderUpdated`](../../../api-reference/orders/objects/draft-order-updated) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when draft order is updated.
+>
+> <Badge text="Added in Saleor 3.2" class="secondary margin-bottom--sm" />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-bulk-created.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-bulk-created.mdx
@@ -1,0 +1,102 @@
+---
+id: order-bulk-created
+title: orderBulkCreated
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when orders are imported.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderBulkCreated(
+  channels: [String!]
+): OrderBulkCreated
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderBulkCreated.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderBulkCreated`](../../../api-reference/orders/objects/order-bulk-created) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when orders are imported.
+>
+> <Badge text="Added in Saleor 3.14" class="secondary margin-bottom--sm" />
+>
+> <FeaturePreview />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-cancelled.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-cancelled.mdx
@@ -1,0 +1,100 @@
+---
+id: order-cancelled
+title: orderCancelled
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when order is cancelled.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderCancelled(
+  channels: [String!]
+): OrderCancelled
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderCancelled.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderCancelled`](../../../api-reference/orders/objects/order-cancelled) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when order is canceled.
+>
+> <Badge text="Added in Saleor 3.2" class="secondary margin-bottom--sm" />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-confirmed.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-confirmed.mdx
@@ -1,0 +1,100 @@
+---
+id: order-confirmed
+title: orderConfirmed
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when order is confirmed.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderConfirmed(
+  channels: [String!]
+): OrderConfirmed
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderConfirmed.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderConfirmed`](../../../api-reference/orders/objects/order-confirmed) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when order is confirmed.
+>
+> <Badge text="Added in Saleor 3.2" class="secondary margin-bottom--sm" />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-created.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-created.mdx
@@ -1,0 +1,100 @@
+---
+id: order-created
+title: orderCreated
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when new order is created.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderCreated(
+  channels: [String!]
+): OrderCreated
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderCreated.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderCreated`](../../../api-reference/orders/objects/order-created) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when new order is created.
+>
+> <Badge text="Added in Saleor 3.2" class="secondary margin-bottom--sm" />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-expired.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-expired.mdx
@@ -1,0 +1,102 @@
+---
+id: order-expired
+title: orderExpired
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when order becomes expired.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderExpired(
+  channels: [String!]
+): OrderExpired
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderExpired.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderExpired`](../../../api-reference/orders/objects/order-expired) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when order becomes expired.
+>
+> <Badge text="Added in Saleor 3.13" class="secondary margin-bottom--sm" />
+>
+> <FeaturePreview />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-fulfilled.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-fulfilled.mdx
@@ -1,0 +1,100 @@
+---
+id: order-fulfilled
+title: orderFulfilled
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when order is fulfilled.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderFulfilled(
+  channels: [String!]
+): OrderFulfilled
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderFulfilled.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderFulfilled`](../../../api-reference/orders/objects/order-fulfilled) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when order is fulfilled.
+>
+> <Badge text="Added in Saleor 3.2" class="secondary margin-bottom--sm" />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-fully-paid.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-fully-paid.mdx
@@ -1,0 +1,100 @@
+---
+id: order-fully-paid
+title: orderFullyPaid
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when order is fully paid.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderFullyPaid(
+  channels: [String!]
+): OrderFullyPaid
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderFullyPaid.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderFullyPaid`](../../../api-reference/orders/objects/order-fully-paid) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when order is fully paid.
+>
+> <Badge text="Added in Saleor 3.2" class="secondary margin-bottom--sm" />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-fully-refunded.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-fully-refunded.mdx
@@ -1,0 +1,102 @@
+---
+id: order-fully-refunded
+title: orderFullyRefunded
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+The order is fully refunded.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderFullyRefunded(
+  channels: [String!]
+): OrderFullyRefunded
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderFullyRefunded.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderFullyRefunded`](../../../api-reference/orders/objects/order-fully-refunded) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> The order is fully refunded.
+>
+> <Badge text="Added in Saleor 3.14" class="secondary margin-bottom--sm" />
+>
+> <FeaturePreview />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-metadata-updated.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-metadata-updated.mdx
@@ -1,0 +1,100 @@
+---
+id: order-metadata-updated
+title: orderMetadataUpdated
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when order metadata is updated.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderMetadataUpdated(
+  channels: [String!]
+): OrderMetadataUpdated
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderMetadataUpdated.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderMetadataUpdated`](../../../api-reference/orders/objects/order-metadata-updated) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when order metadata is updated.
+>
+> <Badge text="Added in Saleor 3.8" class="secondary margin-bottom--sm" />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-paid.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-paid.mdx
@@ -1,0 +1,102 @@
+---
+id: order-paid
+title: orderPaid
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Payment has been made. The order may be partially or fully paid.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderPaid(
+  channels: [String!]
+): OrderPaid
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderPaid.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderPaid`](../../../api-reference/orders/objects/order-paid) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Payment has been made. The order may be partially or fully paid.
+>
+> <Badge text="Added in Saleor 3.14" class="secondary margin-bottom--sm" />
+>
+> <FeaturePreview />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-refunded.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-refunded.mdx
@@ -1,0 +1,102 @@
+---
+id: order-refunded
+title: orderRefunded
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+The order received a refund. The order may be partially or fully refunded.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderRefunded(
+  channels: [String!]
+): OrderRefunded
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderRefunded.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderRefunded`](../../../api-reference/orders/objects/order-refunded) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> The order received a refund. The order may be partially or fully refunded.
+>
+> <Badge text="Added in Saleor 3.14" class="secondary margin-bottom--sm" />
+>
+> <FeaturePreview />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/api-reference/miscellaneous/subscriptions/order-updated.mdx
+++ b/docs/api-reference/miscellaneous/subscriptions/order-updated.mdx
@@ -1,0 +1,100 @@
+---
+id: order-updated
+title: orderUpdated
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="\_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import { useState } from "react";
+
+export const Details = ({
+  dataOpen,
+  dataClose,
+  children,
+  startOpen = false,
+}) => {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <details
+      {...(open ? { open: true } : {})}
+      className="details"
+      style={{
+        border: "none",
+        boxShadow: "none",
+        background: "var(--ifm-background-color)",
+      }}
+    >
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }}
+        style={{ listStyle: "none" }}
+      >
+        {open ? dataOpen : dataClose}
+      </summary>
+      {open && children}
+    </details>
+  );
+};
+
+Event sent when order is updated.
+
+<Badge text="Added in Saleor 3.20" class="secondary margin-bottom--sm" />
+
+<FeaturePreview />
+
+```graphql
+orderUpdated(
+  channels: [String!]
+): OrderUpdated
+```
+
+### Arguments
+
+#### [<code style={{ fontWeight: 'normal' }}>orderUpdated.<b>channels</b></code>](#)<Bullet />[`[String!]`](../../../api-reference/miscellaneous/scalars/string) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> <Badge class="badge badge--secondary" text="miscellaneous"/>
+
+> List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+
+### Type
+
+#### [`OrderUpdated`](../../../api-reference/orders/objects/order-updated) <Badge class="badge badge--secondary" text="object"/> <Badge class="badge badge--secondary" text="orders"/>
+
+> Event sent when order is updated.
+>
+> <Badge text="Added in Saleor 3.2" class="secondary margin-bottom--sm" />
+
+import FeaturePreview from "@site/components/FeaturePreview";

--- a/docs/developer/extending/webhooks/subscription-webhook-payloads.mdx
+++ b/docs/developer/extending/webhooks/subscription-webhook-payloads.mdx
@@ -36,6 +36,63 @@ subscription {
 }
 ```
 
+### Filterable subscription query
+
+:::info
+
+This feature was introduced in **Saleor 3.20**.
+
+:::
+
+:::caution
+
+This feature is in the **Feature Preview** stage, which means that it is available for experimentation and
+feedback. However, it is still undergoing development and is subject to modifications.
+
+:::
+
+For some webhook events, you can create a filterable subscription. A filterable subscription means the event will be delivered only when the filter input matches the object.
+
+All filterable events are available as a top-level subscription field, on the same level as the [event](api-reference/miscellaneous/subscriptions/event.mdx) field.
+
+:::note
+Only one top field can be requested as a filterable subscription query. This means that in a single subscription, you cannot define more than one filterable event or mix it with the `event` field. In that case, a new webhook with a new subscription should be created.
+:::
+
+The example below is a subscription query that filters out newly created orders that do not belong to the channels with slugs: `uk`, `pl`:
+
+```graphql
+subscription {
+  orderCreated(channels: ["uk", "pl"]) {
+    order {
+      id
+      lines {
+        id
+      }
+    }
+  }
+}
+```
+
+The above subscription will generate the following webhook payload:
+
+```json
+{
+  "data": {
+    "orderCreated": {
+      "order": {
+        "id": "T3JkZXI6YzhmY2FjMTgtMWQ5Yy00NWRkLTgxMGYtMGIzMTJiYTNjZDYz",
+        "lines": [
+          {
+            "id": "T3JkZXJMaW5lOjkzYTFjZGMxLTQxMzAtNDE4ZC05YTAxLTQyY2I5N2E3ZjIxMw=="
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
 ## Creating webhook with subscription query
 
 To create a webhook that will have its payload generated using a subscription, you need to use the same mutation as with standard webhooks. The only difference is passing the `query` field as an input with a subscription query converted to a string.

--- a/docs/developer/extending/webhooks/subscription-webhook-payloads.mdx
+++ b/docs/developer/extending/webhooks/subscription-webhook-payloads.mdx
@@ -8,11 +8,11 @@ Subscription Webhook Payloads for **asynchronous** events are available in Saleo
 Subscription Webhook payloads for **synchronous** events are available in Saleor **3.6**.
 :::
 
-## Custom payloads
+## Custom Payloads
 
 You can define webhook payloads in Saleor with GraphQL subscriptions. Subscription queries allow you to subscribe to different events and determine what fields should be returned in the payload.
 
-## Building subscription query
+## Building Subscription Query
 
 To build a subscription query you can use any GraphQL interface (like [GraphQL Playground](api-usage/developer-tools.mdx)). Just like with building a GraphQL query, you can use prompts and build the whole subscription from our API. Payload generation will use resolvers/permissions that are normally used in our API.
 Inside the query, you must define the event type for which the payload will be generated. The event type must be supported by our subscription mechanism (see the [list of supported events](api-reference/miscellaneous/subscriptions/event.mdx)).
@@ -36,7 +36,7 @@ subscription {
 }
 ```
 
-### Filtering webhooks
+### Filtering
 
 :::info
 
@@ -57,10 +57,10 @@ For some webhook events, you can create a filterable subscription. A filterable 
 - Making a separation between different markets. For example: `US` channel doesn't need to receive order events from `UK` market.
 - Reducing the traffic between Saleor and apps. Instead of sending each event to each app, the traffic will be reduced as only events for defined channels will be delivered.
 
+
 All filterable events are available as a top-level subscription field, on the same level as the [event](api-reference/miscellaneous/subscriptions/event.mdx) field.
 
 Below events can be filtered:
-
 - [draftOrderCreated](api-reference/miscellaneous/subscriptions/draft-order-created.mdx)
 - [draftOrderDeleted](api-reference/miscellaneous/subscriptions/draft-order-deleted.mdx)
 - [draftOrderUpdated](api-reference/miscellaneous/subscriptions/draft-order-updated.mdx)
@@ -177,7 +177,7 @@ The above subscription will generate the following webhook payload:
 }
 ```
 
-## Creating webhook with subscription query
+## Creating Webhook With Subscription Query
 
 To create a webhook that will have its payload generated using a subscription, you need to use the same mutation as with standard webhooks. The only difference is passing the `query` field as an input with a subscription query converted to a string.
 Webhook with the `query` field defined will be treated as a subscription webhook, and its payload will be generated from the subscription query.
@@ -252,14 +252,14 @@ Example **synchronous** webhook payload:
 }
 ```
 
-## Synchronous webhooks payload
+## Synchronous Webhooks Payload
 
 Defining synchronous webhook payloads using subscriptions is also supported. Each event subscription type has access to its specific object fields.
 :::caution
 Keep in mind that some fields that use the synchronous event to be resolved are not allowed to be called in synchronous webhook payload subscriptions.
 :::
 
-# Blocked fields for subscription payloads
+# Blocked Fields for Subscription Payloads
 
 Synchronous events are not allowed to request fields that are resolved using other synchronous events, which would lead to circular calls of the webhook.
 Fields that are currently unallowed:

--- a/docs/developer/extending/webhooks/subscription-webhook-payloads.mdx
+++ b/docs/developer/extending/webhooks/subscription-webhook-payloads.mdx
@@ -36,7 +36,7 @@ subscription {
 }
 ```
 
-### Filterable subscription query
+### Filtering webhooks
 
 :::info
 
@@ -51,19 +51,99 @@ feedback. However, it is still undergoing development and is subject to modifica
 
 :::
 
-For some webhook events, you can create a filterable subscription. A filterable subscription means the event will be delivered only when the filter input matches the object.
+For some webhook events, you can create a filterable subscription. A filterable subscription means the event will be delivered only when the filter input matches the object. This can be useful in below cases:
+
+- The app is responsible for additional actions for orders that come from a specific channel. For example: `US` channel requires to receive information that payment was charged, whereas the rest of the channels have auto-capture.
+- Making a separation between different markets. For example: `US` channel doesn't need to receive order events from `UK` market.
+- Reducing the traffic between Saleor and apps. Instead of sending each event to each app, the traffic will be reduced as only events for defined channels will be delivered.
 
 All filterable events are available as a top-level subscription field, on the same level as the [event](api-reference/miscellaneous/subscriptions/event.mdx) field.
 
+Below events can be filtered:
+
+- [draftOrderCreated](api-reference/miscellaneous/subscriptions/draft-order-created.mdx)
+- [draftOrderDeleted](api-reference/miscellaneous/subscriptions/draft-order-deleted.mdx)
+- [draftOrderUpdated](api-reference/miscellaneous/subscriptions/draft-order-updated.mdx)
+- [orderBulkCreated](api-reference/miscellaneous/subscriptions/order-bulk-created.mdx)
+- [orderCancelled](api-reference/miscellaneous/subscriptions/order-cancelled.mdx)
+- [orderCreated](api-reference/miscellaneous/subscriptions/order-created.mdx)
+- [orderExpired](api-reference/miscellaneous/subscriptions/order-expired.mdx)
+- [orderFulfilled](api-reference/miscellaneous/subscriptions/order-fulfilled.mdx)
+- [orderFullyPaid](api-reference/miscellaneous/subscriptions/order-fully-paid.mdx)
+- [orderFullyRefunded](api-reference/miscellaneous/subscriptions/order-fully-refunded.mdx)
+- [orderMetadataUpdated](api-reference/miscellaneous/subscriptions/order-metadata-updated.mdx)
+- [orderPaid](api-reference/miscellaneous/subscriptions/order-paid.mdx)
+- [orderRefunded](api-reference/miscellaneous/subscriptions/order-refunded.mdx)
+- [orderUpdated](api-reference/miscellaneous/subscriptions/order-updated.mdx)
+
 :::note
 Only one top field can be requested as a filterable subscription query. This means that in a single subscription, you cannot define more than one filterable event or mix it with the `event` field. In that case, a new webhook with a new subscription should be created.
-:::
 
-The example below is a subscription query that filters out newly created orders that do not belong to the channels with slugs: `uk`, `pl`:
+Subscription queries like the below will raise validation error:
 
 ```graphql
 subscription {
-  orderCreated(channels: ["uk", "pl"]) {
+  orderUpdated(channels: ["different-channel"]) {
+    order {
+      lines {
+        id
+        variant {
+          id
+          product {
+            id
+          }
+        }
+      }
+    }
+  }
+  orderCreated(channels: ["default-channel"]) {
+    order {
+      lines {
+        id
+        variant {
+          id
+          product {
+            id
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+```graphql
+subscription {
+  event {
+    ... on OrderCreated {
+      order {
+        id
+      }
+    }
+  }
+  orderCreated(channels: ["default-channel"]) {
+    order {
+      lines {
+        id
+        variant {
+          id
+          product {
+            id
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::
+
+The example below is a subscription query that triggers a webhook only for orders that belong to given channels: `uk`, `us`:
+
+```graphql
+subscription {
+  orderCreated(channels: ["uk", "us"]) {
     order {
       id
       lines {
@@ -73,6 +153,10 @@ subscription {
   }
 }
 ```
+
+:::note
+The input `channels` will accept a maximally 500 values. Exceeding this value will cause a validation error.
+:::
 
 The above subscription will generate the following webhook payload:
 


### PR DESCRIPTION
The PR adds sections related to the filterable subscription webhooks that will be introduced in this PRs:
https://github.com/saleor/saleor/pull/16323
https://github.com/saleor/saleor/pull/16327

(The feature will be ported to 3.20)