### PR TITLE
docs: add security section

### DIFF
--- a/components/Icons/icons.jsx
+++ b/components/Icons/icons.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Shield } from "lucide-react";
 
 const paths = {
   graphql: (
@@ -105,26 +106,8 @@ const paths = {
       fill="currentColor"
     />
   ),
-  /**
-   * The 'shield' icon was created by Lucide.dev (https://lucide.dev/)
-   * and is licensed under ISC (https://opensource.org/license/isc-license-txt)
-   * A copy of the license is available under LICENSES/Lucide-LICENSE.txt.
-   *
-   * The icon can be modified and distributed as long as a copy of the license
-   * is provided.
-   *
-   * Modifications done: resized from 24x24 to 16x16.
-   */
   shield: (
-    <path
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M 19.998047 13.001953 C 19.998047 18 16.5 20.501953 12.339844 21.949219 C 12.123047 22.025391 11.882812 22.019531 11.671875 21.9375 C 7.5 20.501953 4.001953 18 4.001953 13.001953 L 4.001953 6 C 4.001953 5.449219 4.447266 4.998047 4.998047 4.998047 C 7.001953 4.998047 9.498047 3.802734 11.238281 2.279297 C 11.677734 1.904297 12.322266 1.904297 12.761719 2.279297 C 14.507812 3.808594 16.998047 4.998047 19.001953 4.998047 C 19.552734 4.998047 19.998047 5.449219 19.998047 6 Z M 19.998047 13.001953 "
-      transform="matrix(0.666667,0,0,0.666667,0,0)"
-    />
+    <Shield size={16} />
   ),
   feedback: (
     <svg

--- a/components/Icons/icons.jsx
+++ b/components/Icons/icons.jsx
@@ -105,6 +105,27 @@ const paths = {
       fill="currentColor"
     />
   ),
+  /**
+   * The 'shield' icon was created by Lucide.dev (https://lucide.dev/)
+   * and is licensed under ISC (https://opensource.org/license/isc-license-txt)
+   * A copy of the license is available under LICENSES/Lucide-LICENSE.txt.
+   *
+   * The icon can be modified and distributed as long as a copy of the license
+   * is provided.
+   *
+   * Modifications done: resized from 24x24 to 16x16.
+   */
+  shield: (
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M 19.998047 13.001953 C 19.998047 18 16.5 20.501953 12.339844 21.949219 C 12.123047 22.025391 11.882812 22.019531 11.671875 21.9375 C 7.5 20.501953 4.001953 18 4.001953 13.001953 L 4.001953 6 C 4.001953 5.449219 4.447266 4.998047 4.998047 4.998047 C 7.001953 4.998047 9.498047 3.802734 11.238281 2.279297 C 11.677734 1.904297 12.322266 1.904297 12.761719 2.279297 C 14.507812 3.808594 16.998047 4.998047 19.001953 4.998047 C 19.552734 4.998047 19.998047 5.449219 19.998047 6 Z M 19.998047 13.001953 "
+      transform="matrix(0.666667,0,0,0.666667,0,0)"
+    />
+  ),
   feedback: (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Security
+displayed_sidebar: main
 ---
 
 :::note

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -1,0 +1,67 @@
+---
+title: Security
+---
+
+:::note
+This section is currently not exhaustive.
+:::
+
+This document describes the different security measures and deployment settings provided by Saleor.
+
+*Looking to report a security issue instead? See our [Security Policy].*
+
+## External Connectivity
+
+### HTTP Redirects and Timeouts
+
+Out of the box, Saleor disables HTTP redirects for outgoing connections, and sets a strict timeout value (typically \<20s).
+
+This is a design choice intended to prevent potential Denial of Service (DoS) attacks from being done by internal actors.
+
+Without such measure in place, a malicious staff user could, for example, create an infinite redirection loop in a malicious endpoint and exhaust server resources.
+
+Timeout settings cannot be overridden dynamically. However, they can be altered inside [`settings.py`](https://github.com/saleor/saleor/blob/1f2127e1e92722cecae7409c0d26ac7ab05d23d8/saleor/settings.py#L961-L968).
+
+### IP Address Filtering (SSRF Protection)
+
+This section describes the IP address filtering capabilities of [Saleor Core]. **By default, Saleor rejects any outgoing traffic to private and loopback IP addresses.**
+
+This behavior prevents malicious staff users from accessing inward-facing resources, which could lead to unauthorized access to resources you may deploy within your networks or even gaining a foothold (such as achieving lateral movements to gain more privileges).
+
+For more in-depth information, refer to:
+
+* [CWE-918: Server-Side Request Forgery (SSRF)](https://cwe.mitre.org/data/definitions/918.html)
+* [The OWASP community page about SSRF attacks](https://owasp.org/www-community/attacks/Server_Side_Request_Forgery)
+
+**Implementation Details:**
+
+* **IP Addresses are Pinned:**  the resolved IP address for each outgoing HTTP(S) request is pinned, meaning that a malicious actor cannot set-up round-robin DNS responses or use race-condition attacks ([Time-of-Check](https://cwe.mitre.org/data/definitions/367.html)) to trick Saleor into connecting to a different IP address after validation.
+* **IP Address Validation for Each Request:**  validation is ran before sending each and every HTTP(S) request. This prevents a malicious actor from changing the DNS records after adding a non-malicious URL inside the database.
+
+**Settings:**
+
+* [`HTTP_IP_FILTER_ENABLED`](https://docs.saleor.io/setup/configuration#http_ip_filter_enabled) - controls whether the IP filtering feature should be enabled. **IP Filtering is enabled by default.**
+* [`HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS`](https://docs.saleor.io/setup/configuration#http_ip_filter_allow_loopback_ips) - whether to allow outgoing traffic to loopback addresses. **Loopback addresses are** **disallowed** **by default.**
+
+**Caveats:**
+
+* **Allow-Lists:**  it is not currently possible to put given IP addresses into an allow-list (or block-list). It currently only supports: "block-all" or "allow-all".
+
+**Additional Capabilities:**
+
+* **Proxies:**  SOCKS and HTTP proxies can be used in combination with the IP Filtering.
+
+  * The IP address used to establish the proxy tunnel itself is not restricted. However, any HTTP requests sent through the proxy will be filtered based on their destination IP address.
+
+    For example, setting `HTTPS_PROXY=socks5://10.0.0.1:8888` is allowed, but attempting to access `https://10.0.0.2` **through** the tunnel will be blocked.
+  * Can be configured through environment variables, such as:
+
+    ```python
+    $ export HTTP_PROXY="http://10.10.1.10:3128"
+    $ export HTTPS_PROXY="http://10.10.1.10:1080"
+    ```
+* **HTTP redirects:**  each redirection is checked whether it points to a private or loopback IP address range.
+
+[Security Policy]: https://github.com/saleor/.github/blob/-/SECURITY.md
+[Saleor Core]: https://github.com/saleor/saleor/
+

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -28,7 +28,7 @@ This section describes the IP address filtering capabilities of [Saleor Core]. *
 
 This behavior prevents malicious staff users from accessing inward-facing resources, which could lead to unauthorized access to resources you may deploy within your networks or even gaining a foothold (such as achieving lateral movements to gain more privileges).
 
-For more in-depth information, refer to:
+For in-depth details, refer to:
 
 * [CWE-918: Server-Side Request Forgery (SSRF)](https://cwe.mitre.org/data/definitions/918.html)
 * [The OWASP community page about SSRF attacks](https://owasp.org/www-community/attacks/Server_Side_Request_Forgery)
@@ -56,9 +56,11 @@ For more in-depth information, refer to:
     For example, setting `HTTPS_PROXY=socks5://10.0.0.1:8888` is allowed, but attempting to access `https://10.0.0.2` **through** the tunnel will be blocked.
   * Can be configured through environment variables, such as:
 
-    ```python
+    ```bash
     $ export HTTP_PROXY="http://10.10.1.10:3128"
     $ export HTTPS_PROXY="http://10.10.1.10:1080"
+    # Alternatively:
+    $ export ALL_PROXY="http://10.10.1.10:1080"
     ```
 * **HTTP redirects:**  each redirection is checked whether it points to a private or loopback IP address range.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -78,7 +78,7 @@ module.exports = {
     ref("setup/overview", "Self-hosting", "selfHost"),
     ref("developer/community/contributing", "Community", "community"),
     ref("upgrade-guides/index", "Upgrade Guides", "guides"),
-    ref("security/index", "Security", "security"),
+    ref("security/index", "Security", "shield"),
     {
       type: "link",
       label: "Report an Issue",

--- a/sidebars.js
+++ b/sidebars.js
@@ -78,6 +78,7 @@ module.exports = {
     ref("setup/overview", "Self-hosting", "selfHost"),
     ref("developer/community/contributing", "Community", "community"),
     ref("upgrade-guides/index", "Upgrade Guides", "guides"),
+    ref("security/index", "Security", "security"),
   ],
   concepts: [backToHome, ...coreConcepts],
   appStore: [backToHome, ...appStore],


### PR DESCRIPTION
This adds a 'Security' section, the intent of this page is to provide details about security features and design choices.

For now, it only documents the IP address filtering feature and other hardening we have around outgoing traffic. In the future, we may want to expand it further to provide details such as rate-limiting, and self-hosting best-practices.

Internal task: https://linear.app/saleor/issue/SEC-63/

Preview of the changes (@ Vercel): https://saleor-docs-git-docs-saleoradd-security-i-f94229-saleorcommerce.vercel.app/security/