### PR TITLE
Extend automatic checkout completion with info that the checkout will not be completed if any validation error occurs

### DIFF
--- a/docs/developer/payments/transactions.mdx
+++ b/docs/developer/payments/transactions.mdx
@@ -412,8 +412,18 @@ Query variables:
 }
 ```
 
-:::info
-If any issues occur during checkout validation (e.g., checkout contains unavailable items), the checkout will not be completed.
+:::warning
+If any issues occur during checkout validation, the checkout will not be completed.
+The checkout does not pass the validation when:
+  - contains unavailable items:
+    - one of the checkout line has missing product or variant channel listing or the price is not set;
+    - one of the product is not available for purchase;
+    - one of the product is set as not visible to the customers;
+  - billing address is not set;
+  - attached voucher is not applicable;
+  - attached gift card is not valid;
+  - shipping method is invalid;
+  - channel is inactive.
 
 You can view the specific issues using the `Checkout.problems` query. For more details, please refer to the [Checkout Problems page](/developer/checkout/problems).
 :::

--- a/docs/developer/payments/transactions.mdx
+++ b/docs/developer/payments/transactions.mdx
@@ -412,6 +412,12 @@ Query variables:
 }
 ```
 
+:::info
+If any issues occur during checkout validation (e.g., checkout contains unavailable items), the checkout will not be completed.
+
+You can view the specific issues using the `Checkout.problems` query. For more details, please refer to the [Checkout Problems page](/developer/checkout/problems).
+:::
+
 :::danger
 **Once this setting is enabled, you should verify if your connected services, including storefront, can handle this flow.**
 

--- a/docs/upgrade-guides/core/3-19-to-3-20.mdx
+++ b/docs/upgrade-guides/core/3-19-to-3-20.mdx
@@ -98,7 +98,7 @@ If automatic checkout completion is not enabled in a `Channel`, storefront shoul
 The checkout may not be automatically completed due to issues that arise during validation.
 
 You can identify any existing problems using the `Checkout.problems` query.
-For more information, refer to the  [Checkout Problems page](/developer/checkout/problems).
+For more information, refer to the [Checkout Problems page](/developer/checkout/problems).
 
 :::
 

--- a/docs/upgrade-guides/core/3-19-to-3-20.mdx
+++ b/docs/upgrade-guides/core/3-19-to-3-20.mdx
@@ -95,6 +95,14 @@ If automatic checkout completion is not enabled in a `Channel`, storefront shoul
 :::
 
 :::tip
+The checkout may not be automatically completed due to issues that arise during validation.
+
+You can identify any existing problems using the `Checkout.problems` query.
+For more information, refer to the  [Checkout Problems page](/developer/checkout/problems).
+
+:::
+
+:::tip
 To determine if `Checkout` was completed you can also rely on response from `transactionInitialize` or `transactionProcess` mutations by checking the `TransactionEvent` object returned in the mutation response.
 
 Such transaction is considered successful in a context of a `Checkout` when the `TransactionEvent`'s `amount` is equal to `Checkout.totalPrice` and its `type` is one of these:


### PR DESCRIPTION
Extend the docs regarding `automatic checkout completion` - add an info that the checkout will not be automatically completed when any validation error occurs. Explain how to check the problems on checkout.

Related PR: https://github.com/saleor/saleor/pull/16941