### PR TITLE
Update dummy app links

### DIFF
--- a/docs/developer/payments.mdx
+++ b/docs/developer/payments.mdx
@@ -36,6 +36,13 @@ In this guide, we use the terms **Payment App** and **Payment Gateway** intercha
 
 :::
 
+:::tip
+
+You can refer to [Dummy Payment App](https://github.com/saleor/dummy-payment-app) for an example of a Payment App implementation.
+It also includes a UI for testing Transactions API.
+
+:::
+
 ### Processing payments with the Payment App
 
 :::info
@@ -370,10 +377,6 @@ The response:
 
 The current status of payment can be determined based on the value of [`transactionEvent.type`](api-reference/payments/enums/transaction-event-type-enum.mdx).
 On some occasions, multiple calls to [`transactionProcess`](api-reference/payments/mutations/transaction-process.mdx) may be required to proceed with the payment.
-
-### Community resources
-
-- [witoszekdev/dummy-payment-server](https://github.com/witoszekdev/dummy-payment-server) - App for testing Transactions API without a real payment provider
 
 ## Custom App
 

--- a/docs/developer/payments.mdx
+++ b/docs/developer/payments.mdx
@@ -30,7 +30,7 @@ Saleor then communicates with the app using synchronous webhooks, automatically 
 
 Payment apps are responsible for handling the implementation details of payments with a certain payment gateway (i.e. Adyen, Stripe) while Saleor hides the complexity of the payment process from the storefront under a consistent set of GraphQL queries and mutations.
 
-:::tip
+:::note
 
 In this guide, we use the terms **Payment App** and **Payment Gateway** interchangeably.
 


### PR DESCRIPTION
This PR removes mentions of old dummy-payment-server as community resource, and adds links to new Dummy Payment App
