### PR TITLE
Add information about stocks & fulfillment cancelations

### DIFF
--- a/docs/developer/checkout/order-status.mdx
+++ b/docs/developer/checkout/order-status.mdx
@@ -35,20 +35,23 @@ flowchart TD
     isNotFulfilled -->|No| FULFILLED(FULFILLED)
     UNFULFILLED -->|Cancel order| CANCELLED(CANCELLED)
 
+    FULFILLED -->|Return products| isNotReturned
+    FULFILLED -->|Cancel fulfillment| isAllCancelled
+
     PARTIALLY_FULFILLED -->|Create fulfillment| isNotFulfilled
     PARTIALLY_FULFILLED --->|Return products| isNotReturned{Are there unreturned\n order lines?}
     PARTIALLY_FULFILLED --->|Cancel fulfillment| isAllCancelled{Are all fulfillments\n cancelled?}
 
-    FULFILLED -->|Return products| isNotReturned
-    FULFILLED -->|Cancel fulfillment| isAllCancelled
+    isAllCancelled ~~~ isNotFulfilled
 
-    isAllCancelled -->|Yes| UNFULFILLED
     isAllCancelled -->|No| PARTIALLY_FULFILLED
+    isAllCancelled -->|Yes| UNFULFILLED
 
     isNotReturned -->|Yes| PARTIALLY_RETURNED(PARTIALLY_RETURNED)
     isNotReturned -->|No| RETURNED(RETURNED)
 
     PARTIALLY_RETURNED -->|Return products| isNotReturned
+
 
 ```
 
@@ -124,7 +127,7 @@ stateDiagram-v2
 
 #### Available transitions
 
-- Fulfill: creating fulfillments will result in transition to `PARTIALLY_FULFILLED` or `FULFILLED` state, depending on whether there are any unfulfilled items left. This will also deduct stock quantity from warehouses and release allocations.
+- Fulfill: creating fulfillments will result in transition to `PARTIALLY_FULFILLED` or `FULFILLED` state, depending on whether there are any unfulfilled items left. For items with inventory tracking enabled, this will also deduct stock quantity from warehouses and release allocations.
 - Return: creating returns will result in transition to `PARTIALLY_RETURNED` or `RETURNED` state. Returning items will not modify stock.
 - Cancel: the status will change to `CANCELED` and order will be visible in the dashboard.
 
@@ -158,7 +161,7 @@ stateDiagram-v2
 
 #### Available actions
 
-- Fulfill: creating fulfillments will result in transition to `PARTIALLY_FULFILLED` or `FULFILLED` state, depending on whether there are any unfulfilled items left. This will also deduct stock quantity from warehouses and release allocations for items with inventory tracking enabled.
+- Fulfill: creating fulfillments will result in transition to `PARTIALLY_FULFILLED` or `FULFILLED` state, depending on whether there are any unfulfilled items left. For items with inventory tracking enabled, this will also deduct stock quantity from warehouses and release allocations.
 - Cancel fulfillment: cancelling all fulfillments will result in transition to `UNFULFILLED` state. Items with inventory tracking enabled will be restocked in the warehouse specified in the input of `orderFulfillmentCancel` mutation.
 - Return: creating returns will result in transition to `PARTIALLY_RETURNED` or `RETURNED` state. Returning items will not modify stock.
 

--- a/docs/developer/checkout/order-status.mdx
+++ b/docs/developer/checkout/order-status.mdx
@@ -27,7 +27,6 @@ flowchart TD
     isAutomated -->|Yes| UNFULFILLED
     isAutomated -->|No| UNCONFIRMED(UNCONFIRMED)
 
-
     UNCONFIRMED -->|Expire time overdue| EXPIRED(EXPIRED)
     UNCONFIRMED -->|Confirm order| UNFULFILLED
 
@@ -37,13 +36,20 @@ flowchart TD
     UNFULFILLED -->|Cancel order| CANCELLED(CANCELLED)
 
     PARTIALLY_FULFILLED -->|Create fulfillment| isNotFulfilled
-    PARTIALLY_FULFILLED -->|Return products| isNotReturned{Are there unreturned\n order lines?}
+    PARTIALLY_FULFILLED --->|Return products| isNotReturned{Are there unreturned\n order lines?}
+    PARTIALLY_FULFILLED --->|Cancel fulfillment| isAllCancelled{Are all fulfillments\n cancelled?}
 
     FULFILLED -->|Return products| isNotReturned
+    FULFILLED -->|Cancel fulfillment| isAllCancelled
+
+    isAllCancelled -->|Yes| UNFULFILLED
+    isAllCancelled -->|No| PARTIALLY_FULFILLED
+
     isNotReturned -->|Yes| PARTIALLY_RETURNED(PARTIALLY_RETURNED)
     isNotReturned -->|No| RETURNED(RETURNED)
 
     PARTIALLY_RETURNED -->|Return products| isNotReturned
+
 ```
 
 ### DRAFT
@@ -119,7 +125,7 @@ stateDiagram-v2
 #### Available transitions
 
 - Fulfill: creating fulfillments will result in transition to `PARTIALLY_FULFILLED` or `FULFILLED` state, depending on whether there are any unfulfilled items left. This will also deduct stock quantity from warehouses and release allocations.
-- Return: creating returns will result in transition to `PARTIALLY_RETURNED` or `RETURNED` state.
+- Return: creating returns will result in transition to `PARTIALLY_RETURNED` or `RETURNED` state. Returning items will not modify stock.
 - Cancel: the status will change to `CANCELED` and order will be visible in the dashboard.
 
 ### PARTIALLY_FULFILLED
@@ -131,11 +137,16 @@ stateDiagram-v2
     [*] --> PARTIALLY_FULFILLED
     state if_state_fulfillments <<choice>>
     state if_state_returns <<choice>>
+    state if_state_cancel_fulfillments <<choice>>
 
 
     PARTIALLY_FULFILLED --> if_state_fulfillments: Fulfillment created
     if_state_fulfillments --> PARTIALLY_FULFILLED: Products waiting for fulfillment
     if_state_fulfillments --> FULFILLED: All products fulfilled
+
+    PARTIALLY_FULFILLED --> if_state_cancel_fulfillments: Fulfillment canceled
+    if_state_cancel_fulfillments --> PARTIALLY_FULFILLED: Not all fulfillments canceled
+    if_state_cancel_fulfillments --> UNFULFILLED: All fulfillments canceled
 
     PARTIALLY_FULFILLED --> if_state_returns: Return items
     if_state_returns --> PARTIALLY_RETURNED: Not all products returned
@@ -147,8 +158,9 @@ stateDiagram-v2
 
 #### Available actions
 
-- Fulfill: creating fulfillments will result in transition to `PARTIALLY_FULFILLED` or `FULFILLED` state, depending on whether there are any unfulfilled items left. This will also deduct stock quantity from warehouses and release allocations.
-- Return: creating returns will result in transition to `PARTIALLY_RETURNED` or `RETURNED` state.
+- Fulfill: creating fulfillments will result in transition to `PARTIALLY_FULFILLED` or `FULFILLED` state, depending on whether there are any unfulfilled items left. This will also deduct stock quantity from warehouses and release allocations for items with inventory tracking enabled.
+- Cancel fulfillment: cancelling all fulfillments will result in transition to `UNFULFILLED` state. Items with inventory tracking enabled will be restocked in the warehouse specified in the input of `orderFulfillmentCancel` mutation.
+- Return: creating returns will result in transition to `PARTIALLY_RETURNED` or `RETURNED` state. Returning items will not modify stock.
 
 ### FULFILLED
 
@@ -158,11 +170,15 @@ stateDiagram-v2
 
     [*] --> FULFILLED
     state if_state_returns <<choice>>
+    state if_state_cancel_fulfillments <<choice>>
 
     FULFILLED --> if_state_returns: Return items
     if_state_returns --> PARTIALLY_RETURNED: Not all products returned
     if_state_returns --> RETURNED: All products returned
 
+    FULFILLED --> if_state_cancel_fulfillments: Cancel fulfillment
+    if_state_cancel_fulfillments --> PARTIALLY_FULFILLED: Not all fulfillments canceled
+    if_state_cancel_fulfillments --> UNFULFILLED: All fulfillments canceled
 
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-docs-2",
+  "name": "saleor-docs",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
This change updates mermaid charts for order status now including effects of `orderFulfillmentCancel` mutation, also adding info how returns and fulfillment cancelations affect stock