### PR TITLE
Remove stripe plugin deprecation note

### DIFF
--- a/docs/developer/app-store/legacy-plugins/stripe.mdx
+++ b/docs/developer/app-store/legacy-plugins/stripe.mdx
@@ -2,12 +2,6 @@
 title: Stripe
 ---
 
-:::warning
-This plugin is deprecated!
-
-If you plan on building a new integration with Saleor, we recommend building [an app](developer/extending/apps/overview.mdx) instead.
-:::
-
 Stripe plugin uses [custom payment flow](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements) to process customer transactions.
 
 :::note


### PR DESCRIPTION
This plugin is not deprecated at this moment.

Link to the Stripe App was also broken