### PR TITLE
Turn off deprecated GA plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -177,10 +177,6 @@ module.exports = {
         googleTagManager: {
           containerId: "GTM-WC5R92LK",
         },
-        // Google Analytics tracking ID to track page views.
-        googleAnalytics: {
-          trackingID: "UA-10159761-25",
-        },
       },
     ],
   ],


### PR DESCRIPTION
https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-analytics
No package.json has to be modified since this plugin is part of another bundle.


The plugin is marked as deprecated and outdated, it has to be turned off.
After the merge well check if GTM integration is enough or we'll need to activate updated plugin.