### PR TITLE
Update voucher section

### DIFF
--- a/docs/developer/discounts/vouchers.mdx
+++ b/docs/developer/discounts/vouchers.mdx
@@ -16,11 +16,14 @@ The vouchers on draft orders are applicable since v3.19.
 
 There are three types of vouchers:
 
-- Fixed amount: reduces the price by a specified value.
-- Percentage: reduces the price by a specified percentage value. The discount is applied
-  on the total value of checkout (if the voucher is a type of `ENTIRE_ORDER`)
-  or on the total value of the product (if the voucher is a type of `SPECIFIC_PRODUCT`)
-- Shipping: reduces the shipping price.
+- `ENTIRE_ORDER`: the discount is applied on the total value of checkout
+- `SPECIFIC_PRODUCT`: the discount is applied on the total value of the product
+- `SHIPPING`: the discount is applied on the shipping price
+
+We can also distinguish vouchers by their value type:
+
+- `FIXED`: reduces the price by a specified value.
+- `PERCENTAGE`: reduces the price by a specified percentage value.
 
 The voucher can be applied to all checkout products, or only to specified ones.
 
@@ -30,7 +33,9 @@ the cheapest item included in the discount. If the voucher applies to all produc
 the discount will be applied only to the cheapest item overall.
 
 To apply the voucher on checkout use [checkoutAddPromoCode](api-reference/checkout/mutations/checkout-add-promo-code.mdx)
-mutation. The discount will be visible both in the line prices and in the `checkout.discount` field. Let's see the examples.
+mutation. The discount will be visible both in the line prices and in the `checkout.discount` field.
+To apply the voucher on draft order use [draftOrderCreate](api-reference/orders/mutations/draft-order-create) or [draftOrderUpdate](api-reference/orders/mutations/draft-order-update)
+and pass `voucherCode` as an argument.
 
 ### Usage limits
 
@@ -45,6 +50,11 @@ The voucher can be also set as single-use, when `singleUse` flag is set to `true
 **This flag can be updated on existing voucher only when no code has been used yet.**
 
 Those limitation options can be combined. For example, if `usageLimit` is set to `10` and `applyOncePerCustomer` is set to `true`, the voucher can be used by the first 10 users.
+
+:::warning
+Shuffling voucher settings might result in a mismatch between the `voucher.used` field and the number of orders utilizing the voucher.
+Saleor operates on the general assumption that updating the voucher settings should not affect existing orders if possible.
+:::
 
 ### Voucher usage in draft orders
 

--- a/docs/developer/discounts/vouchers.mdx
+++ b/docs/developer/discounts/vouchers.mdx
@@ -34,7 +34,7 @@ the discount will be applied only to the cheapest item overall.
 
 To apply the voucher on checkout use [checkoutAddPromoCode](api-reference/checkout/mutations/checkout-add-promo-code.mdx)
 mutation. The discount will be visible both in the line prices and in the `checkout.discount` field.
-To apply the voucher on draft order use [draftOrderCreate](api-reference/orders/mutations/draft-order-create) or [draftOrderUpdate](api-reference/orders/mutations/draft-order-update)
+To apply the voucher on draft order use [draftOrderCreate](api-reference/orders/mutations/draft-order-create.mdx) or [draftOrderUpdate](api-reference/orders/mutations/draft-order-update.mdx)
 and pass `voucherCode` as an argument.
 
 ### Usage limits


### PR DESCRIPTION
Adding some additional information about voucher usage and correct voucher types, as currently, it looks like only `PERCENTAGE` vouchers have options `ENTIRE ORDER` and `SPECIFIC PRODUCT`. Recently, there was also a question how to apply voucher to draft order. 