### PR TITLE
Add OIDC plugin limitations

### DIFF
--- a/docs/api-usage/authentication.mdx
+++ b/docs/api-usage/authentication.mdx
@@ -441,7 +441,7 @@ Saleor supports OIDC authentication in two modes:
 
 - **Saleor as an OIDC client**: the client uses Saleor as a proxy to the authorization server.
 
-To enable OIDC authentication, you must enable and configure the OpenID Connect plugin using the Saleor dashboard.To enable OIDC authentication, you must enable and configure the OpenID Connect plugin using the Saleor dashboard. See [OIDC Plugin docs](../developer/app-store/plugins/oidc).
+To enable OIDC authentication, you must enable and configure the OpenID Connect plugin using the Saleor dashboard. See [OIDC Plugin docs](../developer/app-store/plugins/oidc).
 
 ### OAuth scopes
 

--- a/docs/api-usage/authentication.mdx
+++ b/docs/api-usage/authentication.mdx
@@ -441,7 +441,7 @@ Saleor supports OIDC authentication in two modes:
 
 - **Saleor as an OIDC client**: the client uses Saleor as a proxy to the authorization server.
 
-To enable OIDC authentication, you must enable and configure the OpenID Connect plugin using the Saleor dashboard.
+To enable OIDC authentication, you must enable and configure the OpenID Connect plugin using the Saleor dashboard.To enable OIDC authentication, you must enable and configure the OpenID Connect plugin using the Saleor dashboard. See [OIDC Plugin docs](../developer/app-store/plugins/oidc).
 
 ### OAuth scopes
 

--- a/docs/developer/app-store/plugins/oidc.mdx
+++ b/docs/developer/app-store/plugins/oidc.mdx
@@ -9,7 +9,7 @@ The OIDC plugin supports two-way of integrations:
 - _Saleor as a client for authorization server_ - uses authorization code flow to authorize user.
 - _Saleor as a resource server_ - grant access users to Saleor by using the OAuth access token
 
-### Configuration
+## Configuration
 
 Go to Configuration -> Plugins -> OpenID Connect and fill in the fields:
 
@@ -28,7 +28,7 @@ Go to Configuration -> Plugins -> OpenID Connect and fill in the fields:
 - **Default permission group name for new staff users:** The name of the default permission group to which the new staff user should be assigned to.
   When the provided group doesn't exist, the new group without any permissions and any channels is created.
 
-### Using OAuth permissions in Saleor
+## Using OAuth permissions in Saleor
 
 If `Use OAuth scope permissions` is enabled, Saleor will request his own permissions as OAuth scopes. Each permission has the prefix `saleor:`. If the user has assigned Saleor's permissions on the OAuth side, Saleor will grant them to the logged-in user.
 
@@ -79,3 +79,7 @@ graph TD
  D --> |No| Z[The user is successfully logged in]
  J --> Z
 ```
+
+## Limitations
+### Email change
+Currently, the OIDC plugin does not support updating a user's email address while retaining the same identity. If the email address is changed at the identity provider, Saleor will treat it as a new account, resulting in the creation of a separate user profile. To maintain order history, addresses, and other associated data, a manual migration is required.


### PR DESCRIPTION
This change adds information about OIDC plugin limitation - as of current implementation, it is not possible to change e-mail address while preserving identity.