### PR TITLE
Add warnings explaining allowUnpaidOrders incompatibility with Stripe plugin

### DIFF
--- a/docs/developer/app-store/plugins/stripe.mdx
+++ b/docs/developer/app-store/plugins/stripe.mdx
@@ -193,6 +193,11 @@ As a result, we get details required to finalize a payment.
 `client_secret` is required to process a customer payment.
 Steps required to finalize a payment transaction are described in [Stripe documentation](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements).
 
+:::warning
+If your checkout is transformed into an order during this step, please make sure that in a given channel, `allowUnpaidOrders` setting is turned off.
+This setting is only compatible with Transaction API and will not work with the Stripe Plugin.
+:::
+
 ### Finalizing a payment
 
 When the customer finalizes a payment, Stripe sends a webhook notification with all details

--- a/docs/developer/channels/configuration.mdx
+++ b/docs/developer/channels/configuration.mdx
@@ -38,6 +38,11 @@ The following mutations would allow to create orders without payment:
 
 Which means the admins would also be able to create orders without payment via the dashboard.
 
+:::warning
+Allow unpaid order setting is only compatible with Transaction API.
+It should not be used with Payments API (e.g. Stripe plugin is not going to work)
+:::
+
 ### Exemplary setup
 
 Here is how configuration of a business with many markets would look like:


### PR DESCRIPTION
`channel.allowUnpaidOrders` is a setting that is incompatible with Payment API, meaning it's not going to work with e.g. Stripe Plugin. Warnings have been added to avoid user confusion.

<img width="887" alt="image" src="https://github.com/user-attachments/assets/bf566f10-1234-4ac0-8673-b10c1d3aad98" />
<img width="890" alt="image" src="https://github.com/user-attachments/assets/40936234-98cf-4db9-a242-c047b93ce6e6" />
