### PR TITLE
Add info about deprecating manager.perform_mutation

### DIFF
--- a/docs/upgrade-guides/2-11-to-3-0.mdx
+++ b/docs/upgrade-guides/2-11-to-3-0.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrading from 2.11 to 3.0
+title: Upgrading From 2.11 To 3.0
 sidebar_position: 1
 ---
 

--- a/docs/upgrade-guides/3-0-to-3-1.mdx
+++ b/docs/upgrade-guides/3-0-to-3-1.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrading from 3.0 to 3.1
+title: Upgrading From 3.0 To 3.1
 sidebar_position: 2
 ---
 

--- a/docs/upgrade-guides/3-1-to-3-2.mdx
+++ b/docs/upgrade-guides/3-1-to-3-2.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrading from 3.1 to 3.2
+title: Upgrading From 3.1 To 3.2
 sidebar_position: 3
 ---
 

--- a/docs/upgrade-guides/3-11-to-3-12.mdx
+++ b/docs/upgrade-guides/3-11-to-3-12.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrading from 3.11 to 3.12
+title: Upgrading From 3.11 To 3.12
 sidebar_position: 5
 ---
 

--- a/docs/upgrade-guides/3-12-to-3-13.mdx
+++ b/docs/upgrade-guides/3-12-to-3-13.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrading from 3.12 to 3.13
+title: Upgrading From 3.12 To 3.13
 sidebar_position: 6
 ---
 

--- a/docs/upgrade-guides/3-13-to-3-14.mdx
+++ b/docs/upgrade-guides/3-13-to-3-14.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrading from 3.13 to 3.14
+title: Upgrading From 3.13 To 3.14
 sidebar_position: 7
 ---
 

--- a/docs/upgrade-guides/3-16-to-3-17.mdx
+++ b/docs/upgrade-guides/3-16-to-3-17.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrading from 3.16 to 3.17
+title: Upgrading From 3.16 To 3.17
 sidebar_position: 8
 ---
 

--- a/docs/upgrade-guides/3-17-to-3-18.mdx
+++ b/docs/upgrade-guides/3-17-to-3-18.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrading from 3.17 to 3.18
+title: Upgrading From 3.17 To 3.18
 sidebar_position: 9
 ---
 

--- a/docs/upgrade-guides/3-18-to-3-19.mdx
+++ b/docs/upgrade-guides/3-18-to-3-19.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrading from 3.18 to 3.19
+title: Upgrading From 3.18 To 3.19
 sidebar_position: 10
 ---
 

--- a/docs/upgrade-guides/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/3-20-to-3-21.mdx
@@ -1,0 +1,15 @@
+---
+title: Upgrading from 3.20 to 3.21
+sidebar_position: 11
+---
+
+:::info
+To follow the zero-downtime strategy when upgrading to 3.21, **It is recommended to first migrate to latest 3.20.X** and turn on the Celery worker to process all data migrations asynchronously.
+Otherwise, you will need to downtime your solution to ensure correct data migration.
+:::
+
+## Deprecated `manager.perform_mutation` method
+
+Note: This change only affects open-source Saleor users with custom plugins overriding the `perform_mutation` plugin method.
+
+As part of gradual plugin deprecation, Saleor 3.20 deprecates the `perform_mutation` plugin hook. This method allowed to customize the mutation execution flow and call arbitrary logic during mutation execution. From now on, we recommend building such customizations via apps by reacting to webhooks triggered by mutations. The `perform_mutation` plugin method will be removed in Saleor 3.21.

--- a/docs/upgrade-guides/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/3-20-to-3-21.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrading from 3.20 to 3.21
+title: Upgrading From 3.20 To 3.21
 sidebar_position: 11
 ---
 

--- a/docs/upgrade-guides/3-5-to-3-6.mdx
+++ b/docs/upgrade-guides/3-5-to-3-6.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrading from 3.5 to 3.6
+title: Upgrading From 3.5 To 3.6
 sidebar_position: 4
 ---
 

--- a/docs/upgrade-guides/notify-user-deprecation.mdx
+++ b/docs/upgrade-guides/notify-user-deprecation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Migrating from NOTIFY_USER to dedicated events
+title: Migrating From NOTIFY_USER To Dedicated Events
 sidebar_label: Migrating from NOTIFY_USER
 ---
 


### PR DESCRIPTION
Related Core PR: https://github.com/saleor/saleor/pull/16511
In 3.20 we deprecate `perform_mutation` plugin method and we'll remove it in Saleor 3.21.