### PR TITLE
Enhance `applyOncePerOrder` voucher behaviour description

### DIFF
--- a/docs/developer/discounts/vouchers.mdx
+++ b/docs/developer/discounts/vouchers.mdx
@@ -24,6 +24,7 @@ We can also distinguish vouchers by their value type:
 - `PERCENTAGE`: reduces the price by a specified percentage value.
 
 By setting `Voucher.applyOncePerOrder`, there is an option to apply the discount only to the cheapest eligible product.
+The discount reduces the value of a single unit, not the entire line.
 If the voucher specifies certain products, the discount will be applied only to the cheapest item included in the discount.
 If the voucher applies to all products, the discount will be applied only to the cheapest item overall.
 

--- a/docs/developer/discounts/vouchers.mdx
+++ b/docs/developer/discounts/vouchers.mdx
@@ -24,7 +24,7 @@ We can also distinguish vouchers by their value type:
 - `PERCENTAGE`: reduces the price by a specified percentage value.
 
 By setting `Voucher.applyOncePerOrder`, there is an option to apply the discount only to the cheapest eligible product.
-The discount reduces the value of a single unit, not the entire line.
+The discount applies to a single unit of the product, not the entire order line.
 If the voucher specifies certain products, the discount will be applied only to the cheapest item included in the discount.
 If the voucher applies to all products, the discount will be applied only to the cheapest item overall.
 


### PR DESCRIPTION
This PR clarifies, that `applyOncePerOrder` voucher reduces the value of a single unit, and not the entire line