### PR TITLE
Add workflow to check licenses

### DIFF
--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -1,0 +1,49 @@
+name: Check Licenses
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    paths:
+      # Self
+      - ".github/workflows/check-licenses.yaml"
+      # Python Ecosystem
+      - "**/pyproject.toml"
+      - "**/setup.py"
+      - "**/requirements*.txt"
+      - "**/Pipfile.lock"
+      - "**/poetry.lock"
+      # JS/TS Ecosystem
+      - "**/package.json"
+      - "**/pnpm-lock.yaml"
+      - "**/package-lock.json"
+
+jobs:
+  default:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: saleor/saleor-internal-actions/.github/workflows/run-license-check.yaml@v1
+    with:
+      # List of ecosystems to scan.
+      ecosystems: >-
+        python
+        javascript
+      # Grant rules (https://github.com/anchore/grant/blob/4362dc22cf5ea9baeccfa59b2863879afe0c30d7/README.md#usage)
+      rules: |
+        # Explicitly allow LGPL as "*GPL*" rule will cause to reject them otherwise.
+        - pattern: "*lgpl*"
+          name: "allow-lgpl"
+          mode: "allow"
+          reason: "LGPL is allowed."
+        - pattern: "*gpl*"
+          name: "deny-gpl"
+          mode: "deny"
+          reason: "GPL licenses are not compatible with BSD-3-Clause"
+          exceptions:
+            # node-forge is dual licensed: (BSD-3-Clause OR GPL-2.0)
+            # License: https://github.com/digitalbazaar/forge/blob/a0a4a4264bedb3296974b9675349c9c190144aeb/LICENSE
+            - node-forge
+        - pattern: "*proprietary*"
+          name: "deny-proprietary"
+          mode: "deny"


### PR DESCRIPTION
This adds a workflow that checks our repository does not use non-BSD-3 compatible licenses.

The workflow reviews each pull requests against given rules, and sends a summary.