### PR TITLE
Add info on potentially overcharged orders

### DIFF
--- a/docs/developer/app-store/legacy-plugins/adyen.mdx
+++ b/docs/developer/app-store/legacy-plugins/adyen.mdx
@@ -140,7 +140,7 @@ For the Adyen payment gateway, we need to provide:
 
 - `input.gateway`: ID of the payment gateway which should be assigned to this payment. For Adyen, it will be: `mirumee.payments.adyen`.
 
-- `input.amount`: Amount of payment to process.
+- `input.amount`: Amount of payment to process. Must be equal to `checkout.totalPrice`.
 
 - `input.returnUrl`: URL to where the customer should be taken back to after a redirection.
 
@@ -236,6 +236,13 @@ When payment doesn't require any additional action from the customer, Saleor wil
   }
 }
 ```
+
+:::note
+
+To create an order, the payment must cover the order total. However, we do not verify if an overpayment occurs.
+In such cases, the order will still be created, and the excess amount must be handled manually.
+
+:::
 
 ### Processing the checkout payment with additional actions required
 

--- a/docs/developer/app-store/legacy-plugins/np-atobarai.mdx
+++ b/docs/developer/app-store/legacy-plugins/np-atobarai.mdx
@@ -129,6 +129,12 @@ mutation {
 }
 ```
 
+:::note
+
+The provided `amount` in `checkoutPaymentCreate.input` must be equal to `checkout.totalPrice`.
+
+:::
+
 ## Completing the checkout
 
 After we create a payment object for the NP Atobarai payment gateway,
@@ -157,6 +163,13 @@ If the credit check was successful, an order will be created.
 
 In case of errors, NP recommends to display an error according to the communication guidelines available in their documentation.
 Since customers most likely won't be able to fix that error, NP recommends offering your customers an alternative payment method.
+
+:::note
+
+To create an order, the payment must cover the order total. However, we do not verify if an overpayment occurs.
+In such cases, the order will still be created, and the excess amount must be handled manually.
+
+:::
 
 ## Handling errors during checkout
 

--- a/docs/developer/app-store/plugins/stripe.mdx
+++ b/docs/developer/app-store/plugins/stripe.mdx
@@ -118,6 +118,12 @@ mutation {
 }
 ```
 
+:::note
+
+The provided `amount` in `checkoutPaymentCreate.input` must be equal to `checkout.totalPrice`.
+
+:::
+
 ## Completing the checkout
 
 The purpose of the operation is to ensure this checkout is correct. The validation consists of checking:
@@ -300,6 +306,13 @@ Here are the example scenarios that may end up with payment refunding:
 - the checkout is not fully paid
 - some products became unavailable od there is not enough stock of them
 - the processed payment became inactive
+
+:::
+
+:::note
+
+To create an order, the payment must cover the order total. However, we do not verify if an overpayment occurs.
+In such cases, the order will still be created, and the excess amount must be handled manually.
 
 :::
 

--- a/docs/developer/checkout/lifecycle.mdx
+++ b/docs/developer/checkout/lifecycle.mdx
@@ -27,6 +27,12 @@ The following are the requirements to finalize the checkout:
 
 4. The [payments](/developer/payments/overview.mdx) are processed unless the `Channel` setting of the checkout has [`allowUnpaidOrders`](/api-reference/miscellaneous/objects/order-settings#ordersettingsallowunpaidordersboolean--) setting enabled or checkout's total is `0`. If you need to bypass this setting, you use [`orderCreateFromCheckout`](api-reference/orders/mutations/order-create-from-checkout.mdx).
 
+:::note
+
+If case an order is overcharged, it will still be created. The overcharge must be handled manually.
+
+:::
+
 ## Checkout Expiration and Deletion
 
 To avoid overloading the database, unfinished and unpaid checkouts are automatically deleted after a specified period from their last modification:


### PR DESCRIPTION
- Add info on potentially overcharged orders
- Add info that `amount` in `checkoutPaymentCreate` must be equal to `checkout.totalPrice`