### PR TITLE
Load GTM ID from the environment variable.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,6 +3,8 @@ require("dotenv").config();
 const { themes } = require("prism-react-renderer");
 const path = require("node:path");
 
+const gtmContainerId = process.env.GTM_CONTAINER_ID;
+
 module.exports = {
   title: "Saleor Commerce Documentation",
   tagline: "High performance, composable, headless commerce API.",
@@ -174,9 +176,11 @@ module.exports = {
           },
           sidebarPath: "sidebars.js",
         },
-        googleTagManager: {
-          containerId: "GTM-WC5R92LK",
-        },
+        ...(gtmContainerId && {
+          googleTagManager: {
+            containerId: gtmContainerId,
+          },
+        }),
       },
     ],
   ],


### PR DESCRIPTION
The GTM tag id has been added to the deployment settings and will be enabled only on production builds to prevent sending events from test deployments.