### PR TITLE
Extend Transaction event types section with `*_ACTION_REQUIRED` events

### DIFF
--- a/docs/developer/payments/lifecycle.mdx
+++ b/docs/developer/payments/lifecycle.mdx
@@ -328,6 +328,12 @@ be used to provide the history of `transactionItem` actions.
 
 Saleor assigns the provided `amount` to the `transaction.authorizedAmount`.
 
+#### `AUTHORIZATION_ACTION_REQUIRED`
+
+Indicates that additional action is required from the customer to finalize the payment.
+Does not affect any amounts in the `transactionItem`.
+Multiple events of this type might be present.
+
 ### Charge events
 
 #### `CHARGE_SUCCESS`
@@ -352,6 +358,13 @@ be used to provide the history of `transactionItem` actions.
 
 The provided `amount` will be used to reduce `transaction.chargedAmount`
 (`transaction.chargedAmount -= amount`).
+
+
+#### `CHARGE_ACTION_REQUIRED`
+
+Indicates that additional action is required from the customer to finalize the payment.
+Does not affect any amounts in the `transactionItem`.
+Multiple events of this type might be present.
 
 ### Refund events
 
@@ -410,6 +423,13 @@ If an `CANCEL_FAILURE` event is related to an `CANCEL_REQUEST` event by `pspRefe
 will be reduced by the amount reported in the `CANCEL_FAILURE` event. If there is no related `CANCEL_REQUEST`, the failure event will only
 be used to provide the history of `transactionItem` actions.
 
+### Other events
+
+#### `INFO`
+
+Represents an informational event that provides context or updates without directly impacting the payment process.
+Does not affect any amounts in the `transactionItem`.
+Multiple events of this type might be present.
 
 ## Transaction event flow
 

--- a/docs/developer/payments/transactions.mdx
+++ b/docs/developer/payments/transactions.mdx
@@ -387,9 +387,9 @@ contain a `pspReference` field, which refers to the payment service provider ref
 
 **Key Assumptions:**
 - For a specific `TransactionItem`, only one `TransactionEvent` of a given `type` and `pspReference` may exist, except for the following types:
-  - `AUTHORIZATION_ACTION_REQUIRED`
-	-	`CHARGE_ACTION_REQUIRED`
-	-	`INFO`
+	- [`AUTHORIZATION_ACTION_REQUIRED`](/developer/payments/lifecycle#authorization_action_required)
+	-	[`CHARGE_ACTION_REQUIRED`](/developer/payments/lifecycle#charge_action_required)
+	-	[`INFO`](/developer/payments/lifecycle#info)
 - Only one `TransactionEvent` of type `AUTHORIZATION_SUCCESS` is allowed to exist.
 If an update is needed, the existing `AUTHORIZATION_SUCCESS` event can be modified using
 the [`AUTHORIZATION_ADJUSTMENT`](/developer/payments/lifecycle#authorization_adjustment) event.


### PR DESCRIPTION
Extend `Transaction event types` with `AUTHORIZATION_ACTION_REQUIRED`, `CHARGE_ACTION_REQUIRED` and `INFO`.