### PR TITLE
Inform about event report message limit

### DIFF
--- a/docs/developer/extending/webhooks/synchronous-events/transaction.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/transaction.mdx
@@ -135,7 +135,7 @@ The response in this case should have the following structure:
   "amount": "<Decimal amount of the processed action>",
   "time": "<[Optional] time of the action>",
   "externalUrl": "<[Optional] external url with action details>",
-  "message": "<[Optional] message related to the action>",
+  "message": "<[Optional] message related to the action. The maximum length is 512 characters; any text exceeding this limit will be truncated>",
   "actions": "<[Optional] list of actions available for the transaction. Possible items: CHARGE, REFUND, CANCEL>"
 }
 ```
@@ -264,7 +264,7 @@ The response in this case should have the following structure:
   "amount": "<Decimal amount of the processed action>",
   "time": "<[Optional] time of the action>",
   "externalUrl": "<[Optional] external url with action details>",
-  "message": "<[Optional] message related to the action>",
+  "message": "<[Optional] message related to the action. The maximum length is 512 characters; any text exceeding this limit will be truncated.>",
   "actions": "<[Optional] list of actions available for the transaction. Possible items: CHARGE, REFUND, CANCEL>"
 }
 ```
@@ -415,7 +415,7 @@ The response in this case should have the following structure:
   "amount": "<Decimal amount of the processed action>",
   "time": "<[Optional] time of the action>",
   "externalUrl": "<[Optional] external url with action details>",
-  "message": "<[Optional] message related to the action>",
+  "message": "<[Optional] message related to the action. The maximum length is 512 characters; any text exceeding this limit will be truncated>",
   "actions": "<[Optional] list of actions available for the transaction. Possible items: CHARGE, REFUND, CANCEL>"
 }
 ```
@@ -596,7 +596,7 @@ The response in this case should have the following structure:
   "data": "<[Optional] JSON data tha will be returned to storefront>",
   "time": "<[Optional] time of the action>",
   "externalUrl": "<[Optional] external url with action details.",
-  "message": "<[Optional] message related to the action>",
+  "message": "<[Optional] message related to the action. The maximum length is 512 characters; any text exceeding this limit will be truncated>",
   "actions": "<[Optional] list of actions available for the transaction. Possible items: CHARGE, REFUND, CANCEL>"
 }
 ```
@@ -717,7 +717,7 @@ The response in this case should have the following structure:
   "data": "<[Optional] JSON data tha will be returned to storefront>",
   "time": "<[Optional] time of the action>",
   "externalUrl": "<[Optional] external url with action details.",
-  "message": "<[Optional] message related to the action>",
+  "message": "<[Optional] message related to the action. The maximum length is 512 characters; any text exceeding this limit will be truncated>",
   "actions": "<[Optional] list of actions available for the transaction. Possible items: CHARGE, REFUND, CANCEL>"
 }
 ```

--- a/docs/developer/payments/transactions.mdx
+++ b/docs/developer/payments/transactions.mdx
@@ -198,7 +198,7 @@ If the amount cannot be determined, an error will be raised. (Refer to the addit
 - `pspReference`: The reference assigned to the action.
 - `time`: The time of the action.
 - `externalUrl`: The URL for the staff user to check the details of the action on the payment provider's page. This URL will be available in the Saleor Dashboard.
-- `message`: Message related to the action.
+- `message`: Message related to the action. The maximum length is 512 characters; any text exceeding this limit will be truncated.
 - `availableActions`: Current list of actions available for the transaction.
 
 :::info


### PR DESCRIPTION
Make clear that any message above 512 characters reported for transaction event, will be truncated.