### PR TITLE
Adjust transaction page

### DIFF
--- a/docs/developer/extending/webhooks/synchronous-events/transaction.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/transaction.mdx
@@ -129,7 +129,7 @@ The response in this case should have the following structure:
 The app has the possibility to report the status of the requested action immediately.
 This is a common case when the payment provider returns the status of the action in
 response to the requested action.
-The payload response has to contain at least `pspReference`, `result` (
+The payload response has to contain at least `pspReference` (optional for `CHARGE_FAILURE`), `result` (
 [`CHARGE_SUCCESS`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcharge_success)
 or [`CHARGE_FAILURE`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcharge_failure)),
 and `amount` fields.
@@ -138,7 +138,7 @@ The response in this case should have the following structure:
 
 ```json
 {
-  "pspReference": "<psp reference recieved from payment provider>",
+  "pspReference": "<[Optional for CHARGE_FAILURE] psp reference recieved from payment provider>",
   "result": "<CHARGE_SUCCESS or CHARGE_FAILURE>",
   "amount": "<Decimal amount of the processed action>",
   "time": "<[Optional] time of the action>",
@@ -264,7 +264,7 @@ The response in this case should have the following structure:
 The app has the possibility to report the status of the requested action immediately.
 This is a common case when the payment provider returns the status of the action in
 response to the requested action.
-The payload response has to contain at least `pspReference`, `result` (
+The payload response has to contain at least `pspReference` (optional for `CANCEL_FAILURE`), `result` (
 [`CANCEL_SUCCESS`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcancel_success)
 or [`CANCEL_FAILURE`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumcancel_failure)),
 and `amount` fields.
@@ -273,7 +273,7 @@ The response in this case should have the following structure:
 
 ```json
 {
-  "pspReference": "<psp reference recieved from payment provider>",
+  "pspReference": "<[Optional for CANCEL_FAILURE] psp reference recieved from payment provider>",
   "result": "<CANCEL_SUCCESS or CANCEL_FAILURE>",
   "amount": "<Decimal amount of the processed action>",
   "time": "<[Optional] time of the action>",
@@ -421,7 +421,7 @@ The response in this case should have the following structure:
 The app has the possibility to report the status of the requested action immediately.
 This is a common case when the payment provider returns the status of the action in
 response to the requested action.
-The payload response has to contain at least `pspReference`, `result` (
+The payload response has to contain at least `pspReference` (optional for `REFUND_FAILURE`), `result` (
 [`REFUND_SUCCESS`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumrefund_success)
 or [`REFUND_FAILURE`](../../../../api-reference/payments/enums/transaction-event-type-enum#transactioneventtypeenumrefund_failure)),
 and `amount` fields.
@@ -430,7 +430,7 @@ The response in this case should have the following structure:
 
 ```json
 {
-  "pspReference": "<psp reference recieved from payment provider>",
+  "pspReference": "<[Optional for REFUND_FAILURE] psp reference recieved from payment provider>",
   "result": "<REFUND_SUCCESS or REFUND_FAILURE>",
   "amount": "<Decimal amount of the processed action>",
   "time": "<[Optional] time of the action>",
@@ -620,7 +620,7 @@ The response in this case should have the following structure:
 
 ```json
 {
-  "pspReference": "<psp reference recieved from payment provider>",
+  "pspReference": "<[Optional for some results, see details below] psp reference recieved from payment provider>",
   "result": "CHARGE_SUCCESS or CHARGE_FAILURE or CHARGE_REQUEST or AUTHORIZATION_SUCCESS or AUTHORIZATION_FAILURE or AUTHORIZATION_REQUEST or AUTHORIZATION_ACTION_REQUIRED or CHARGE_ACTION_REQUIRED>",
   "amount": "<Decimal amount of the processed action>",
   "data": "<[Optional] JSON data tha will be returned to storefront>",
@@ -641,6 +641,20 @@ Below are the possible `result` values and their explanations:
 - `result:CHARGE_ACTION_REQUIRED`: Additional actions are required from the customer to charge the payment. Before finalizing these additional actions, the payment is treated as not processed.
 - `result:CHARGE_FAILURE`: Charging the payment has failed.
 - `result:AUTHORIZATION_FAILURE`: Authorizing the payment has failed.
+
+The `pspReference` is required for the following `results`:
+
+- `result:CHARGE_SUCCESS`
+- `result:AUTHORIZATION_SUCCESS`
+- `result:CHARGE_REQUEST`
+- `result:AUTHORIZATION_REQUEST`
+
+The `pspReference` is optional for the following `results`:
+
+- `result:AUTHORIZATION_ACTION_REQUIRED`
+- `result:CHARGE_ACTION_REQUIRED`
+- `result:CHARGE_FAILURE`
+- `result:AUTHORIZATION_FAILURE`
 
 ## Process transaction session
 
@@ -733,7 +747,7 @@ The response in this case should have the following structure:
 
 ```json
 {
-  "pspReference": "<psp reference recieved from payment provider>",
+  "pspReference": "[Optional for some results, see details below] <psp reference recieved from payment provider>",
   "result": "CHARGE_SUCCESS or CHARGE_FAILURE or CHARGE_REQUEST or AUTHORIZATION_SUCCESS or AUTHORIZATION_FAILURE or AUTHORIZATION_REQUEST or AUTHORIZATION_ACTION_REQUIRED or CHARGE_ACTION_REQUIRED>",
   "amount": "<Decimal amount of the processed action>",
   "data": "<[Optional] JSON data tha will be returned to storefront>",
@@ -754,3 +768,17 @@ Below are the possible `result` values and their explanations:
 - `result:CHARGE_ACTION_REQUIRED`: Additional actions are required from the customer to charge the payment. Before finalizing these additional actions, the payment is treated as not processed.
 - `result:CHARGE_FAILURE`: Charging the payment has failed.
 - `result:AUTHORIZATION_FAILURE`: Authorizing the payment has failed.
+
+The `pspReference` is required for the following `results`:
+
+- `result:CHARGE_SUCCESS`
+- `result:AUTHORIZATION_SUCCESS`
+- `result:CHARGE_REQUEST`
+- `result:AUTHORIZATION_REQUEST`
+
+The `pspReference` is optional for the following `results`:
+
+- `result:AUTHORIZATION_ACTION_REQUIRED`
+- `result:CHARGE_ACTION_REQUIRED`
+- `result:CHARGE_FAILURE`
+- `result:AUTHORIZATION_FAILURE`


### PR DESCRIPTION
Update the docs according to changes introduced in https://github.com/saleor/saleor/pull/16181.
For some webhooks responses, the `pspReference` becomes optional.