### PR TITLE
fix: invalid anchor to docusaurus section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - [Directory Structure](#directory-structure)
 - [Editing Content](#editing-content)
 - [Adding Content](#adding-content)
-- [Full Documentation](#full-documentation)
+- [Full Documentation](#full-docusaurus-documentation)
 
 # Get Started in 5 Minutes
 


### PR DESCRIPTION
This fixes the link to the anchor to the docusaurus documentation section (issue introduced by 41199b2428293f1a6476585ecbea87562d4f94be)