### PR TITLE
Add note about IP address in adyen and add migration guide

### DIFF
--- a/docs/developer/app-store/apps/adyen/overview.mdx
+++ b/docs/developer/app-store/apps/adyen/overview.mdx
@@ -210,3 +210,59 @@ To disable this setting that go to the `Dashboard > Developers > Webhooks`. In u
 On the Webhook settings page make sure to uncheck "Delayed Capture" setting:
 
 ![Adyen dashboard webhook settings page, where Delayed Capture setting is available, the checkbox is unchecked](./adyen_webhook_settings_delayed_capture_2.png)
+
+### Transactions rejected due to fraud
+
+Adyen app sends [`customerIpAddress`](api-reference/payments/objects/transaction-initialize-session.mdx#transactioninitializesessioncustomeripaddressstring--) it receives from Saleor `TRANSACTION_INITIALIZE_SESSION` and `TRANSACTION_PROCESS_SESSION` to Adyen as [`shopperIP` field](https://docs.adyen.com/api-explorer/Checkout/71/post/sessions#request-shopperIP).
+
+If Adyen detects that IP address is suspicious, it might reject the payment. In such case, you should investigate the IP address and make sure that it's not blacklisted in your Adyen [Block and trust list](https://docs.adyen.com/risk-management/configure-manual-risk/referral-rules/#referral-shopper).
+
+#### Using proxy
+
+Keep in mind that if you use proxy for making request to Saleor on your customers behalf, you need to specify `customerIpAddress` field on your own in the `transactionInitialize` and `transactionProcess` mutation input:
+
+
+`transactionInitialize` mutation:
+```graphql
+mutation TransactionInitialize($checkoutId: ID!, $data: JSON, $customerIpAddress: String!) {
+  transactionInitialize(
+    id: $checkoutId
+    paymentGateway: {id: "app.saleor.adyen", data: $data}
+    customerIpAddress: $customerIpAddress # <-- provide customer IP address in your proxy implementation
+  ) {
+    data
+    transactionEvent {
+      pspReference
+      type
+    }
+    errors {
+      field
+      message
+      code
+    }
+  }
+}
+```
+
+`transactionProcess` mutation:
+
+```graphql
+mutation TransactionProcess($transactionId: ID!, $data: JSON, $customerIpAddress: String!) {
+  transactionProcess(
+    id: $transactionId
+    data: $data
+    customerIpAddress: $customerIpAddress
+  ) {
+    data
+    transactionEvent {
+      pspReference
+      type
+    }
+    errors {
+      field
+      message
+      code
+    }
+  }
+}
+```

--- a/docs/upgrade-guides/3-15-to-3-16.mdx
+++ b/docs/upgrade-guides/3-15-to-3-16.mdx
@@ -1,0 +1,20 @@
+---
+title: Upgrading From 3.15 To 3.16
+sidebar_position: 7
+---
+
+## `customerIpAddress` field
+
+Saleor 3.16 added `customerIpAddress` to [`TRANSACTION_INITIALIZE_SESSION`](/api-reference/payments/objects/transaction-initialize-session.mdx) and [`TRANSACTION_PROCESS_SESSION`](/api-reference/payments/objects/transaction-process-session.mdx) webhooks.
+
+This field is calculated based on the request's IP address. It might be consumed by Payment App and passed to a payment provider for fraud checking.
+
+:::danger
+If you are making requests on behalf of your customers (for example if you use a proxy or have a backend-for-frontend architecture), make sure to provide `customerIpAddress` parameter in [`transactionInitialize`](/api-reference/payments/mutations/transaction-initialize#transactioninitializecustomeripaddressstring--) and [`transactionProcess`](http://localhost:3000/api-reference/payments/mutations/transaction-process#transactionprocesscustomeripaddressstring--) mutations:
+
+Not providing `customerIpAddress` will result in an incorrect calculation of IP Address by Saleor that is sent to the Payment App, which might cause transactions to fail.
+
+Future Saleor version might make this field required if called by an app.
+:::
+
+To see an example how `customerIpAddress` might be consumed by a Payment App, [see Adyen App docs](/developer/app-store/apps/adyen/overview.mdx#transactions-rejected-due-to-fraud)


### PR DESCRIPTION
Added docs about `customerIpAddress` usage in Adyen app and migration guide for Saleor 3.15 -> 3.16 that mention this field.

> [!NOTE]
> Currently this field is not used by Adyen App, it will be re-enabled in future releases