### PR TITLE
fix: invalid filename for docs to modify sidebars in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ title: This Doc Needs To Be Edited
 My new content here..
 ```
 
-1. Refer to that doc's ID in an existing sidebar in `sidebar.js`:
+1. Refer to that doc's ID in an existing sidebar in `sidebars.js`:
 
 ```javascript
 // Add newly-created-doc to the Getting Started category of docs


### PR DESCRIPTION
The README.md was referencing `sidebar.js` which is a non-existent file, instead it should be `sidebars.js`