### PR TITLE
Mention the possible errors in subscription payload

### DIFF
--- a/docs/developer/extending/webhooks/overview.mdx
+++ b/docs/developer/extending/webhooks/overview.mdx
@@ -51,6 +51,36 @@ The payload is sent in the `data` field of the subscription response. The payloa
 
 You can read more about GraphQL subscriptions in the [Subscription Webhook Payloads](./subscription-webhook-payloads.mdx) section.
 
+:::warning
+If an error occurs during payload generation, the subscription response will contain only the `errors field`, and all other fields will be omitted.
+
+Below is an example of an error response. Instead of the expected data fields, you will receive only the errors field:
+```json
+{
+  "errors": [
+    {
+      "message": "Cannot return null for non-nullable field PaymentGatewayInitializeSession.sourceObject.",
+      "locations": [
+        {
+          "line": 1,
+          "column": 97
+        }
+      ],
+      "path": [
+        "event",
+        "sourceObject"
+      ],
+      "extensions": {
+        "exception": {
+          "code": "GraphQLError"
+        }
+      }
+    }
+  ]
+}
+```
+:::
+
 ### Webhook headers
 
 In addition to the payload several headers are included:

--- a/docs/developer/extending/webhooks/subscription-webhook-payloads.mdx
+++ b/docs/developer/extending/webhooks/subscription-webhook-payloads.mdx
@@ -177,6 +177,37 @@ The above subscription will generate the following webhook payload:
 }
 ```
 
+
+:::warning
+If an error occurs during payload generation, the subscription response will contain only the `errors field`, and all other fields will be omitted.
+
+Below is an example of an error response. Instead of the expected data fields, you will receive only the errors field:
+```json
+{
+  "errors": [
+    {
+      "message": "Cannot return null for non-nullable field PaymentGatewayInitializeSession.sourceObject.",
+      "locations": [
+        {
+          "line": 1,
+          "column": 97
+        }
+      ],
+      "path": [
+        "event",
+        "sourceObject"
+      ],
+      "extensions": {
+        "exception": {
+          "code": "GraphQLError"
+        }
+      }
+    }
+  ]
+}
+```
+:::
+
 ## Creating Webhook With Subscription Query
 
 To create a webhook that will have its payload generated using a subscription, you need to use the same mutation as with standard webhooks. The only difference is passing the `query` field as an input with a subscription query converted to a string.
@@ -264,10 +295,12 @@ Keep in mind that some fields that use the synchronous event to be resolved are 
 Synchronous events are not allowed to request fields that are resolved using other synchronous events, which would lead to circular calls of the webhook.
 Fields that are currently not allowed:
 
-| Object     | Fields                                                                    |
-| ---------- | ------------------------------------------------------------------------- |
-| `Checkout` | `shippingMethods`, `availableShippingMethods`, `availablePaymentGateways` |
-| `Order`    | `shippingMethods`, `availableShippingMethods`                             |
+| Object         | Fields                                                                                                                                                    |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Checkout`     | `totalPrice`, `subtotalPrice`, `shippingPrice`, `shippingMethods`, `availableShippingMethods`, `availablePaymentGateways`                                 |
+| `CheckoutLine` | `unitPrice`, `totalPrice`                                                                                                                                 |
+| `Order`        | `discounts`, `total`, `undiscountedTotal`, `shippingPrice`, `undiscountedShippingPrice`, `shippingTaxRate`, `shippingMethods`, `availableShippingMethods` |
+| `OrderLine`    | `unitPrice`, `undiscountedUnitPrice`, `totalPrice`, `undiscountedTotalPrice`                                                                              |
 
 ## Permissions
 

--- a/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
@@ -221,11 +221,8 @@ Saleor Apps can subscribe to the synchronous webhooks:
 - `ORDER_FILTER_SHIPPING_METHODS` is called whenever shipping methods are listed for an editable order, such as a [draft order](api-reference/orders/enums/order-status.mdx#orderstatusdraft) or an [unconfirmed order](api-reference/orders/enums/order-status.mdx#orderstatusunconfirmed)
 
 :::warning
-Due to circular reference, subscription queries should not contain fields:
-
-- `checkout.shippingMethods`,
-- `checkout.deliveryMethods`,
-- `order.shippingMethods`.
+Due to circular reference, subscription queries should not contains fields listed
+[here](/developer/extending/webhooks/subscription-webhook-payloads.mdx#synchronous-webhooks-payload).
 
 :::
 

--- a/docs/developer/extending/webhooks/synchronous-events/tax.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/tax.mdx
@@ -110,6 +110,11 @@ The payload sent to the app would look like this:
 }
 ```
 
+:::warning
+If an error occurs during payload generation, the subscription response will contain only the `errors field`, and all other fields will be omitted.
+ For an example, refer to the [Webhook payload](/developer/extending/webhooks/overview.mdx#webhook-payload) section.
+:::
+
 ### Response
 
 #### Request format
@@ -308,6 +313,12 @@ The payload sent to the app would look like this:
   "__typename": "CalculateTaxes"
 }
 ```
+
+:::warning
+If an error occurs during payload generation, the subscription response will contain only the `errors field`, and all other fields will be omitted.
+ For an example, refer to the [Webhook payload](/developer/extending/webhooks/overview.mdx#webhook-payload) section.
+:::
+
 
 ### Response
 


### PR DESCRIPTION
- Mention that in case of error subscription payload might contains just an `errors` field.
- Extend the list of `Blocked Fields for Subscription Payloads`