### PR TITLE
Improve description in Adyen app assumptions

### DIFF
--- a/docs/developer/app-store/apps/adyen/overview.mdx
+++ b/docs/developer/app-store/apps/adyen/overview.mdx
@@ -42,6 +42,7 @@ If you want to self-host the Adyen app, reach out to [our team <Mail size={12}/>
 
 - If Adyen doesn't respond to app request for [initialize transaction session](/developer/extending/webhooks/synchronous-events/transaction#initialize-transaction-session) or [process transaction session](/developer/extending/webhooks/synchronous-events/transaction#process-transaction-session) with `pspReference`:
   - App will return `CHARGE_ACTION_REQUIRED` or `AUTHORIZATION_ACTION_REQUIRED` as the transaction result. This is because Saleor doesn't require `pspReference` in app response for these transaction results.
+  - App can also return this status if an action is required to be performed on the storefront, this is incicated by an `action` object being included in the Adyen response.
 - App might not return `pspReference` for:
   - [Transaction refund webhook](/developer/extending/webhooks/synchronous-events/transaction#transaction-refund) with transaction status of `REFUND_FAILURE`
   - [Transaction charge webhook](/developer/extending/webhooks/synchronous-events/transaction#transaction-charge) with transaction status of `CHARGE_FAILURE`

--- a/docs/developer/app-store/apps/adyen/overview.mdx
+++ b/docs/developer/app-store/apps/adyen/overview.mdx
@@ -40,9 +40,9 @@ If you want to self-host the Adyen app, reach out to [our team <Mail size={12}/>
 
 ## Assumptions
 
-- If Adyen don't response to app request for [initialize transaction session](/developer/extending/webhooks/synchronous-events/transaction#initialize-transaction-session) or [process transaction session](/developer/extending/webhooks/synchronous-events/transaction#process-transaction-session) with `pspReference` or `action`:
-  - App will return `CHARGE_ACTION_REQUIRED` or `AUTHORIZATION_ACTION_REQUIRED` as the transaction result. This is because Saleor don't require `pspReference` in app response for this transaction result.
-- App will not return `pspReference` for:
+- If Adyen doesn't respond to app request for [initialize transaction session](/developer/extending/webhooks/synchronous-events/transaction#initialize-transaction-session) or [process transaction session](/developer/extending/webhooks/synchronous-events/transaction#process-transaction-session) with `pspReference`:
+  - App will return `CHARGE_ACTION_REQUIRED` or `AUTHORIZATION_ACTION_REQUIRED` as the transaction result. This is because Saleor doesn't require `pspReference` in app response for these transaction results.
+- App might not return `pspReference` for:
   - [Transaction refund webhook](/developer/extending/webhooks/synchronous-events/transaction#transaction-refund) with transaction status of `REFUND_FAILURE`
   - [Transaction charge webhook](/developer/extending/webhooks/synchronous-events/transaction#transaction-charge) with transaction status of `CHARGE_FAILURE`
   - [Transaction cancelation webhook](/developer/extending/webhooks/synchronous-events/transaction#transaction-cancelation) with transaction status of `CANCEL_FAILURE`


### PR DESCRIPTION
Improved description in Adyen app assumptions:
- app doesn't **always** return `pspReference` for XX_FAILURE responses, only when there wasn't a `pspReference` in a response from Adyen or an error was caused by internal app error handling
- app returns `XX_ACTION_REQUIRED` when there is no `pspReference` in the response from Adyen, response with `action` object might include a `pspReference` and it might be mapped to other response type
