### PR TITLE
Explain automatic checkout completion option

### DIFF
--- a/docs/developer/checkout/cookbook.mdx
+++ b/docs/developer/checkout/cookbook.mdx
@@ -163,6 +163,13 @@ See example [repository](https://github.com/saleor/saleor-app-checkout-prices) f
 
 You can use a phone number instead of an email address to identify customers. While Saleor always requires email to create orders, you can use the `email` field as a phone number or other semantic meaning. For example: `123456789@noreply.yourcompany.com`. Make sure always to use **domain names you own**, to avoid leaking user data.
 
+## Automatic checkout completion
+
+The checkout can be automatically completed once full payment is received when using Payment Apps.
+
+For more details, read [here](/developer/payments/transactions#automatic-checkout-completion).
+
+
 ## Order approvals and quotes
 
 Example order approval flow:

--- a/docs/developer/payments/lifecycle.mdx
+++ b/docs/developer/payments/lifecycle.mdx
@@ -69,7 +69,7 @@ stateDiagram-v2
 
 ```
 
-Charge status depends on:
+Authorize status depends on:
 
 - the sum of **charged** transactions
 - the sum of **authorized** transactions
@@ -77,6 +77,34 @@ Charge status depends on:
 - the `order.total` value
 
 The difference between `total` and `totalGrantedRefund` is compared with the sum of **charged** and **authorized** transactions. The result is one of the statuses: `PARTIAL`, `FULL`. If no transaction has been charged, the status is `NONE`.
+
+#### Authorization status calculation for Checkout
+
+The status is calculated based on all transactions assigned to the `Checkout`. 
+
+For a checkout, authorization means that funds have been either authorized or charged (or a combination of partially charged and partially authorized).
+The status takes into account the following fields: `authorizedAmount`, `chargedAmount`, `authorizePendingAmount`, and `chargePendingAmount`:
+
+- **NONE**: No funds have been authorized.
+- **PARTIAL**: The available funds do not fully cover the checkout's total amount.
+- **FULL**: The funds fully cover the checkout's total amount. At this point, `checkoutComplete` can be called to convert the checkout into an order. 
+
+Note that pending amounts (success or failure) will be confirmed later by the payment app. This means the system can create an order that may remain unpaid if the pending amounts eventually fail.
+
+#### Available transitions
+
+- Status is updated on operations that change the checkout's `total`, or transactions.
+
+#### Authorization status calculation for Order
+
+The status is calculated based on all transactions assigned to the `Order`.
+Authorization means that funds have been either fully or partially authorized or charged.
+Unlike checkout, this status does not consider pending amounts.
+It uses the fields `authorizedAmount` and `chargedAmount`, and the calculation is adjusted by subtracting `order.totalGrantedRefund` from the total.
+
+- **NONE**: No funds have been authorized.
+- **PARTIAL**: The authorized and charged funds do not fully cover the amount of `order.total - order.totalGrantedRefund`.
+- **FULL**: The authorized and charged funds fully cover the amount of `order.total - order.totalGrantedRefund`.
 
 #### Available transitions
 
@@ -109,6 +137,32 @@ Charge status depends on:
 - the `order.total` value
 
 The difference between `total` and `totalGrantedRefund` is compared with **charged** transactions, and the result is one of the statuses: `PARTIAL`, `FULL`, `OVERCHARGED`. If no transaction has been charged, the status is `NONE`.
+
+#### Charge status calculations for Checkout
+
+The status is calculated based on all transactions assigned to the checkout.
+It takes into account the fields: `chargedAmount` and `chargePendingAmount`.
+
+- **NONE**: No funds have been charged.
+- **PARTIAL**: The charged funds do not fully cover the checkout's total amount.
+- **FULL**: The charged funds fully cover the checkout's total. At this point, `checkoutComplete` can be called to convert the checkout into an order.
+However, pending amounts (success/failure) will be confirmed later by the payment app, which means the created order could still remain unpaid if the pending amounts fail.
+- **OVERCHARGED**: The charged funds exceed the checkout's total. In this case, `checkoutComplete` can still be called to convert the checkout into an order.
+
+#### Available transitions
+
+- Status is updated on operations that change the checkouts `total`, or transactions.
+
+#### Charge status calculations for Order
+
+The status is calculated based on all transactions assigned to the order.
+It uses the field `chargedAmount` and does not consider **pending amounts** (which differs from the charge status of the checkout).
+The amount used for the status calculation is reduced by `order.totalGrantedRefund`.
+
+- **NONE**: No funds have been charged.
+- **PARTIAL**: The charged funds do not fully cover the amount of `order.total - order.totalGrantedRefund`.
+- **FULL**: The charged funds fully cover the amount of `order.total - order.totalGrantedRefund`.
+- **OVERCHARGED**: The charged funds exceed the amount of `order.total - order.totalGrantedRefund`.
 
 #### Available transitions
 

--- a/docs/developer/payments/lifecycle.mdx
+++ b/docs/developer/payments/lifecycle.mdx
@@ -76,11 +76,11 @@ Authorize status depends on:
 - the `order.totalGrantedRefund` value
 - the `order.total` value
 
-The difference between `total` and `totalGrantedRefund` is compared with the sum of **charged** and **authorized** transactions. The result is one of the statuses: `PARTIAL`, `FULL`. If no transaction has been charged, the status is `NONE`.
+The difference between `total` and `totalGrantedRefund` is compared with the sum of **charged** and **authorized** transactions. The result is one of the statuses: `PARTIAL`, `FULL`. If no transaction has been authorized, the status is `NONE`.
 
 #### Authorization status calculation for Checkout
 
-The status is calculated based on all transactions assigned to the `Checkout`. 
+The status is calculated based on all  `TransactionItem`'s assigned to the `Checkout`. 
 
 For a checkout, authorization means that funds have been either authorized or charged (or a combination of partially charged and partially authorized).
 The status takes into account the following fields: `authorizedAmount`, `chargedAmount`, `authorizePendingAmount`, and `chargePendingAmount`:
@@ -89,18 +89,24 @@ The status takes into account the following fields: `authorizedAmount`, `charged
 - **PARTIAL**: The available funds do not fully cover the checkout's total amount.
 - **FULL**: The funds fully cover the checkout's total amount. At this point, `checkoutComplete` can be called to convert the checkout into an order. 
 
+:::caution
 Note that pending amounts (success or failure) will be confirmed later by the payment app. This means the system can create an order that may remain unpaid if the pending amounts eventually fail.
+:::
 
 #### Available transitions
 
-- Status is updated on operations that change the checkout's `total`, or transactions.
+- Status is updated when Checkout's `totalAmount` is changed.
+- Status is updated when Checkout's `TransactionItem`'s amounts are updated.
 
 #### Authorization status calculation for Order
 
 The status is calculated based on all transactions assigned to the `Order`.
 Authorization means that funds have been either fully or partially authorized or charged.
-Unlike checkout, this status does not consider pending amounts.
 It uses the fields `authorizedAmount` and `chargedAmount`, and the calculation is adjusted by subtracting `order.totalGrantedRefund` from the total.
+
+:::caution
+Unlike checkout, this status does not consider pending amounts.
+:::
 
 - **NONE**: No funds have been authorized.
 - **PARTIAL**: The authorized and charged funds do not fully cover the amount of `order.total - order.totalGrantedRefund`.
@@ -108,7 +114,9 @@ It uses the fields `authorizedAmount` and `chargedAmount`, and the calculation i
 
 #### Available transitions
 
-- Status is updated on operations that change the order's `total,` `totalGrantedRefund`, or transactions.
+- Status is updated when Order's `totalAmount` is changed.
+- Status is updated when Order's `TransactionItem`'s amounts are updated.
+- Status is updated when `Order.grantedRefunds` are updated.
 
 ### Charge status
 
@@ -145,13 +153,25 @@ It takes into account the fields: `chargedAmount` and `chargePendingAmount`.
 
 - **NONE**: No funds have been charged.
 - **PARTIAL**: The charged funds do not fully cover the checkout's total amount.
-- **FULL**: The charged funds fully cover the checkout's total. At this point, `checkoutComplete` can be called to convert the checkout into an order.
-However, pending amounts (success/failure) will be confirmed later by the payment app, which means the created order could still remain unpaid if the pending amounts fail.
-- **OVERCHARGED**: The charged funds exceed the checkout's total. In this case, `checkoutComplete` can still be called to convert the checkout into an order.
+- **FULL**: The charged funds fully cover the checkout's total. At this point,
+the `CHECKOUT_FULLY_PAID` webhook event is sent, and `checkoutComplete` can be called
+to convert the checkout into an order.
+- **OVERCHARGED**: The charged funds exceed the checkout's total. In this case,
+the `CHECKOUT_FULLY_PAID` webhook event is sent as well, and `checkoutComplete`
+can still be called to convert the checkout into an order.
+
+:::caution
+When the checkout `chargeStatus` is either `FULL` or `OVERCHARGED`, the `authorizeStatus`
+also changes to `FULL`, allowing the checkout to be completed.
+However, any pending amounts (whether successful or failed) will be confirmed later
+by the payment application. This means that even though the order is created,
+it may still remain unpaid if the pending amounts fail to process.
+:::
 
 #### Available transitions
 
-- Status is updated on operations that change the checkouts `total`, or transactions.
+- Status is updated when Checkout's `totalAmount` is changed.
+- Status is updated when Checkout's `TransactionItem`'s amounts are updated.
 
 #### Charge status calculations for Order
 
@@ -166,7 +186,9 @@ The amount used for the status calculation is reduced by `order.totalGrantedRefu
 
 #### Available transitions
 
-- Status is updated on operations that change the order's `total`, `totalGrantedRefund`, or transactions.
+- Status is updated when Order's `totalAmount` is changed.
+- Status is updated when Order's `TransactionItem`'s amounts are updated.
+- Status is updated when `Order.grantedRefunds` are updated.
 
 ## Transactions recalculation of amounts
 

--- a/docs/developer/payments/transactions.mdx
+++ b/docs/developer/payments/transactions.mdx
@@ -371,7 +371,7 @@ Follow [Transactions Webhook Events](/developer/extending/webhooks/synchronous-e
 
 The checkout process can be automatically completed based on the transaction events, once the full payment is made.
 
-A checkout is considered fully paid when the [`checkout.charge_status`](/api-reference/checkout/objects/checkout#checkoutchargestatuscheckoutchargestatusenum---) 
+A checkout is considered fully paid when the [`Checkout.authorizeStatus`](/api-reference/checkout/objects/checkout#checkoutchargestatuscheckoutchargestatusenum---) 
 is set to `FULL`.
 This occurs when the total of the [`chargedAmount`](/api-reference/payments/objects/transaction-item#transactionitemchargedamountmoney---) 
 and [`chargePendingAmount`](/api-reference/payments/objects/transaction-item#transactionitemchargependingamountmoney---)
@@ -409,15 +409,18 @@ Query variables:
 
 :::info
 Enabling automatic checkout completion will not disrupt storefront functionality.
-If `checkoutComplete` is called for a checkout that has already been converted to an order,
+If `checkoutComplete` is called for a `Checkout` that has already been converted to an `Order`,
 the corresponding `Order` instance will be return.
 :::
 
 :::warning
-The checkout will be automatically completed even if some authorized or charged amounts are still pending,
+Checkout will be automatically completed even if some authorized or charged amounts are still pending,
 as long as the total amount is covered (`authorizeStatus` will be `FULL`).
 However, once the checkout is converted to an `Order`, the `authorizeStatus` will be `NONE`
 because pending amounts are not considered in the order status calculation.
+
+
+Keep in mind that a pending Transaction might be rejected later.
 
 Read more about payment statuses [here](/developer/payments/lifecycle#payment-status).
 :::

--- a/docs/developer/payments/transactions.mdx
+++ b/docs/developer/payments/transactions.mdx
@@ -413,6 +413,14 @@ If `checkoutComplete` is called for a checkout that has already been converted t
 the corresponding `Order` instance will be return.
 :::
 
+:::warning
+The checkout will be automatically completed even if some authorized or charged amounts are still pending,
+as long as the total amount is covered (`authorizeStatus` will be `FULL`).
+However, once the checkout is converted to an `Order`, the `authorizeStatus` will be `NONE`
+because pending amounts are not considered in the order status calculation.
+
+Read more about payment statuses [here](/developer/payments/lifecycle#payment-status).
+:::
 
 ## Related resources
 

--- a/docs/developer/payments/transactions.mdx
+++ b/docs/developer/payments/transactions.mdx
@@ -367,6 +367,53 @@ sequenceDiagram
 
 Follow [Transactions Webhook Events](/developer/extending/webhooks/synchronous-events/transaction.mdx) guide.
 
+### Automatic checkout completion
+
+The checkout process can be automatically completed based on the transaction events, once the full payment is made.
+
+A checkout is considered fully paid when the [`checkout.charge_status`](/api-reference/checkout/objects/checkout#checkoutchargestatuscheckoutchargestatusenum---) 
+is set to `FULL`.
+This occurs when the total of the [`chargedAmount`](/api-reference/payments/objects/transaction-item#transactionitemchargedamountmoney---) 
+and [`chargePendingAmount`](/api-reference/payments/objects/transaction-item#transactionitemchargependingamountmoney---)
+from all transactions covers the [`checkout.totalPrice`](/api-reference/checkout/objects/checkout#checkoutsubtotalpricetaxedmoney---).
+
+To enable automatic checkout completion, update the channel checkout settings using the configuration example below:
+```graphql
+mutation UpdateChannel($id: ID!,$input: ChannelUpdateInput!){
+  channelUpdate(id: $id, input: $input){
+    channel{
+      id
+      checkoutSettings {
+        automaticallyCompleteFullyPaidCheckouts
+      }
+    }
+    errors{
+      field
+      code
+      message
+    }
+  }
+}
+```
+Query variables:
+```json
+{
+  "id": "Q2hhbm5lbDox",
+  "input": {
+    "checkoutSettings": {
+      "automaticallyCompleteFullyPaidCheckouts": true
+    }
+  }
+}
+```
+
+:::info
+Enabling automatic checkout completion will not disrupt storefront functionality.
+If `checkoutComplete` is called for a checkout that has already been converted to an order,
+the corresponding `Order` instance will be return.
+:::
+
+
 ## Related resources
 
 - [Building Payment Apps](/developer/extending/apps/building-payment-app.mdx)


### PR DESCRIPTION
- Docs for https://github.com/saleor/saleor/pull/16782 (Should be merged together)
- Explain how `authorizeStatus` and `chargeStatus` work (resolves https://github.com/saleor/saleor-docs/issues/1010)
