### PR TITLE
docs: add notice to not store sensitive data in metadata

### DIFF
--- a/docs/api-usage/metadata.mdx
+++ b/docs/api-usage/metadata.mdx
@@ -6,6 +6,10 @@ Saleor gives you the possibility to customize your shop without modifying the co
 
 Metadata allows you to store additional information about each object, for example, external identifiers for items synchronized with a third-party platform. You can also use metadata to customize how your storefront looks and behaves.
 
+:::warning
+Never store sensitive information, including financial data such as credit card details.
+:::
+
 ## Supported object types
 
 Metadata is available in all GraphQL types that implement the `ObjectWithMetadata` interface. See the [Implemented by](api-reference/miscellaneous/interfaces/object-with-metadata.mdx#implemented-by) section of the `ObjectWithMetadata` interface for the full list of supported types.


### PR DESCRIPTION
This adds a warning to inform developers to not store sensitive data in metadata, especially not financial information that may subject to PCI DSS regulation.