### PR TITLE
Add bulk order import warning for deleted variants

### DIFF
--- a/docs/developer/bulks/bulk-orders.mdx
+++ b/docs/developer/bulks/bulk-orders.mdx
@@ -659,6 +659,10 @@ The input also accepts arbitrary names of variant (`variantName`), product (`pro
 
 `warehouse` - ID of the warehouse, where the order line should be allocated. It is required to check stock availability.
 
+:::warning
+If you include order lines containing product variants no longer existing in Saleor database, you need to use [`IGNORE_FAILED`](developer/bulks/error-policy.mdx#ignore_failed) error policy.
+:::
+
 #### Fulfillments (`OrderBulkCreateFulfillmentLineInput`)
 
 Product variant is searched by one of the following identifiers: `id`, `sku` or `external_reference`.


### PR DESCRIPTION
This change adds a warning in bulk order import article, explaining to use `IGNORE_FAILED` error policy if an user wants to create orders with product variants which were deleted from Saleor database.