### PR TITLE
Nest permissions visually for clarity

### DIFF
--- a/components/Permissions/styles.module.css
+++ b/components/Permissions/styles.module.css
@@ -3,6 +3,9 @@
   line-height: 1.5rem;
   vertical-align: baseline;
   display: flex;
+  border-left: var(--ifm-blockquote-border-left-width) solid
+    var(--ifm-blockquote-border-color);
+  padding-left: var(--ifm-blockquote-padding-horizontal);
 }
 
 .svg {

--- a/components/Permissions/styles.module.css
+++ b/components/Permissions/styles.module.css
@@ -1,11 +1,14 @@
 .permissions {
-  font-size: var(--font-size-sm);
   line-height: 1.5rem;
   vertical-align: baseline;
   display: flex;
   border-left: var(--ifm-blockquote-border-left-width) solid
     var(--ifm-blockquote-border-color);
   padding-left: var(--ifm-blockquote-padding-horizontal);
+}
+
+.permissions span {
+  font-size: var(--font-size-xs) !important;
 }
 
 .svg {


### PR DESCRIPTION
Permission blocks look ambiguous as they have equal proximity to the bottom row 

Before:
<img width="878" alt="image" src="https://github.com/user-attachments/assets/d383e97f-ff88-4d15-9712-665502f72f84">

After:
<img width="859" alt="image" src="https://github.com/user-attachments/assets/db12a738-4001-4f29-9159-8501d0fb5fbd">
