### PR TITLE
Payment nudges

### DIFF
--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -39,7 +39,7 @@ Saleor supports two types of webhooks: synchronous and asynchronous. Synchronous
 
 We will look at what webhooks we must implement in [the "Webhooks" section](#webhooks).
 
-Each payment service has its unique payment flow, so Saleor needs a flexible API to support them. This flexibility is the core idea behind the [Transactions API](developer/extending/webhooks/synchronous-events/transaction.mdx), which we will use for processing payments.
+Saleor provides flexible API to support unique payment flows of different payment services. This flexibility is the core idea behind the [Transactions API](developer/extending/webhooks/synchronous-events/transaction.mdx), which we will use for processing payments.
 
 Our fictional payment gateway is a simple one, so we won't cover the entire API in this tutorial. For real payment providers, the flow may differ. Gateway X may require multiple webhooks to capture the payment process, while Gateway Y may only need one.
 

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -4,22 +4,17 @@ title: How to Build a Payment App
 
 ## Overview
 
-This tutorial will guide you through creating a basic [Payment App](/developer/payments/payment-apps.mdx) using [Transactions API](developer/extending/webhooks/synchronous-events/transaction.mdx).
+This tutorial will demonstrate how to build a [Payment App](/developer/payments/payment-apps.mdx) using dummy payment (without a real payment provider) as an example.
 
-:::note
+If you need a reference point for integrating with real payment providers, you can check out the following examples:
 
-We will integrate with a fictional **Dummy Payment Gateway**. This gateway will simulate real payment processing without handling actual payments.
-
-:::
-
-:::note
-
-If you're considering building a custom payment integration, please check if the payment provider you're interested in isn't already available [Saleor App Store](developer/app-store/apps/overview.mdx#built-in-apps-catalog).
-
-:::
+- [Example Stripe App](https://github.com/saleor/saleor-app-payment-stripe)
+- [Example Authorize.net App](https://github.com/saleor/saleor-app-payment-authorize.net)
+- [Example Klarna App](https://github.com/saleor/saleor-app-payment-klarna)
 
 ### Prerequisites
 
+- Understanding of [Using Payment Apps](/developer/payments/payment-apps)
 - Basic understanding of [Saleor Apps](developer/extending/apps/overview.mdx)
 - Familiarity with [Next.js](https://nextjs.org/)
 - `node >=18.17.0 <=20`
@@ -42,16 +37,6 @@ We will look at what webhooks we must implement in [the "Webhooks" section](#web
 Saleor provides flexible API to support unique payment flows of different payment services. This flexibility is the core idea behind the [Transactions API](/developer/payments/transactions.mdx), which we will use for processing payments.
 
 For simplicity, this tutorial will not cover the entire API as a real-world implementation would, where some gateways might require multiple webhooks to capture the payment process.
-
-:::info
-
-If you need a reference point for integrating with real payment providers, you can check out the following examples:
-
-- [Example Stripe App](https://github.com/saleor/saleor-app-payment-stripe)
-- [Example Authorize.net App](https://github.com/saleor/saleor-app-payment-authorize.net)
-- [Example Klarna App](https://github.com/saleor/saleor-app-payment-klarna)
-
-:::
 
 ### What is a Transaction
 

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -14,11 +14,8 @@ If you need a reference point for integrating with real payment providers, you c
 
 ### Prerequisites
 
-- Understanding of [Using Payment Apps](/developer/payments/payment-apps)
-- Basic understanding of [Saleor Apps](developer/extending/apps/overview.mdx)
-- Familiarity with [Next.js](https://nextjs.org/)
-- `node >=18.17.0 <=20`
-- `pnpm >=9`
+- Understanding of [Payment Apps Usage](/developer/payments/payment-apps)
+- Understanding of [Transactions](/developer/payments/transactions.mdx)
 
 ### What is a Payment App
 
@@ -127,6 +124,14 @@ sequenceDiagram
 
 ## Creating a Saleor App from Template
 
+#### Prerequisites
+- Basic understanding of [Saleor Apps](developer/extending/apps/overview.mdx)
+- Familiarity with [Next.js](https://nextjs.org/)
+- `node >=18.17.0 <=20`
+- `pnpm >=9`
+
+
+#### Getting started
 Any app with server-side capabilities can be considered a Saleor App if it matches the requirements described in the [App Requirements](developer/extending/apps/architecture/app-requirements.mdx) document. Thanks to the [App Template](developer/extending/apps/developing-apps/app-template.mdx), we won't have to check all the boxes manually.
 
 [`saleor-app-template`](https://github.com/saleor/saleor-app-template) is your Next.js starting point for building a Saleor App. It comes with all the necessary scaffolding to get you started. We will explore its features in the following sections of the tutorial.

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -61,24 +61,18 @@ Besides the events, a transaction also contains other payment information, like 
 
 Transactions can be created and managed using the [Transactions API](/developer/payments/transactions.mdx).
 
-### Dummy Payment Gateway Flow
+### What will we build
 
-We want Dummy Payment Gateway to feel like a real payment provider. To achieve that, we will model the payment process after a typical 3D Secure flow.
+We will build a _Dummy Gateway_ that will simulate a typical 3D secure flow:
 
-Here is how it looks:
-
-> Dummy Payment Gateway offers a drop-in payment UI that returns a token when the user starts the payment. The token should be used to confirm the payment on the backend.
->
-> The payment process flow consists of the following steps:
->
-> 1. Initiate the payment process in the drop-in.
-> 2. Ask for payment confirmation (e.g., redirect the user to the 3D Secure page).
-> 3. Charge the payment on the 3D Secure page.
-> 4. Redirect the user to the result (success or failure) page.
+1. A Drop-in payment UI will create a token when the user initiates the payment.
+2. Ask for payment confirmation (e.g., redirect the user to the 3D Secure page).
+3. Charge the payment on the 3D Secure page.
+4. Redirect the user to the result (success or failure) page.
 
 ### Checkout
 
-Transaction API can be used both in Checkout and Order. In this tutorial, we will focus on the payment part only and assume that [the checkout is already created](developer/checkout/overview.mdx#creating-a-checkout-session) and the user is ready to pay.
+Transaction API can be used both in Checkout and Order. In this tutorial, we will cover only payment steps for [existing checkout](developer/checkout/overview.mdx#creating-a-checkout-session).
 
 ## Modeling the Transaction Flow
 

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -39,7 +39,7 @@ Saleor supports two types of webhooks: synchronous and asynchronous. Synchronous
 
 We will look at what webhooks we must implement in [the "Webhooks" section](#webhooks).
 
-Saleor provides flexible API to support unique payment flows of different payment services. This flexibility is the core idea behind the [Transactions API](developer/extending/webhooks/synchronous-events/transaction.mdx), which we will use for processing payments.
+Saleor provides flexible API to support unique payment flows of different payment services. This flexibility is the core idea behind the [Transactions API](/developer/payments/transactions.mdx), which we will use for processing payments.
 
 For simplicity, this tutorial will not cover the entire API as a real-world implementation would, where some gateways might require multiple webhooks to capture the payment process.
 
@@ -59,7 +59,7 @@ A transaction represents a payment instance created in Order or Checkout. It hol
 
 Besides the events, a transaction also contains other payment information, like the amount or currency.
 
-Transactions can be created and managed using the [Transactions API](developer/extending/webhooks/synchronous-events/transaction.mdx).
+Transactions can be created and managed using the [Transactions API](/developer/payments/transactions.mdx).
 
 ### Dummy Payment Gateway Flow
 

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -4,7 +4,7 @@ title: How to Build a Payment App
 
 ## Overview
 
-This tutorial will guide you through creating a basic Payment App with [Transactions API](developer/extending/webhooks/synchronous-events/transaction.mdx).
+This tutorial will guide you through creating a basic [Payment App](/developer/payments/payment-apps.mdx) using [Transactions API](developer/extending/webhooks/synchronous-events/transaction.mdx).
 
 :::note
 

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -19,24 +19,6 @@ If you need a reference point for integrating with real payment providers, you c
 - Understanding of [Payment Apps Usage](/developer/payments/payment-apps)
 - Understanding of [Transactions](/developer/payments/transactions.mdx)
 
-### What is a Payment App
-
-A Payment App is [a Saleor App](developer/extending/apps/overview.mdx) that follows a standard payment interface, enabling Saleor to identify the app as a payment gateway and manage payments through it.
-
-That interface consists of [synchronous webhooks](developer/extending/webhooks/synchronous-events/overview.mdx). This feature allows Saleor to suspend the resolution of an API call until Saleor receives a response from the app in the correct format. Saleor can then pass that response as the value of the requested field.
-
-:::info
-
-Saleor supports two types of webhooks: synchronous and asynchronous. Synchronous events are sent immediately after the event happens during GraphQL requests. Asynchronous events are sent after request processing is finished. You can read more about them in the [Webhooks](developer/extending/webhooks/overview.mdx) article.
-
-:::
-
-We will look at what webhooks we must implement in [the "Webhooks" section](#webhooks).
-
-Saleor provides flexible API to support unique payment flows of different payment services. This flexibility is the core idea behind the [Transactions API](/developer/payments/transactions.mdx), which we will use for processing payments.
-
-For simplicity, this tutorial will not cover the entire API as a real-world implementation would, where some gateways might require multiple webhooks to capture the payment process.
-
 
 ### What will we build
 

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -41,7 +41,7 @@ We will look at what webhooks we must implement in [the "Webhooks" section](#web
 
 Saleor provides flexible API to support unique payment flows of different payment services. This flexibility is the core idea behind the [Transactions API](developer/extending/webhooks/synchronous-events/transaction.mdx), which we will use for processing payments.
 
-Our fictional payment gateway is a simple one, so we won't cover the entire API in this tutorial. For real payment providers, the flow may differ. Gateway X may require multiple webhooks to capture the payment process, while Gateway Y may only need one.
+For simplicity, this tutorial will not cover the entire API as a real-world implementation would, where some gateways might require multiple webhooks to capture the payment process.
 
 :::info
 

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -19,7 +19,6 @@ If you need a reference point for integrating with real payment providers, you c
 - Understanding of [Payment Apps Usage](/developer/payments/payment-apps)
 - Understanding of [Transactions](/developer/payments/transactions.mdx)
 
-
 ### What will we build
 
 We will build a _Dummy Gateway_ that will simulate a typical 3D secure flow:
@@ -31,82 +30,38 @@ We will build a _Dummy Gateway_ that will simulate a typical 3D secure flow:
 
 Transaction API can be used both in Checkout and Order. In this tutorial, we will cover only payment steps for [existing checkout](developer/checkout/overview.mdx#creating-a-checkout-session).
 
-## Modeling the Transaction Flow
+### Event Flow
 
-### Transaction Events
-
-The first step in building our Payment App does not involve any code. To avoid further rework, we need to understand the transaction flow we want to model. The goal is to have a list of events produced by the app and their corresponding webhooks.
-
-Let's highlight two key details from the [Dummy Payment Gateway flow](#dummy-payment-gateway-flow):
-
-- The desired result is charging the payment successfully.
-- We can't charge the payment without the user's confirmation (3D Secure).
-
-In Saleor Transactions API, a successfully charged payment is represented by the [`CHARGE_SUCCESS`](api-reference/payments/enums/transaction-event-type-enum.mdx#transactioneventtypeenumcharge_success) event status. If the payment fails, the status is [`CHARGE_FAILURE`](api-reference/payments/enums/transaction-event-type-enum.mdx#transactioneventtypeenumcharge_failure).
-
-However, before the payment can be charged, we need to confirm it via 3D Secure. This additional action is represented by the [`CHARGE_ACTION_REQUIRED`](api-reference/payments/enums/transaction-event-type-enum.mdx#transactioneventtypeenumcharge_action_required) event status.
-
-:::note
-
-There is a setting in Saleor that can affect this behavior. [Transaction Flow Strategy](api-reference/payments/enums/transaction-flow-strategy-enum.mdx) can be set to `CHARGE` or `AUTHORIZATION`. The `CHARGE` strategy allows the payment to be charged immediately, while the `AUTHORIZATION` strategy will require the funds to be authorized first. You can decide on the strategy on per channel basis in the _Configuration_ → _Channels_ → your channel page.
-
-:::
-
-Now that we understand the key Saleor transaction event statuses, let's align them with our [Dummy Payment Gateway flow](#dummy-payment-gateway-flow). This mapping will show how each step in our payment process corresponds to a specific Saleor transaction status:
-
-| Step                                           | Status                                                                                                                                  | Description                                                                                                        |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| 1. Initiate the payment process in the drop-in | ---                                                                                                                                     | ---                                                                                                                |
-| 2. Confirm the payment via 3D Secure           | [`CHARGE_ACTION_REQUIRED`](api-reference/payments/enums/transaction-event-type-enum.mdx#transactioneventtypeenumcharge_action_required) | The payment requires additional action to be completed. **The drop-in token is needed to initialize the payment.** |
-| 3. Charge the payment                          | ---                                                                                                                                     | ---                                                                                                                |
-| 3a. Charge successful                          | [`CHARGE_SUCCESS`](api-reference/payments/enums/transaction-event-type-enum.mdx#transactioneventtypeenumcharge_success)                 | The payment was successful.                                                                                        |
-| 3b. Charge failed                              | [`CHARGE_FAILURE`](api-reference/payments/enums/transaction-event-type-enum.mdx#transactioneventtypeenumcharge_failure)                 | The payment failed, for example, due to insufficient funds.                                                        |
-| 4. Redirect the user to the result page        | ---                                                                                                                                     | ---                                                                                                                |
-
-### Webhooks
-
-#### Transaction Initialize Session
-
-With our transaction events mapped out, let's determine which webhooks we need to implement to handle these events.
-
-When exploring the [Transaction Events](developer/extending/webhooks/synchronous-events/transaction.mdx) documentation, you may notice that three webhooks can result in the `CHARGE_SUCCESS` event: [`TRANSACTION_CHARGE_REQUESTED`](developer/extending/webhooks/synchronous-events/transaction.mdx#transaction-charge), [`TRANSACTION_INITIALIZE_SESSION`](developer/extending/webhooks/synchronous-events/transaction.mdx#initialize-transaction-session) and [`TRANSACTION_PROCESS_SESSION`](developer/extending/webhooks/synchronous-events/transaction.mdx#process-transaction-session).
-
-There are two reasons for why **we are not going** with the `TRANSACTION_CHARGE_REQUESTED` webhook:
-
-1. It is designed for the staff users to charge the payment manually. Since we want a checkout user (possibly unauthenticated) to be able to pay for the order, it is not a good fit.
-2. It does not allow the return of the `CHARGE_ACTION_REQUIRED` event status.
-
-`TRANSACTION_PROCESS_SESSION` is also not a match. It is triggered when `transactionProcess` mutation is called, but only when the `TRANSACTION_INITIALIZE_SESSION` was called first and returned `CHARGE_ACTION_REQUIRED` or `AUTHORIZE_ACTION_REQUIRED` event status. This webhook will be useful for the second step of our payment process.
-
-That leaves us with the `TRANSACTION_INITIALIZE_SESSION` webhook. It is triggered on the [`transactionInitialize`](api-reference/payments/mutations/transaction-initialize.mdx) mutation which can be used without any permissions (unless you are using [the `action` field](api-reference/payments/mutations/transaction-initialize.mdx#transactioninitializeactiontransactionflowstrategyenum-)). It can result in the `CHARGE_ACTION_REQUIRED` event status, as required.
-
-#### Transaction Process Session
-
-When `TRANSACTION_INITIALIZE_SESSION` returns `CHARGE_ACTION_REQUIRED`, the app must execute this additional action. Depending on the outcome, we want the status to change to either `CHARGE_SUCCESS` or `CHARGE_FAILURE`.
-
-The additional [`TRANSACTION_PROCESS_SESSION`](developer/extending/webhooks/synchronous-events/transaction.mdx#process-transaction-session) webhook will be responsible for this transition.
-
-#### Webhook Sequence
-
-The final sequence of webhooks and their corresponding mutations in our payment process is as follows:
+Here is the complete webhooks and their corresponding mutations:
 
 ```mermaid
 sequenceDiagram
  participant Storefront
  participant Saleor
  participant Dummy Payment App
- Storefront->>Saleor: transactionInitialize
- Saleor->>Dummy Payment App: TRANSACTION_INITIALIZE_SESSION
+ Storefront->>Saleor: mutation: transactionInitialize
+ Saleor->>Dummy Payment App: webhook: TRANSACTION_INITIALIZE_SESSION
  Dummy Payment App-->>Saleor: { result: CHARGE_ACTION_REQUIRED }
  Saleor->>Storefront: { type: CHARGE_ACTION_REQUIRED, ... }
- Storefront->>Saleor: transactionProcess
- Saleor->>Dummy Payment App: TRANSACTION_PROCESS_SESSION
+ Storefront->>Saleor: mutation: transactionProcess
+ Saleor->>Dummy Payment App: webhook TRANSACTION_PROCESS_SESSION
  Dummy Payment App-->>Saleor: {result: CHARGE_SUCCESS / CHARGE_FAILURE }
  Saleor->>Storefront: { type: CHARGE_SUCCESS / CHARGE_FAILURE, ... }
  Note over Dummy Payment App: This process is modeled after a 3D Secure flow.
 ```
 
-## Creating a Saleor App from Template
+#### Flow breakdown
+
+1. Storefront will initiate the payment intent by calling the [`transactionInitialize`](/developer/payments/payment-apps.mdx#initialize-transaction) mutation, triggering the -> [`TRANSACTION_INITIALIZE_SESSION`](/developer/extending/webhooks/synchronous-events/transaction#initialize-transaction-session) webhook. The app will return [`CHARGE_ACTION_REQUIRED`](api-reference/payments/enums/transaction-event-type-enum.mdx#transactioneventtypeenumcharge_action_required) as `action_type` to signal the storefront that 3D secure confirmation is required.
+
+2. Storefront will pass 3D secure confirmation data to the [`transactionProcess`](/developer/payments/payment-apps.mdx#process-transaction) mutation which will trigger [`TRANSACTION_PROCESS_SESSION`](/developer/extending/webhooks/synchronous-events/transaction#process-transaction-session) webhook.
+   In this step we simulate the attempt of charging payment gateway by returning [`CHARGE_SUCCESS`](api-reference/payments/enums/transaction-event-type-enum.mdx#transactioneventtypeenumcharge_success) or [`CHARGE_FAILURE`](api-reference/payments/enums/transaction-event-type-enum.mdx#transactioneventtypeenumcharge_failure) back from the app.
+
+:::warning
+[Transaction Flow Strategy](api-reference/payments/enums/transaction-flow-strategy-enum.mdx) setting can alter the behaviour of `transactionProcess` mutation. When set to `CHARGE` strategy, payments will be charged immediately, when it set `AUTHORIZATION` additional authorization step would be necessary. You can decide on the strategy on per channel basis in the _Configuration_ → _Channels_ → your channel page. For this tutorial, we will assume the `CHARGE` strategy is used.
+:::
+
+## Building Saleor App from Template
 
 #### Prerequisites
 

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -70,8 +70,6 @@ We will build a _Dummy Gateway_ that will simulate a typical 3D secure flow:
 3. Charge the payment on the 3D Secure page.
 4. Redirect the user to the result (success or failure) page.
 
-### Checkout
-
 Transaction API can be used both in Checkout and Order. In this tutorial, we will cover only payment steps for [existing checkout](developer/checkout/overview.mdx#creating-a-checkout-session).
 
 ## Modeling the Transaction Flow

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -109,13 +109,14 @@ sequenceDiagram
 ## Creating a Saleor App from Template
 
 #### Prerequisites
+
 - Basic understanding of [Saleor Apps](developer/extending/apps/overview.mdx)
 - Familiarity with [Next.js](https://nextjs.org/)
 - `node >=18.17.0 <=20`
 - `pnpm >=9`
 
-
 #### Getting started
+
 Any app with server-side capabilities can be considered a Saleor App if it matches the requirements described in the [App Requirements](developer/extending/apps/architecture/app-requirements.mdx) document. Thanks to the [App Template](developer/extending/apps/developing-apps/app-template.mdx), we won't have to check all the boxes manually.
 
 [`saleor-app-template`](https://github.com/saleor/saleor-app-template) is your Next.js starting point for building a Saleor App. It comes with all the necessary scaffolding to get you started. We will explore its features in the following sections of the tutorial.

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -38,13 +38,6 @@ Saleor provides flexible API to support unique payment flows of different paymen
 
 For simplicity, this tutorial will not cover the entire API as a real-world implementation would, where some gateways might require multiple webhooks to capture the payment process.
 
-### What is a Transaction
-
-A transaction represents a payment instance created in Order or Checkout. It holds a list of events that make up the payment process. Each event has a type that describes the action taken on the transaction. You can see the complete list of events in the [`TransactionEventTypeEnum`](api-reference/payments/enums/transaction-event-type-enum.mdx).
-
-Besides the events, a transaction also contains other payment information, like the amount or currency.
-
-Transactions can be created and managed using the [Transactions API](/developer/payments/transactions.mdx).
 
 ### What will we build
 

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -842,3 +842,9 @@ Its scope doesn't have to end here. You can further extend the app with addition
 - If your payment provider requires additional operation before the payment is even initialized (for example, to render the drop-in), you might be interested in reading about the [`PAYMENT_GATEWAY_INITIALIZE_SESSION`](/developer/payments/payment-apps.mdx#initialize-payment-gateway) webhook.
 - To allow users to save their payment methods for future use, you should implement the [Stored Payment Methods API](developer/payments/stored-payments.mdx).
 - If your payment provider needs to report the transaction status to Saleor asynchronously, you can use the [`transactionEventReport` mutation](developer/payments/transactions.mdx#reporting-actions-for-transactions).
+
+## Related resources
+
+- [Using Payment Apps](/developer/payments/payment-apps)
+- [Transactions API](/developer/payments/transactions)
+- [Transactions Webhooks](/developer/extending/webhooks/synchronous-events/transaction)

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -19,7 +19,7 @@ If you need a reference point for integrating with real payment providers, you c
 - Understanding of [Payment Apps Usage](/developer/payments/payment-apps)
 - Understanding of [Transactions](/developer/payments/transactions.mdx)
 
-### What will we build
+### What Will We Build
 
 We will build a _Dummy Gateway_ that will simulate a typical 3D secure flow:
 
@@ -50,7 +50,7 @@ sequenceDiagram
  Note over Dummy Payment App: This process is modeled after a 3D Secure flow.
 ```
 
-#### Flow breakdown
+#### Flow Breakdown
 
 1. Storefront will initiate the payment intent by calling the [`transactionInitialize`](/developer/payments/payment-apps.mdx#initialize-transaction) mutation, triggering the -> [`TRANSACTION_INITIALIZE_SESSION`](/developer/extending/webhooks/synchronous-events/transaction#initialize-transaction-session) webhook. The app will return [`CHARGE_ACTION_REQUIRED`](api-reference/payments/enums/transaction-event-type-enum.mdx#transactioneventtypeenumcharge_action_required) as `action_type` to signal the storefront that 3D secure confirmation is required.
 
@@ -63,14 +63,14 @@ sequenceDiagram
 
 ## Building Saleor App from Template
 
-#### Prerequisites
+#### Install Dependencies
 
 - Basic understanding of [Saleor Apps](developer/extending/apps/overview.mdx)
 - Familiarity with [Next.js](https://nextjs.org/)
 - `node >=18.17.0 <=20`
 - `pnpm >=9`
 
-#### Getting started
+#### Getting Started
 
 Any app with server-side capabilities can be considered a Saleor App if it matches the requirements described in the [App Requirements](developer/extending/apps/architecture/app-requirements.mdx) document. Thanks to the [App Template](developer/extending/apps/developing-apps/app-template.mdx), we won't have to check all the boxes manually.
 
@@ -783,7 +783,7 @@ Its scope doesn't have to end here. You can further extend the app with addition
 - To allow users to save their payment methods for future use, you should implement the [Stored Payment Methods API](developer/payments/stored-payments.mdx).
 - If your payment provider needs to report the transaction status to Saleor asynchronously, you can use the [`transactionEventReport` mutation](developer/payments/transactions.mdx#reporting-actions-for-transactions).
 
-## Related resources
+## Related Resources
 
 - [Using Payment Apps](/developer/payments/payment-apps)
 - [Transactions API](/developer/payments/transactions)

--- a/docs/developer/extending/apps/building-payment-app.mdx
+++ b/docs/developer/extending/apps/building-payment-app.mdx
@@ -6,6 +6,8 @@ title: How to Build a Payment App
 
 This tutorial will demonstrate how to build a [Payment App](/developer/payments/payment-apps.mdx) using dummy payment (without a real payment provider) as an example.
 
+For simplicity, this tutorial will not cover the entire API as a real-world implementation would, where some gateways might require multiple webhooks to capture the payment process.
+
 If you need a reference point for integrating with real payment providers, you can check out the following examples:
 
 - [Example Stripe App](https://github.com/saleor/saleor-app-payment-stripe)

--- a/docs/developer/extending/webhooks/synchronous-events/transaction.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/transaction.mdx
@@ -455,7 +455,7 @@ This feature was introduced in **Saleor 3.13**.
 :::
 
 The synchronous [PAYMENT_GATEWAY_INITIALIZE_SESSION](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumpayment_gateway_initialize_session)
-webhook is called when a customer requests payment gateway initialization by calling the [paymentGatewayInitialize](developer/payments/overview.mdx#initialize-payment-gateway) mutation. The webhook contains details about the object (`Order`/`Checkout`)
+webhook is called when a customer requests payment gateway initialization by calling the [paymentGatewayInitialize](developer/payments/transactions.mdx#initialize-payment-gateway) mutation. The webhook contains details about the object (`Order`/`Checkout`)
 for which the payment gateway initialization was requested, the requested amount, and the `data` received from the frontend.
 As a response, the webhook expects the `data` field with all initialization details that will be passed to the storefront.
 
@@ -534,7 +534,7 @@ This feature was introduced in **Saleor 3.13**.
 :::
 
 The synchronous [TRANSACTION_INITIALIZE_SESSION](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_initialize_session) webhook
-is called when a customer begins processing a payment by calling the [transactionInitialize](developer/payments/overview.mdx#initialize-transaction)
+is called when a customer begins processing a payment by calling the [transactionInitialize](/developer/payments/payment-apps.mdx#initialize-transaction)
 mutation. The webhook contains details about the object (`Order`/`Checkout`) related to this action, the `transactionItem` object, details related to the
 requested action, and the `data` passed in the mutation input. Saleor expects the response to be in the proper format. Based on the response, the `transactionItem`'s amount can be marked as fully covered
 or marked as a transaction that requires additional actions from the customer, such as processing 3D secure action.
@@ -653,7 +653,7 @@ This feature was introduced in **Saleor 3.13**.
 
 The [TRANSACTION_PROCESS_SESSION](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_process_session) webhook is called synchronously when
 a customer needs to process additional actions received as a response from either
-the [transactionInitialize](developer/payments/overview.mdx#initialize-transaction) or [transactionProcess](/developer/payments/overview.mdx#process-transaction) mutations. This webhook is triggered when the customer calls the
+the [transactionInitialize](/developer/payments/payment-apps.mdx#initialize-transaction) or [transactionProcess](/developer/payments/overview.mdx#process-transaction) mutations. This webhook is triggered when the customer calls the
 [transactionProcess](/developer/payments/overview.mdx#process-transaction) mutation.
 It contains details about the `Order` or `Checkout` object related to this action, the `transactionItem` object, details related to the requested action, and the `data` passed in the mutation input.
 Saleor expects the response to be in the proper format. Based on the response, the amount of the `transactionItem` can be marked as fully covered or marked as a transaction

--- a/docs/developer/extending/webhooks/synchronous-events/transaction.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/transaction.mdx
@@ -29,19 +29,19 @@ This feature was introduced in **Saleor 3.13**.
 
 A synchronous webhook called inside a Celery task. It is triggered when a staff user requests the charge action.
 
-The webhook expects to return at least the `pspReference` in the response. The `pspReference` will be attached to [TransactionEvent](api-reference/payments/objects/transaction-event.mdx)
+The webhook expects to return at least the `pspReference` in the response. The `pspReference` will be attached to [`TransactionEvent`](api-reference/payments/objects/transaction-event.mdx)
 with request details. When `pspReference` is attached to the `request` object, it means the app has successfully processed the webhook.
 
 Optionally the result data can be provided. The data is
-used to provide the final status of the requested action, and it will be used to create a new [TransactionEvent](api-reference/payments/objects/transaction-event.mdx)
-object. The new [TransactionEvent](../../../../api-reference/payments/objects/transaction-event.mdx) object will have provided `pspReference`, and will be used in the
+used to provide the final status of the requested action, and it will be used to create a new [`TransactionEvent`](api-reference/payments/objects/transaction-event.mdx)
+object. The new [`TransactionEvent`](../../../../api-reference/payments/objects/transaction-event.mdx) object will have provided `pspReference`, and will be used in the
 [recalculation of the transaction's amount process](/developer/payments/lifecycle.mdx#recalculations-of-amounts).
 
 ### Request
 
 Saleor will send a
-[TRANSACTION_CHARGE_REQUESTED](../../../../api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_charge_requested)
-webhook by using the [TransactionChargeRequested](../../../../api-reference/payments/objects/transaction-charge-requested) subscription type or with a pre-defined payload in case of a missing subscription query.
+[`TRANSACTION_CHARGE_REQUESTED`](../../../../api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_charge_requested)
+webhook by using the [`TransactionChargeRequested`](../../../../api-reference/payments/objects/transaction-charge-requested) subscription type or with a pre-defined payload in case of a missing subscription query.
 
 You can find more details about building webhook subscription query
 [here](../../../extending/webhooks/subscription-webhook-payloads).
@@ -113,7 +113,7 @@ App needs to at least return the `pspReference` of the requested action. This is
 when the payment provider doesn't return a status of the requested action in the response.
 In this situation, the status of the action is delivered by an asynchronous notification that
 should be handled by App, and passed to Saleor by using the
-[transactionEventReport](/developer/payments/transactions.mdx#reporting-actions-for-transactions)
+[`transactionEventReport`](/developer/payments/transactions.mdx#reporting-actions-for-transactions)
 mutation.
 
 The response in this case should have the following structure:
@@ -130,8 +130,8 @@ The app has the possibility to report the status of the requested action immedia
 This is a common case when the payment provider returns the status of the action in
 response to the requested action.
 The payload response has to contain at least `pspReference`, `result` (
-[CHARGE_SUCCESS](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcharge_success)
-or [CHARGE_FAILURE](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcharge_failure)),
+[`CHARGE_SUCCESS`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcharge_success)
+or [`CHARGE_FAILURE`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcharge_failure)),
 and `amount` fields.
 
 The response in this case should have the following structure:
@@ -165,19 +165,19 @@ This feature was introduced in **Saleor 3.13**.
 
 A synchronous webhook called inside a Celery task. They are called when a staff user requests the cancelation action.
 The webhook expects to return at least the `pspReference` in the response. The `pspReference` will
-be attached to [TransactionEvent](api-reference/payments/objects/transaction-event.mdx)
+be attached to [`TransactionEvent`](api-reference/payments/objects/transaction-event.mdx)
 with request details. When `pspReference` is attached to the `request` object, it means the app has successfully processed the webhook. Optionally the result data can be provided. The data is
 used to provide the final status of the requested action, and it will be used to create a new
-[TransactionEvent](api-reference/payments/objects/transaction-event.mdx) object. The new
-[TransactionEvent](../../../../api-reference/payments/objects/transaction-event.mdx) object will have
+[`TransactionEvent`](api-reference/payments/objects/transaction-event.mdx) object. The new
+[`TransactionEvent`](../../../../api-reference/payments/objects/transaction-event.mdx) object will have
 provided `pspReference`, and will be used in the
 [recalculation of the transaction's amount process](developer/payments/lifecycle.mdx#recalculations-of-amounts).
 
 ### Request
 
 Saleor will send a
-[TRANSACTION_CANCEL_REQUESTED](../../../../api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_cancelation_requested)
-webhook by using the [TransactionCancelationRequested](../../../../api-reference/payments/objects/transaction-cancelation-requested) subscription type or with a pre-defined payload in case of a missing subscription query.
+[`TRANSACTION_CANCEL_REQUESTED`](../../../../api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_cancelation_requested)
+webhook by using the [`TransactionCancelationRequested`](../../../../api-reference/payments/objects/transaction-cancelation-requested) subscription type or with a pre-defined payload in case of a missing subscription query.
 You can find more details about building webhook subscription query
 [here](../../../extending/webhooks/subscription-webhook-payloads).
 
@@ -248,7 +248,7 @@ App needs to at least return the `pspReference` of the requested action. This is
 when the payment provider doesn't return a status of the requested action in the response.
 In this situation, the status of the action is delivered by an asynchronous notification that
 should be handled by App, and passed to Saleor by using the
-[transactionEventReport](../../../payments/transactions.mdx#reporting-actions-for-transactions)
+[`transactionEventReport`](../../../payments/transactions.mdx#reporting-actions-for-transactions)
 mutation.
 
 The response in this case should have the following structure:
@@ -265,8 +265,8 @@ The app has the possibility to report the status of the requested action immedia
 This is a common case when the payment provider returns the status of the action in
 response to the requested action.
 The payload response has to contain at least `pspReference`, `result` (
-[CANCEL_SUCCESS](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcancel_success)
-or [CANCEL_FAILURE](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcancel_failure)),
+[`CANCEL_SUCCESS`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcancel_success)
+or [`CANCEL_FAILURE`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcancel_failure)),
 and `amount` fields.
 
 The response in this case should have the following structure:
@@ -299,17 +299,17 @@ This feature was introduced in **Saleor 3.13**.
 :::
 
 A synchronous webhook called inside a Celery task. They are called when a staff user requests the refund action.
-The webhook expects to return at least the `pspReference` in the response. The `pspReference` will be attached to [TransactionEvent](api-reference/payments/objects/transaction-event.mdx)
+The webhook expects to return at least the `pspReference` in the response. The `pspReference` will be attached to [`TransactionEvent`](api-reference/payments/objects/transaction-event.mdx)
 with request details. When `pspReference` is attached to the `request` object, it means the app has successfully processed the webhook. Optionally the result data can be provided. The data is
-used to provide the final status of the requested action, and it will be used to create a new [TransactionEvent](api-reference/payments/objects/transaction-event.mdx)
-object. The new [TransactionEvent](../../../../api-reference/payments/objects/transaction-event.mdx) object will have provided `pspReference`, and will be used in the
+used to provide the final status of the requested action, and it will be used to create a new [`TransactionEvent`](api-reference/payments/objects/transaction-event.mdx)
+object. The new [`TransactionEvent`](../../../../api-reference/payments/objects/transaction-event.mdx) object will have provided `pspReference`, and will be used in the
 [recalculation of the transaction's amount process](/developer/payments/lifecycle.mdx#recalculations-of-amounts).
 
 ### Request
 
 Saleor will send a
-[TRANSACTION_REFUND_REQUESTED](../../../../api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_refund_requested)
-webhook by using the [TransactionRefundRequested](../../../../api-reference/payments/objects/transaction-refund-requested) subscription type or with a pre-defined payload in case of a missing subscription query.
+[`TRANSACTION_REFUND_REQUESTED`](../../../../api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_refund_requested)
+webhook by using the [`TransactionRefundRequested`](../../../../api-reference/payments/objects/transaction-refund-requested) subscription type or with a pre-defined payload in case of a missing subscription query.
 
 More details about building webhook subscription query can be found
 [here](../../../extending/webhooks/subscription-webhook-payloads).
@@ -360,8 +360,8 @@ subscription {
 
 :::note
 
-`grantedRefund` - This field was introduced in **Saleor 3.15**. It contains the details about [OrderGrantedRefund](api-reference/orders/objects/order-granted-refund.mdx) related to the the refund request action.
-The field will contain OrderGrantedRefund when a refund request was triggered by calling [transactionRequestRefundForGrantedRefund](../../../../api-reference/payments/mutations/transaction-request-refund-for-granted-refund) mutation.
+`grantedRefund` - This field was introduced in **Saleor 3.15**. It contains the details about [`OrderGrantedRefund`](api-reference/orders/objects/order-granted-refund.mdx) related to the the refund request action.
+The field will contain OrderGrantedRefund when a refund request was triggered by calling [`transactionRequestRefundForGrantedRefund`](../../../../api-reference/payments/mutations/transaction-request-refund-for-granted-refund) mutation.
 
 :::
 
@@ -405,7 +405,7 @@ App needs to at least return the `pspReference` of the requested action. This is
 when the payment provider doesn't return a status of the requested action in the response.
 In this situation, the status of the action is delivered by an asynchronous notification that
 should be handled by App, and passed to Saleor by using the
-[transactionEventReport](/developer/payments/transactions#reporting-actions-for-transactions)
+[`transactionEventReport`](/developer/payments/transactions#reporting-actions-for-transactions)
 mutation.
 
 The response in this case should have the following structure:
@@ -422,8 +422,8 @@ The app has the possibility to report the status of the requested action immedia
 This is a common case when the payment provider returns the status of the action in
 response to the requested action.
 The payload response has to contain at least `pspReference`, `result` (
-[REFUND_SUCCESS](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumrefund_success)
-or [REFUND_FAILURE](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumrefund_failure)),
+[`REFUND_SUCCESS`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumrefund_success)
+or [`REFUND_FAILURE`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumrefund_failure)),
 and `amount` fields.
 
 The response in this case should have the following structure:
@@ -454,16 +454,16 @@ This feature was introduced in **Saleor 3.13**.
 
 :::
 
-The synchronous [PAYMENT_GATEWAY_INITIALIZE_SESSION](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumpayment_gateway_initialize_session)
-webhook is called when a customer requests payment gateway initialization by calling the [paymentGatewayInitialize](developer/payments/transactions.mdx#initialize-payment-gateway) mutation. The webhook contains details about the object (`Order`/`Checkout`)
+The synchronous [`PAYMENT_GATEWAY_INITIALIZE_SESSION`](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumpayment_gateway_initialize_session)
+webhook is called when a customer requests payment gateway initialization by calling the [`paymentGatewayInitialize`](developer/payments/transactions.mdx#initialize-payment-gateway) mutation. The webhook contains details about the object (`Order`/`Checkout`)
 for which the payment gateway initialization was requested, the requested amount, and the `data` received from the frontend.
 As a response, the webhook expects the `data` field with all initialization details that will be passed to the storefront.
 
 ### Request
 
 Saleor will send a
-[PAYMENT_GATEWAY_INITIALIZE_SESSION](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumpayment_gateway_initialize_session)
-webhook by using the [PaymentGatewayInitializeSession](api-reference/payments/objects/payment-gateway-initialize-session.mdx) subscription type or with a pre-defined payload in case of a missing subscription query.
+[`PAYMENT_GATEWAY_INITIALIZE_SESSION`](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumpayment_gateway_initialize_session)
+webhook by using the [`PaymentGatewayInitializeSession`](api-reference/payments/objects/payment-gateway-initialize-session.mdx) subscription type or with a pre-defined payload in case of a missing subscription query.
 
 More details about building webhook subscription query can be found
 [here](../../../extending/webhooks/subscription-webhook-payloads).
@@ -514,7 +514,7 @@ The example below shows the pre-defined payload that will be used in the case wh
 
 ### Response
 
-The app needs to return the `data` field. The `data` received from the webhook will be returned as a [paymentGatewayInitialize](developer/payments/overview.mdx#initialize-payment-gateway) mutation response.
+The app needs to return the `data` field. The `data` received from the webhook will be returned as a [`paymentGatewayInitialize`](developer/payments/overview.mdx#initialize-payment-gateway) mutation response.
 
 ```json
 {
@@ -533,8 +533,8 @@ This feature was introduced in **Saleor 3.13**.
 
 :::
 
-The synchronous [TRANSACTION_INITIALIZE_SESSION](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_initialize_session) webhook
-is called when a customer begins processing a payment by calling the [transactionInitialize](/developer/payments/payment-apps.mdx#initialize-transaction)
+The synchronous [`TRANSACTION_INITIALIZE_SESSION`](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_initialize_session) webhook
+is called when a customer begins processing a payment by calling the [`transactionInitialize`](/developer/payments/payment-apps.mdx#initialize-transaction)
 mutation. The webhook contains details about the object (`Order`/`Checkout`) related to this action, the `transactionItem` object, details related to the
 requested action, and the `data` passed in the mutation input. Saleor expects the response to be in the proper format. Based on the response, the `transactionItem`'s amount can be marked as fully covered
 or marked as a transaction that requires additional actions from the customer, such as processing 3D secure action.
@@ -548,8 +548,8 @@ The `idempotencyKey` should be passed to the payment provider to recognize the r
 ### Request
 
 Saleor will send a
-[TRANSACTION_INITIALIZE_SESSION](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_initialize_session)
-webhook by using the [TransactionInitializeSession](api-reference/payments/objects/transaction-initialize-session.mdx) subscription type or with a pre-defined payload in case of a missing subscription query.
+[`TRANSACTION_INITIALIZE_SESSION`](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_initialize_session)
+webhook by using the [`TransactionInitializeSession`](api-reference/payments/objects/transaction-initialize-session.mdx) subscription type or with a pre-defined payload in case of a missing subscription query.
 
 More details about building webhook subscription query can be found
 [here](../../../extending/webhooks/subscription-webhook-payloads).
@@ -651,10 +651,10 @@ This feature was introduced in **Saleor 3.13**.
 
 :::
 
-The [TRANSACTION_PROCESS_SESSION](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_process_session) webhook is called synchronously when
+The [`TRANSACTION_PROCESS_SESSION`](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_process_session) webhook is called synchronously when
 a customer needs to process additional actions received as a response from either
-the [transactionInitialize](/developer/payments/payment-apps.mdx#initialize-transaction) or [transactionProcess](/developer/payments/overview.mdx#process-transaction) mutations. This webhook is triggered when the customer calls the
-[transactionProcess](/developer/payments/overview.mdx#process-transaction) mutation.
+the [`transactionInitialize`](/developer/payments/payment-apps.mdx#initialize-transaction) or [`transactionProcess`](/developer/payments/overview.mdx#process-transaction) mutations. This webhook is triggered when the customer calls the
+[`transactionProcess`](/developer/payments/overview.mdx#process-transaction) mutation.
 It contains details about the `Order` or `Checkout` object related to this action, the `transactionItem` object, details related to the requested action, and the `data` passed in the mutation input.
 Saleor expects the response to be in the proper format. Based on the response, the amount of the `transactionItem` can be marked as fully covered or marked as a transaction
 that requires additional actions from the customer, such as processing a 3D secure action.
@@ -662,8 +662,8 @@ that requires additional actions from the customer, such as processing a 3D secu
 ### Request
 
 Saleor will send a
-[TRANSACTION_PROCESS_SESSION](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_process_session)
-webhook by using the [TransactionProcessSession](/api-reference/payments/objects/transaction-process-session.mdx) subscription type or with a pre-defined payload in case of a missing subscription query.
+[`TRANSACTION_PROCESS_SESSION`](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumtransaction_process_session)
+webhook by using the [`TransactionProcessSession`](/api-reference/payments/objects/transaction-process-session.mdx) subscription type or with a pre-defined payload in case of a missing subscription query.
 
 More details about building webhook subscription query can be found
 [here](../../../extending/webhooks/subscription-webhook-payloads).

--- a/docs/developer/payments/payment-apps.mdx
+++ b/docs/developer/payments/payment-apps.mdx
@@ -14,7 +14,7 @@ In this guide, we use the terms **Payment App** and **Payment Gateway** intercha
 
 :::
 
-### Processing payments with the Payment App
+### Processing Payments With the Payment App
 
 This section describes the flow for processing payments using Payment Apps. The communication between the storefront and the Payment App
 goes through Saleor. Based on the Payment App's response, Saleor creates or updates the transactions with the appropriate [statuses and balances](developer/payments/overview.mdx#recalculations-of-transaction-amounts).
@@ -56,7 +56,7 @@ sequenceDiagram
   PaymentProvider -->>- Storefront: Payment successful
 ```
 
-### Creating orders
+### Creating Orders
 
 Payment Apps support two distinct ways of processing checkouts:
 
@@ -67,7 +67,7 @@ The first approach is used by default. It means that the order can be only creat
 
 In both cases, the order is created by calling the [`checkoutComplete`](api-reference/checkout/mutations/checkout-complete.mdx) mutation.
 
-### Initialize payment gateway
+### Initialize Payment Gateway
 
 To initialize the payment app, call the [`paymentGatewayInitialize`](api-reference/payments/mutations/payment-gateway-initialize.mdx) mutation.
 The [`data`](api-reference/payments/inputs/payment-gateway-to-initialize.mdx#paymentgatewaytoinitializedatajson-) provided in the
@@ -144,7 +144,7 @@ The response:
 The mutation will trigger the [`PAYMENT_GATEWAY_INITIALIZE_SESSION`](api-reference/webhooks/enums/webhook-event-type-sync-enum.mdx#webhookeventtypesyncenumpayment_gateway_initialize_session) webhook.
 For more details about this webhook, please refer to the [Transaction events guide](developer/extending/webhooks/synchronous-events/transaction.mdx#initialize-payment-gateway-session).
 
-### Initialize transaction
+### Initialize Transaction
 
 To initiate payment processing, call the [`transactionInitialize`](api-reference/payments/mutations/transaction-initialize.mdx) mutation.
 The [`data`](api-reference/payments/inputs/payment-gateway-to-initialize.mdx#paymentgatewaytoinitializedatajson-) provided in the
@@ -265,7 +265,7 @@ The current status of payment can be determined based on the value of [`transact
 Pending statuses are used when the Payment App requires additional time or a manual action on the payment provider side to process the payment.
 Depending on the implementation, the Payment App may report the final status of the payment later using the [`transactionEventReport`](developer/payments/overview.mdx#reporting-actions-for-transactions) mutation.
 
-### Process transaction
+### Process Transaction
 
 If [`transactionInitialize`](api-reference/payments/mutations/transaction-initialize.mdx) or [`transactionProcess`](api-reference/payments/mutations/transaction-process.mdx)
 returns `transactionEvent.type` equal to [`AUTHORIZATION_ACTION_REQUIRED`](api-reference/payments/enums/transaction-event-type-enum.mdx#transactioneventtypeenumauthorization_action_required)
@@ -336,6 +336,6 @@ The response:
 The current status of payment can be determined based on the value of [`transactionEvent.type`](api-reference/payments/enums/transaction-event-type-enum.mdx).
 On some occasions, multiple calls to [`transactionProcess`](api-reference/payments/mutations/transaction-process.mdx) may be required to proceed with the payment.
 
-### Related resources
+### Related Resources
 
 - [Building payment apps](developer/extending/apps/building-payment-app.mdx) - Guide on how to build a payment app

--- a/docs/developer/payments/payment-apps.mdx
+++ b/docs/developer/payments/payment-apps.mdx
@@ -336,6 +336,6 @@ The response:
 The current status of payment can be determined based on the value of [`transactionEvent.type`](api-reference/payments/enums/transaction-event-type-enum.mdx).
 On some occasions, multiple calls to [`transactionProcess`](api-reference/payments/mutations/transaction-process.mdx) may be required to proceed with the payment.
 
-### Community resources
+### Related resources
 
-- [witoszekdev/dummy-payment-server](https://github.com/witoszekdev/dummy-payment-server) - App for testing Transactions API without a real payment provider
+- [Building payment apps](developer/extending/apps/building-payment-app.mdx) - Guide on how to build a payment app

--- a/docs/developer/payments/transactions.mdx
+++ b/docs/developer/payments/transactions.mdx
@@ -2,6 +2,11 @@
 title: Transactions
 ---
 
+A transaction represents a payment instance created in Order or Checkout. It holds a list of events that make up the payment process. Each event has a type that describes the action taken on the transaction. You can see the complete list of events in the [`TransactionEventTypeEnum`](api-reference/payments/enums/transaction-event-type-enum.mdx).
+
+Besides the events, a transaction also contains other payment information, like the amount or currency.
+
+
 ### Creating transactions
 
 Transaction stores details of a payment transaction attached to an order or a checkout:

--- a/docs/developer/payments/transactions.mdx
+++ b/docs/developer/payments/transactions.mdx
@@ -323,3 +323,11 @@ sequenceDiagram
     App -->>- Saleor: Return PSP<br> Reference and details<br> about completed action
     Saleor ->> Saleor: Update transaction amounts
 ```
+
+### Webhooks
+
+Follow [Transactions Webhook Events](/developer/extending/webhooks/synchronous-events/transaction.mdx) guide.
+
+## Related resources
+
+- [Building Payment Apps](/developer/extending/apps/building-payment-app.mdx)


### PR DESCRIPTION
While going through the tutorial, I added some optimizations to the content:

* Linked chapters together
* Added prerequisite reading as it is better that the reader first understands the payment APIs usage before building them. This removes the additional context required
* Made some sentences to be more concise 
* Change slightly the order of the content for fluidity

Next step suggestions:
We can extract the next parts and present them as a separate repo for reference, as most of the tutorial can be technology agnostic, making it appealing to a wider audience. The next js parts are quite small so we can leave out specifics in the README of the repository.