### PR TITLE
Arrange docs in discounts

### DIFF
--- a/docs/developer/discounts/displaying-catalogue-discounts.mdx
+++ b/docs/developer/discounts/displaying-catalogue-discounts.mdx
@@ -1,11 +1,7 @@
 ---
-title: Displaying Promotional Prices
-sidebar_label: Displaying Promotional Prices
+title: Displaying Catalogue Discount Prices
+sidebar_label: Catalogue Discount Prices
 ---
-
-:::info
-This feature is available starting from **Saleor 3.21**.
-:::
 
 Saleor API provides pricing information that can be consumed by your storefront for four different scenarios:
 - Individual `ProductVariant` pricing, which provides prices of a specific SKU (`VariantPricingInfo`)
@@ -28,6 +24,10 @@ There are three main types of promotional prices that you can use to display pri
 On top of that, Saleor provides discount calculations relative to `priceUndiscounted` and `pricePrior` for `Product` and `ProductVariant`.
 
 ### Using `pricePrior` as a Base for Discount Calculations
+
+:::info
+`pricePrior` is available starting from **Saleor 3.21**.
+:::
 
 For some geographies, it might be required to calculate discounts based on the lowest price before the promotion. 
 An example of such a requirement is the EU Omnibus directive. 

--- a/docs/developer/discounts/promotions.mdx
+++ b/docs/developer/discounts/promotions.mdx
@@ -30,13 +30,6 @@ The promotion discount will be also visible on the checkout line prices after ad
 product to the card. The checkout subtotal is calculated as a sum of discounted prices of variants
 added to the cart.
 
-###### Saleor 3.17 (Deprecated)
-
-When multiple promotions apply to one product, the promotion with the greatest savings is used.
-The discounts from rules within the single promotion are summed up.
-
-###### Saleor 3.19+
-
 When multiple promotions apply to one product, only the discount from the promotion rule that provides the maximum savings for the customer is applied.
 The discounts from rules within the single promotion are not summed up.
 

--- a/sidebars/core-concepts.js
+++ b/sidebars/core-concepts.js
@@ -63,6 +63,7 @@ export const coreConcepts = [
   "developer/discounts/manual-discounts",
   "developer/discounts/examples",
   "developer/discounts/sales",
+  "developer/discounts/displaying-catalogue-discounts",
 
   title("Miscellaneous"),
 


### PR DESCRIPTION
In https://github.com/saleor/saleor-docs/pull/1432 there was a file not assigned to sidebar that got merged. I have added it to sidebar and changed the name to represent what it does.