### PR TITLE
Remove todo comment that was visible in discord preview

### DIFF
--- a/docs/developer/extending/apps/developing-apps/running-saleor-apps-locally.mdx
+++ b/docs/developer/extending/apps/developing-apps/running-saleor-apps-locally.mdx
@@ -4,8 +4,6 @@ title: Running Saleor Apps locally
 
 # Running Saleor Apps locally
 
-{/* TODO add `apps` repository with setup */}
-
 You can find the code for all the apps from the Saleor App Store in the [`saleor/apps` monorepo](https://github.com/saleor/apps).
 
 Each app is a [Next.js](https://nextjs.org/docs/getting-started) application based off [saleor-app-template](https://github.com/saleor/saleor-app-template).


### PR DESCRIPTION
I removed todo comment that was visible in Discord preview:
![CleanShot 2025-04-07 at 12 56 29@2x](https://github.com/user-attachments/assets/9f54e038-b997-4e5b-99fc-cb3232db278d)
