### PR TITLE
Update upgrade guide - `DraftOrderUpdate` and `OrderUpdate` do not call webhooks anymore if nothing changed

### DIFF
--- a/docs/upgrade-guides/core/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/core/3-20-to-3-21.mdx
@@ -139,6 +139,16 @@ More details can be found [`here`](developer/price-freeze-period.mdx)
 - Unconfirmed orders: the base prices remain frozen indefinitely, and this setting is not configurable.
 - Other orders: remain unchanged and cannot be recalculated.
 
+## `DraftOrderUpdate` mutation no longer calls `DRAFT_ORDER_UPDATED` webhook if nothing has changed
+
+The `DraftOrderUpdate` mutation no longer triggers the `DRAFT_ORDER_UPDATED` webhook event if there are no changes to the draft order.
+This adjustment ensures that the event is only fired when there are actual updates to the draft order, reducing unnecessary event emissions.
+
+## `OrderUpdate` mutation no longer calls `ORDER_UPDATED` webhook if nothing has changed
+
+The `OrderUpdate` mutation no longer triggers the `ORDER_UPDATED` webhook event if there are no changes to the draft order.
+This adjustment ensures that the event is only fired when there are actual updates to the order, reducing unnecessary event emissions.
+
 ## Plugin changes
 The following changes affects only open-source Saleor users.
 


### PR DESCRIPTION
Update of upgrade guide for https://github.com/saleor/saleor/pull/17532 and https://github.com/saleor/saleor/pull/17507