### PR TITLE
feat: add orders overview doc

### DIFF
--- a/docs/developer/order/overview.mdx
+++ b/docs/developer/order/overview.mdx
@@ -1,0 +1,28 @@
+---
+title: Overview
+---
+
+Orders capture the purchasing process between customers and the store. They record what items were bought, at what price, by whom, and how they should be delivered. Orders are created when [customers finalize their checkout](/developer/checkout/lifecycle.mdx#completing-checkout) or when staff members create draft orders in the dashboard.
+
+Each order belongs to a specific sales channel and stores details such as product selections, pricing, customer information, shipping requirements, and fulfillment status.
+
+## Lifecycle
+
+Orders progress through various states during their lifecycle, including unfulfilled, partially fulfilled, fulfilled, and potentially returned or cancelled. For a detailed explanation of order states and the transitions between them, refer to the [Order Status](/developer/order/order-status) documentation.
+
+Orders can be converted back to checkouts for reordering purposes using the functionality described in [Order to Checkout](/developer/order/order-to-checkout).
+
+Orders can also expire if they remain unpaid for a configurable period. The [Order Expiration](/developer/order/order-expiration) documentation covers the configuration and behavior of this process.
+
+## Settings
+
+Several channel settings affect how orders behave in Saleor:
+
+- **[`automaticallyConfirmAllNewOrders`](/api-reference/miscellaneous/objects/order-settings#ordersettingsautomaticallyconfirmallnewordersboolean---)**: When enabled, orders are automatically confirmed upon checkout completion. When disabled, orders remain in the UNCONFIRMED state until manually confirmed.
+- **[`allowUnpaidOrders`](/api-reference/miscellaneous/objects/order-settings#ordersettingsallowunpaidordersboolean---)**: Determines whether a checkout must be paid before an order can be created.
+- **[`expireOrdersAfter`](/api-reference/miscellaneous/objects/order-settings#ordersettingsexpireordersafterminute--)**: Configures how long unpaid orders remain active before being marked as expired. Set in minutes.
+- **[`deleteExpiredOrdersAfter`](/api-reference/miscellaneous/objects/order-settings#ordersettingsdeleteexpiredordersafterday---)**: Determines how many days after expiration an order will be permanently deleted from the system.
+- **[`automaticallyFulfillNonShippableGiftCard`](/api-reference/miscellaneous/objects/order-settings#ordersettingsautomaticallyfulfillnonshippablegiftcardboolean---)**: When enabled, all non-shippable gift card orders will be fulfilled automatically.
+- **[`markAsPaidStrategy`](/api-reference/miscellaneous/objects/order-settings#ordersettingsmarkaspaidstrategymarkaspaidstrategyenum---)**: Determines what strategy will be used to mark the order as paid.
+- **[`includeDraftOrderInVoucherUsage`](/api-reference/miscellaneous/objects/order-settings#ordersettingsincludedraftorderinvoucherusageboolean---)**: Determines if vouchers applied on draft orders should count toward voucher usage limits.
+

--- a/docs/developer/order/overview.mdx
+++ b/docs/developer/order/overview.mdx
@@ -2,6 +2,8 @@
 title: Overview
 ---
 
+# Order Overview
+
 Orders capture the purchasing process between customers and the store. They record what items were bought, at what price, by whom, and how they should be delivered. Orders are created when [customers finalize their checkout](/developer/checkout/lifecycle.mdx#completing-checkout) or when staff members finalize draft orders in the dashboard.
 
 Each order belongs to a specific sales channel and stores details such as product selections, pricing, customer information, shipping requirements, and fulfillment status.
@@ -18,11 +20,11 @@ Orders can also expire if they remain unpaid for a configurable period. The [Ord
 
 Several channel settings affect how orders behave in Saleor:
 
-- **[`automaticallyConfirmAllNewOrders`](/api-reference/miscellaneous/objects/order-settings#ordersettingsautomaticallyconfirmallnewordersboolean---)**: When enabled, orders are automatically confirmed upon checkout completion. When disabled, orders remain in the UNCONFIRMED state until manually confirmed.
-- **[`allowUnpaidOrders`](/api-reference/miscellaneous/objects/order-settings#ordersettingsallowunpaidordersboolean---)**: Determines whether a checkout must be paid before an order can be created.
-- **[`expireOrdersAfter`](/api-reference/miscellaneous/objects/order-settings#ordersettingsexpireordersafterminute--)**: Configures how long unpaid orders remain active before being marked as expired. Set in minutes.
-- **[`deleteExpiredOrdersAfter`](/api-reference/miscellaneous/objects/order-settings#ordersettingsdeleteexpiredordersafterday---)**: Determines how many days after expiration an order will be permanently deleted from the system.
-- **[`automaticallyFulfillNonShippableGiftCard`](/api-reference/miscellaneous/objects/order-settings#ordersettingsautomaticallyfulfillnonshippablegiftcardboolean---)**: When enabled, all non-shippable gift card orders will be fulfilled automatically.
-- **[`markAsPaidStrategy`](/api-reference/miscellaneous/objects/order-settings#ordersettingsmarkaspaidstrategymarkaspaidstrategyenum---)**: Determines what strategy will be used to mark the order as paid.
-- **[`includeDraftOrderInVoucherUsage`](/api-reference/miscellaneous/objects/order-settings#ordersettingsincludedraftorderinvoucherusageboolean---)**: Determines if vouchers applied on draft orders should count toward voucher usage limits.
+- **[`automaticallyConfirmAllNewOrders`](/api-reference/miscellaneous/objects/order-settings.mdx#ordersettingsautomaticallyconfirmallnewordersboolean---)**: When enabled, orders are automatically confirmed upon checkout completion. When disabled, orders remain in the [UNCONFIRMED](/developer/order/order-status.mdx#unconfirmed) state until manually confirmed.
+- **[`allowUnpaidOrders`](/api-reference/miscellaneous/objects/order-settings.mdx#ordersettingsallowunpaidordersboolean---)**: Determines whether a checkout must be paid before an order can be created.
+- **[`expireOrdersAfter`](/api-reference/miscellaneous/objects/order-settings.mdx#ordersettingsexpireordersafterminute--)**: Configures how long unpaid orders remain active before being marked as expired. Set in minutes.
+- **[`deleteExpiredOrdersAfter`](/api-reference/miscellaneous/objects/order-settings.mdx#ordersettingsdeleteexpiredordersafterday---)**: Determines how many days after expiration an order will be permanently deleted from the system.
+- **[`automaticallyFulfillNonShippableGiftCard`](/api-reference/miscellaneous/objects/order-settings.mdx#ordersettingsautomaticallyfulfillnonshippablegiftcardboolean---)**: When enabled, all non-shippable gift card orders will be fulfilled automatically.
+- **[`markAsPaidStrategy`](/api-reference/miscellaneous/objects/order-settings.mdx#ordersettingsmarkaspaidstrategymarkaspaidstrategyenum---)**: Determines whether a Payment or Transaction is created when an order is manually marked as paid in Saleor Dashboard or using [`orderMarkAsPaid`](/api-reference/orders/mutations/order-mark-as-paid) mutation.
+- **[`includeDraftOrderInVoucherUsage`](/api-reference/miscellaneous/objects/order-settings.mdx#ordersettingsincludedraftorderinvoucherusageboolean---)**: Determines if vouchers applied on draft orders should count toward voucher usage limits.
 

--- a/docs/developer/order/overview.mdx
+++ b/docs/developer/order/overview.mdx
@@ -2,7 +2,7 @@
 title: Overview
 ---
 
-Orders capture the purchasing process between customers and the store. They record what items were bought, at what price, by whom, and how they should be delivered. Orders are created when [customers finalize their checkout](/developer/checkout/lifecycle.mdx#completing-checkout) or when staff members create draft orders in the dashboard.
+Orders capture the purchasing process between customers and the store. They record what items were bought, at what price, by whom, and how they should be delivered. Orders are created when [customers finalize their checkout](/developer/checkout/lifecycle.mdx#completing-checkout) or when staff members finalize draft orders in the dashboard.
 
 Each order belongs to a specific sales channel and stores details such as product selections, pricing, customer information, shipping requirements, and fulfillment status.
 

--- a/sidebars/core-concepts.js
+++ b/sidebars/core-concepts.js
@@ -35,6 +35,7 @@ export const coreConcepts = [
   "developer/checkout/api-guide",
 
   title("Orders"),
+  "developer/order/overview",
   "developer/order/order-status",
   "developer/order/order-expiration",
   "developer/order/order-to-checkout",


### PR DESCRIPTION
I am adding an overview-type doc for orders since we don't have one. Main goal is to explain what an order is and point to existing resources