### PR TITLE
Add migration guide for propagating line level voucher discount

### DIFF
--- a/docs/upgrade-guides/core/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/core/3-20-to-3-21.mdx
@@ -338,74 +338,112 @@ Currently, fulfillments with `WAITING_FOR_APPROVAL` status are excluded from det
 Order can only receive `PARTIALLY_FULFILLED` status if there exists `FULFILLED` fulfillment and there are some items that are either unfulfilled or awaiting approval. 
 
 
-## Changes to voucher propagation in orders created from checkout
+## Changes to discount propagation in orders created from checkout
 
-### Before version 3.21
+### Voucher handling before version 3.21
 
-In versions prior to **3.21**, the way voucher discounts were applied and represented differed based on how the order was created:
+In versions prior to **3.21**, how vouchers were applied and represented depended on how the order was created:
 
-- **Orders from checkout** with vouchers of type `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` (with `apply-once-per-order`) used the `OrderDiscount` object. These discounts were returned in the `order.discounts` field.
-- **Orders from draft orders** used `OrderLineDiscount` objects attached to individual lines. In this case, `order.discounts` remained empty.
-
-#### Voucher representation prior to 3.21:
-
-| Order Source     | `SPECIFIC_PRODUCT` Voucher           | `ENTIRE_ORDER` with `apply-once-per-order` Voucher |
-|------------------|--------------------------------------|----------------------------------------------------|
-| From Checkout    | `OrderDiscount` in `order.discounts` | `OrderDiscount` in `order.discounts`               |
-| From Draft Order | (no entry in `order.discounts`)      | (no entry in `order.discounts`)                    |
+| Order source     | `SPECIFIC_PRODUCT` voucher                          | `ENTIRE_ORDER` with `apply-once-per-order` voucher  |
+|------------------|-----------------------------------------------------|-----------------------------------------------------|
+| From checkout    | Represented as `OrderDiscount` in `order.discounts` | Represented as `OrderDiscount` in `order.discounts` |
+| From draft order | **Not** included in `order.discounts`               | **Not** included in `order.discounts`               |
 
 
-Additionally, **percentage-based vouchers** applied during checkout were automatically **converted to fixed value discounts**, unlike draft orders which retained the **percentage type**.
+Additionally, **percentage-based vouchers** applied during checkout were automatically **converted to fixed-value discounts**, while draft orders retained the original **percentage type**:
 
-| Order Source     | `SPECIFIC_PRODUCT` (PERCENTAGE) | `ENTIRE_ORDER` with `apply-once-per-order` (PERCENTAGE) |
+| Order source     | `SPECIFIC_PRODUCT` (percentage) | `ENTIRE_ORDER` with `apply-once-per-order` (percentage) |
 |------------------|---------------------------------|---------------------------------------------------------|
-| From Checkout    | Converted to `FIXED`            | Converted to `FIXED`                                    |
-| From Draft Order | Kept as `PERCENTAGE`            | Kept as `PERCENTAGE`                                    |
+| From checkout    | Converted to `FIXED`            | Converted to `FIXED`                                    |
+| From draft order | Retained as `PERCENTAGE`        | Retained as `PERCENTAGE`                                |
 
 
 
-### Changes introduced in version 3.21
+#### Changes introduced in version 3.21
 
-Starting from **version 3.21**, voucher propagation is unified for all order types:
+Starting in **version 3.21**, voucher propagation is consistent across all order types:
 
-- All orders from checkout with `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` (with `apply-once-per-order`) vouchers now use `OrderLineDiscount` objects, just like draft orders.
-- Percentage `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` (with `apply-once-per-order`) vouchers are no longer converted to fixed value. The original discount type (`PERCENTAGE`) is preserved and reflected in the API.
-
-
-### Backward compatibility: `useLegacyLineVoucherPropagation` flag
-
-To support existing integrations, version 3.21 introduces a **feature flag**: `useLegacyLineVoucherPropagation`. This flag controls how discounts are exposed in the API for orders created via checkout.
-
-#### Discount representation based on flag:
-
-| Order from checkout + voucher           | 3.20                                         | 3.21 + Legacy propagation **enabled**        | 3.21 + Legacy propagation **disabled**                                       |
-|-----------------------------------------|----------------------------------------------|----------------------------------------------|------------------------------------------------------------------------------|
-| `SPECIFIC_PRODUCT`                      | `OrderDiscount` (entry in `order.discounts`) | `OrderDiscount` (entry in `order.discounts`) | `OrderLineDiscount` in `OrderLine.discounts` (no entry in `order.discounts`) |
-| `ENTIRE_ORDER` + `apply-once-per-order` | `OrderDiscount` (entry in `order.discounts`) | `OrderDiscount` (entry in `order.discounts`) | `OrderLineDiscount` in `OrderLine.discounts` (no entry in `order.discounts`) |
+- All orders created via checkout now use `OrderLineDiscount` objects for both `SPECIFIC_PRODUCT` and `ENTIRE_ORDER` (with `apply-once-per-order`) vouchers—same as draft orders.
+- Percentage-based vouchers **are no longer converted** to fixed-value discounts. The original `PERCENTAGE` type is preserved and correctly represented in the API.
 
 
+### Changes to `unitDiscountReason` and `unitDiscount.amount` for orders created from checkout
+
+Previously, for orders created via checkout using a `Voucher:ENTIRE_ORDER`, the discount was represented in two ways:
+- As an `OrderDiscount` object in `order.discounts`
+- As a proportional amount in each line’s `unitDiscount.amount`, along with a corresponding `unitDiscountReason`
+
+#### Before version 3.21
+
+| Order source     | `unitDiscountReason`                        | `unitDiscount.amount`                                      |
+|------------------|---------------------------------------------|------------------------------------------------------------|
+| From checkout    | Included reason for `ENTIRE_ORDER` discount | Included line-level portion of the `ENTIRE_ORDER` discount |
+| From draft order | Not present                                 | Not present                                                |
 
 
-#### Discount type (FIXED vs PERCENTAGE) based on flag:
+This also applied to discounts from active `OrderPromotion`s:
 
-| Order from checkout + percentage voucher             | 3.20                 | 3.21 + Legacy propagation **enabled** | 3.21 + Legacy propagation **disabled** |
-|------------------------------------------------------|----------------------|---------------------------------------|----------------------------------------|
-| `SPECIFIC_PRODUCT` (PERCENTAGE)                      | Converted to `FIXED` | Converted to `FIXED`                  | Retained as `PERCENTAGE`               |
-| `ENTIRE_ORDER` + `apply-once-per-order` (PERCENTAGE) | Converted to `FIXED` | Converted to `FIXED`                  | Retained as `PERCENTAGE`               |
-
-
-By default:
-- **Existing channels** have legacy propagation **enabled**
-- **New channels** will have it **disabled**, unless explicitly configured otherwise.
+| Order source     | `unitDiscountReason`                   | `unitDiscount.amount`                             |
+|------------------|----------------------------------------|---------------------------------------------------|
+| From checkout    | Included reason for promotion discount | Included line-level portion of promotion discount |
+| From draft order | Not present                            | Not present                                       |
 
 
-:::note  
-Changing the `useLegacyLineVoucherPropagation` flag affects how voucher discounts are returned in the API for **all orders created since version 3.21**.  
-However, this flag **does not** affect percentage-based vouchers that were already converted to fixed-value discounts. Toggling the flag will **not** retroactively change their discount type.  
+#### After version 3.21
+
+As of **version 3.21**, `unitDiscountReason` and `unitDiscount.amount` **no longer include** information related to:
+- `Voucher:ENTIRE_ORDER` discounts
+- `OrderPromotion` discounts
+
+This behavior is now consistent with how draft orders have always worked.
+
+
+### Backward compatibility: `useLegacyLineVoucherPropagation` feature flag
+
+To maintain compatibility with existing integrations, version 3.21 introduces a **feature flag**: `useLegacyLineVoucherPropagation`.
+
+This flag controls how voucher and promotion discounts appear in the API for **orders created via checkout**.
+
+#### How discounts are represented based on the flag
+
+| Checkout order + voucher                | 3.20                                   | 3.21 + Legacy propagation **enabled**  | 3.21 + Legacy propagation **disabled**              |
+|-----------------------------------------|----------------------------------------|----------------------------------------|-----------------------------------------------------|
+| `SPECIFIC_PRODUCT`                      | `OrderDiscount` (in `order.discounts`) | `OrderDiscount` (in `order.discounts`) | `OrderLineDiscount` (in `OrderLine.discounts`) only |
+| `ENTIRE_ORDER` + `apply-once-per-order` | `OrderDiscount` (in `order.discounts`) | `OrderDiscount` (in `order.discounts`) | `OrderLineDiscount` (in `OrderLine.discounts`) only |
+
+
+
+#### Discount type (`FIXED` vs `PERCENTAGE`) based on the flag
+
+| Checkout order + percentage voucher | 3.20                 | 3.21 + Legacy propagation **enabled** | 3.21 + Legacy propagation **disabled** |
+|-------------------------------------|----------------------|---------------------------------------|----------------------------------------|
+| `SPECIFIC_PRODUCT` (percentage)     | Converted to `FIXED` | Converted to `FIXED`                  | Retained as `PERCENTAGE`               |
+| `ENTIRE_ORDER` (percentage)         | Converted to `FIXED` | Converted to `FIXED`                  | Retained as `PERCENTAGE`               |
+
+
+#### `unitDiscountReason` and `unitDiscount.amount` based on the flag
+
+| Checkout order + voucher type | 3.20                                                     | 3.21 + Legacy propagation **enabled**                    | 3.21 + Legacy propagation **disabled**                       |
+|-------------------------------|----------------------------------------------------------|----------------------------------------------------------|--------------------------------------------------------------|
+| `Voucher:ENTIRE_ORDER`        | Included in `unitDiscountReason` & `unitDiscount.amount` | Included in `unitDiscountReason` & `unitDiscount.amount` | Not included in `unitDiscountReason` & `unitDiscount.amount` |
+| `OrderPromotion`              | Included in `unitDiscountReason` & `unitDiscount.amount` | Included in `unitDiscountReason` & `unitDiscount.amount` | Not included in `unitDiscountReason` & `unitDiscount.amount` |
+
+
+
+#### Default behavior
+
+- **Existing channels**: `useLegacyLineVoucherPropagation` is **enabled** by default
+- **New channels**: the flag is **disabled** by default, unless explicitly set otherwise
+
+:::note
+Changing the `useLegacyLineVoucherPropagation` flag only affects **orders created after upgrading to version 3.21**.  
+It does **not** retroactively change:
+- Discount types for vouchers already converted from `PERCENTAGE` to `FIXED`
+- `unitDiscountReason` and `unitDiscount.amount` fields on existing orders
 :::
 
 
-#### Creating new channel with legacy flow enabled
+### Creating new channel with legacy flow enabled
 If you need to create a new channel with the **legacy voucher propagation** flow active, you must explicitly set `useLegacyLineVoucherPropagation` in the `channelCreate` mutation input:
 
 ```graphql
@@ -433,9 +471,9 @@ mutation {
 ```
 By default, new channels have legacy propagation **disabled** unless this field is explicitly set to `true`.
 
-### Example responses
+#### Example responses
 
-#### With `useLegacyLineVoucherPropagation` **enabled**:
+##### With `useLegacyLineVoucherPropagation` **enabled**:
 
 ```json
 {
@@ -474,7 +512,7 @@ By default, new channels have legacy propagation **disabled** unless this field 
 }
 ```
 
-#### With `useLegacyLineVoucherPropagation` **disabled**:
+##### With `useLegacyLineVoucherPropagation` **disabled**:
 
 ```json
 {

--- a/docs/upgrade-guides/core/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/core/3-20-to-3-21.mdx
@@ -340,22 +340,26 @@ Order can only receive `PARTIALLY_FULFILLED` status if there exists `FULFILLED` 
 
 ## Changes to discount propagation in orders created from checkout
 
+In Saleor 3.21, we've unified the logic for how discount propagation works in orders. Here's a quick overview of how it worked previously and what's changed. Below, you'll find details on how discount propagation now behaves for different types of discounts.
+
 ### Voucher handling before version 3.21
 
 In versions prior to **3.21**, how vouchers were applied and represented depended on how the order was created:
 
-| Order source     | `SPECIFIC_PRODUCT` voucher                          | `ENTIRE_ORDER` with `apply-once-per-order` voucher  |
-|------------------|-----------------------------------------------------|-----------------------------------------------------|
-| From checkout    | Represented as `OrderDiscount` in `order.discounts` | Represented as `OrderDiscount` in `order.discounts` |
-| From draft order | **Not** included in `order.discounts`               | **Not** included in `order.discounts`               |
+| Order source | `SPECIFIC_PRODUCT` voucher                          | `ENTIRE_ORDER` with `apply-once-per-order` voucher  |
+|--------------|-----------------------------------------------------|-----------------------------------------------------|
+| Checkout     | Represented as `OrderDiscount` in `order.discounts` | Represented as `OrderDiscount` in `order.discounts` |
+| Draft order  | **Not** included in `order.discounts`               | **Not** included in `order.discounts`               |
+
 
 
 Additionally, **percentage-based vouchers** applied during checkout were automatically **converted to fixed-value discounts**, while draft orders retained the original **percentage type**:
 
-| Order source     | `SPECIFIC_PRODUCT` (percentage) | `ENTIRE_ORDER` with `apply-once-per-order` (percentage) |
-|------------------|---------------------------------|---------------------------------------------------------|
-| From checkout    | Converted to `FIXED`            | Converted to `FIXED`                                    |
-| From draft order | Retained as `PERCENTAGE`        | Retained as `PERCENTAGE`                                |
+| Order source | `SPECIFIC_PRODUCT` (percentage) | `ENTIRE_ORDER` with `apply-once-per-order` (percentage) |
+|--------------|---------------------------------|---------------------------------------------------------|
+| Checkout     | Converted to `FIXED`            | Converted to `FIXED`                                    |
+| Draft order  | Retained as `PERCENTAGE`        | Retained as `PERCENTAGE`                                |
+
 
 
 
@@ -363,7 +367,7 @@ Additionally, **percentage-based vouchers** applied during checkout were automat
 
 Starting in **version 3.21**, voucher propagation is consistent across all order types:
 
-- All orders created via checkout now use `OrderLineDiscount` objects for both `SPECIFIC_PRODUCT` and `ENTIRE_ORDER` (with `apply-once-per-order`) vouchers—same as draft orders.
+- All orders created via checkout now use `OrderLineDiscount` objects for both `SPECIFIC_PRODUCT` and `ENTIRE_ORDER` (with `apply-once-per-order`) vouchers — same as draft orders.
 - Percentage-based vouchers **are no longer converted** to fixed-value discounts. The original `PERCENTAGE` type is preserved and correctly represented in the API.
 
 
@@ -375,18 +379,20 @@ Previously, for orders created via checkout using a `Voucher:ENTIRE_ORDER`, the 
 
 #### Before version 3.21
 
-| Order source     | `unitDiscountReason`                        | `unitDiscount.amount`                                      |
-|------------------|---------------------------------------------|------------------------------------------------------------|
-| From checkout    | Included reason for `ENTIRE_ORDER` discount | Included line-level portion of the `ENTIRE_ORDER` discount |
-| From draft order | Not present                                 | Not present                                                |
+| Order source | `unitDiscountReason`                            | `unitDiscount.amount`                                          |
+|--------------|-------------------------------------------------|----------------------------------------------------------------|
+| Checkout     | Included reason for `ENTIRE_ORDER` discount     | Included line-level portion of the `ENTIRE_ORDER` discount     |
+| Draft order  | Reason for `ENTIRE_ORDER` discount not included | Line-level portion of the `ENTIRE_ORDER` discount not included |
+
 
 
 This also applied to discounts from active `OrderPromotion`s:
 
-| Order source     | `unitDiscountReason`                   | `unitDiscount.amount`                             |
-|------------------|----------------------------------------|---------------------------------------------------|
-| From checkout    | Included reason for promotion discount | Included line-level portion of promotion discount |
-| From draft order | Not present                            | Not present                                       |
+| Order source | `unitDiscountReason`                       | `unitDiscount.amount`                                 |
+|--------------|--------------------------------------------|-------------------------------------------------------|
+| Checkout     | Included reason for promotion discount     | Included line-level portion of promotion discount     |
+| Draft order  | Reason for promotion discount not included | Line-level portion of promotion discount not included |
+
 
 
 #### After version 3.21
@@ -395,12 +401,12 @@ As of **version 3.21**, `unitDiscountReason` and `unitDiscount.amount` **no long
 - `Voucher:ENTIRE_ORDER` discounts
 - `OrderPromotion` discounts
 
-This behavior is now consistent with how draft orders have always worked.
+This behavior is now consistent with how draft orders work.
 
 
 ### Backward compatibility: `useLegacyLineDiscountPropagation` feature flag
 
-To maintain compatibility with existing integrations, version 3.21 introduces a **feature flag**: `useLegacyLineDiscountPropagation`.
+To maintain compatibility with existing integrations, version 3.21 introduces a **feature flag**: `useLegacyLineDiscountPropagation`, which allows you to configure the discount propagation behavior per channel.
 
 This flag controls how voucher and promotion discounts appear in the API for **orders created via checkout**.
 
@@ -471,9 +477,11 @@ mutation {
 ```
 By default, new channels have legacy propagation **disabled** unless this field is explicitly set to `true`.
 
-#### Example responses
+#### Example
 
-##### With `useLegacyLineDiscountPropagation` **enabled**:
+The examples below show how order line discounts are represented in the GraphQL response, depending on the `useLegacyLineDiscountPropagation` configuration.
+
+##### With `useLegacyLineDiscountPropagation` enabled:
 
 ```json
 {
@@ -512,7 +520,7 @@ By default, new channels have legacy propagation **disabled** unless this field 
 }
 ```
 
-##### With `useLegacyLineDiscountPropagation` **disabled**:
+##### With `useLegacyLineDiscountPropagation` disabled:
 
 ```json
 {

--- a/docs/upgrade-guides/core/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/core/3-20-to-3-21.mdx
@@ -340,7 +340,7 @@ Order can only receive `PARTIALLY_FULFILLED` status if there exists `FULFILLED` 
 
 ## Changes to discount propagation in orders created from checkout
 
-In Saleor 3.21, we've unified the logic for how discount propagation works in orders. Here's a quick overview of how it worked previously and what's changed. Below, you'll find details on how discount propagation now behaves for different types of discounts.
+In Saleor 3.21, discount propagation for orders created from checkout has been standardized to match the behavior of draft orders, ensuring consistent handling of vouchers and promotions across all order types. Below, you’ll find details on how discount propagation now behaves for different types of discounts.
 
 ### Voucher handling before version 3.21
 

--- a/docs/upgrade-guides/core/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/core/3-20-to-3-21.mdx
@@ -398,9 +398,9 @@ As of **version 3.21**, `unitDiscountReason` and `unitDiscount.amount` **no long
 This behavior is now consistent with how draft orders have always worked.
 
 
-### Backward compatibility: `useLegacyLineVoucherPropagation` feature flag
+### Backward compatibility: `useLegacyLineDiscountPropagation` feature flag
 
-To maintain compatibility with existing integrations, version 3.21 introduces a **feature flag**: `useLegacyLineVoucherPropagation`.
+To maintain compatibility with existing integrations, version 3.21 introduces a **feature flag**: `useLegacyLineDiscountPropagation`.
 
 This flag controls how voucher and promotion discounts appear in the API for **orders created via checkout**.
 
@@ -432,11 +432,11 @@ This flag controls how voucher and promotion discounts appear in the API for **o
 
 #### Default behavior
 
-- **Existing channels**: `useLegacyLineVoucherPropagation` is **enabled** by default
+- **Existing channels**: `useLegacyLineDiscountPropagation` is **enabled** by default
 - **New channels**: the flag is **disabled** by default, unless explicitly set otherwise
 
 :::note
-Changing the `useLegacyLineVoucherPropagation` flag only affects **orders created after upgrading to version 3.21**.  
+Changing the `useLegacyLineDiscountPropagation` flag only affects **orders created after upgrading to version 3.21**.  
 It does **not** retroactively change:
 - Discount types for vouchers already converted from `PERCENTAGE` to `FIXED`
 - `unitDiscountReason` and `unitDiscount.amount` fields on existing orders
@@ -444,7 +444,7 @@ It does **not** retroactively change:
 
 
 ### Creating new channel with legacy flow enabled
-If you need to create a new channel with the **legacy voucher propagation** flow active, you must explicitly set `useLegacyLineVoucherPropagation` in the `channelCreate` mutation input:
+If you need to create a new channel with the **legacy voucher propagation** flow active, you must explicitly set `useLegacyLineDiscountPropagation` in the `channelCreate` mutation input:
 
 ```graphql
 mutation {
@@ -455,7 +455,7 @@ mutation {
       currencyCode: USD
       defaultCountry: PL
       orderSettings: {
-        useLegacyLineVoucherPropagation: true
+        useLegacyLineDiscountPropagation: true
       }
     }
   ) {
@@ -473,7 +473,7 @@ By default, new channels have legacy propagation **disabled** unless this field 
 
 #### Example responses
 
-##### With `useLegacyLineVoucherPropagation` **enabled**:
+##### With `useLegacyLineDiscountPropagation` **enabled**:
 
 ```json
 {
@@ -512,7 +512,7 @@ By default, new channels have legacy propagation **disabled** unless this field 
 }
 ```
 
-##### With `useLegacyLineVoucherPropagation` **disabled**:
+##### With `useLegacyLineDiscountPropagation` **disabled**:
 
 ```json
 {
@@ -558,11 +558,11 @@ To fully support the updated propagation model:
 mutation {
   channelUpdate(
     id: "<channel-id>"
-    input: { orderSettings: { useLegacyLineVoucherPropagation: false } }
+    input: { orderSettings: { useLegacyLineDiscountPropagation: false } }
   ) {
     channel {
       orderSettings {
-        useLegacyLineVoucherPropagation
+        useLegacyLineDiscountPropagation
       }
     }
   }

--- a/docs/upgrade-guides/core/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/core/3-20-to-3-21.mdx
@@ -340,35 +340,102 @@ Order can only receive `PARTIALLY_FULFILLED` status if there exists `FULFILLED` 
 
 ## Changes to voucher propagation in orders created from checkout
 
-In versions before 3.21, orders created from checkout with vouchers such as `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` (with apply-once-per-order) were represented as `OrderDiscount` objects, which were assigned to the `Order` and available in `order.discounts`. 
+### Before version 3.21
 
-Orders created from draft orders with vouchers (i.e., `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` with apply-once-per-order) had the voucher discount represented as `OrderLineDiscount` objects, attached to individual order lines.
+In versions prior to **3.21**, the way voucher discounts were applied and represented differed based on how the order was created:
 
-#### Voucher propagation before version 3.21:
+- **Orders from checkout** with vouchers of type `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` (with `apply-once-per-order`) used the `OrderDiscount` object. These discounts were returned in the `order.discounts` field.
+- **Orders from draft orders** used `OrderLineDiscount` objects attached to individual lines. In this case, `order.discounts` remained empty.
 
-| Creating Order        | Voucher: SPECIFIC_PRODUCT                                                                                     | Voucher: ENTIRE_ORDER with apply-once-per-order                                                                    |
-|-----------------------|----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| From Checkout         | `OrderDiscount` in `order.discounts` holds discount details                                                     | `OrderDiscount` in `order.discounts` holds discount details                                                        |
-| From Draft Order      | `OrderLineDiscount` in `OrderLine.discounts` holds discount details — `order.discounts` does not contain discounts | `OrderLineDiscount` in `OrderLine.discounts` holds discount details — `order.discounts` does not contain discounts  |
+#### Voucher representation prior to 3.21:
 
-#### Changes in version 3.21:
+| Order Source     | `SPECIFIC_PRODUCT` Voucher           | `ENTIRE_ORDER` with `apply-once-per-order` Voucher |
+|------------------|--------------------------------------|----------------------------------------------------|
+| From Checkout    | `OrderDiscount` in `order.discounts` | `OrderDiscount` in `order.discounts`               |
+| From Draft Order | (no entry in `order.discounts`)      | (no entry in `order.discounts`)                    |
 
-Starting from version 3.21, all orders created from checkout that use vouchers like `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` (with apply-once-per-order) will follow the same logic as draft orders. Specifically, instead of using the `OrderDiscount` object, the discount will be applied at the line level using `OrderLineDiscount` objects for each specific order line.
 
-#### Backward compatibility:
+Additionally, **percentage-based vouchers** applied during checkout were automatically **converted to fixed value discounts**, unlike draft orders which retained the **percentage type**.
 
-To ensure backward compatibility, version 3.21 introduces a flag `useLegacyLineVoucherPropagation` that allows you to control how voucher discounts are returned via API.
+| Order Source     | `SPECIFIC_PRODUCT` (PERCENTAGE) | `ENTIRE_ORDER` with `apply-once-per-order` (PERCENTAGE) |
+|------------------|---------------------------------|---------------------------------------------------------|
+| From Checkout    | Converted to `FIXED`            | Converted to `FIXED`                                    |
+| From Draft Order | Kept as `PERCENTAGE`            | Kept as `PERCENTAGE`                                    |
 
-| Creating Order from Checkout with:                   | 3.20                                                      | 3.21 with `useLegacyLineVoucherPropagation` enabled         | 3.21 with `useLegacyLineVoucherPropagation` disabled                                                                |
-|------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| Voucher: SPECIFIC_PRODUCT                            | `OrderDiscount` in `order.discounts` holds discount details | `OrderDiscount` in `order.discounts` holds discount details | `OrderLineDiscount` in `OrderLine.discounts` holds discount details — `order.discounts` does not contain discounts |
-| Voucher: ENTIRE_ORDER with apply-once-per-order      | `OrderDiscount` in `order.discounts` holds discount details | `OrderDiscount` in `order.discounts` holds discount details | `OrderLineDiscount` in `OrderLine.discounts` holds discount details — `order.discounts` does not contain discounts |
 
-By default, legacy line voucher propagation is active for all existing channels. However, for newly created channels, it will be disabled by default unless explicitly configured otherwise.
 
-#### Example:
+### Changes introduced in version 3.21
 
-#### Order with `ENTIRE_ORDER` voucher (apply-once-per-order) and `useLegacyLineVoucherPropagation` enabled:
+Starting from **version 3.21**, voucher propagation is unified for all order types:
+
+- All orders from checkout with `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` (with `apply-once-per-order`) vouchers now use `OrderLineDiscount` objects, just like draft orders.
+- Percentage `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` (with `apply-once-per-order`) vouchers are no longer converted to fixed value. The original discount type (`PERCENTAGE`) is preserved and reflected in the API.
+
+
+### Backward compatibility: `useLegacyLineVoucherPropagation` flag
+
+To support existing integrations, version 3.21 introduces a **feature flag**: `useLegacyLineVoucherPropagation`. This flag controls how discounts are exposed in the API for orders created via checkout.
+
+#### Discount representation based on flag:
+
+| Order from checkout + voucher           | 3.20                                         | 3.21 + Legacy propagation **enabled**        | 3.21 + Legacy propagation **disabled**                                       |
+|-----------------------------------------|----------------------------------------------|----------------------------------------------|------------------------------------------------------------------------------|
+| `SPECIFIC_PRODUCT`                      | `OrderDiscount` (entry in `order.discounts`) | `OrderDiscount` (entry in `order.discounts`) | `OrderLineDiscount` in `OrderLine.discounts` (no entry in `order.discounts`) |
+| `ENTIRE_ORDER` + `apply-once-per-order` | `OrderDiscount` (entry in `order.discounts`) | `OrderDiscount` (entry in `order.discounts`) | `OrderLineDiscount` in `OrderLine.discounts` (no entry in `order.discounts`) |
+
+
+
+
+#### Discount type (FIXED vs PERCENTAGE) based on flag:
+
+| Order from checkout + percentage voucher             | 3.20                 | 3.21 + Legacy propagation **enabled** | 3.21 + Legacy propagation **disabled** |
+|------------------------------------------------------|----------------------|---------------------------------------|----------------------------------------|
+| `SPECIFIC_PRODUCT` (PERCENTAGE)                      | Converted to `FIXED` | Converted to `FIXED`                  | Retained as `PERCENTAGE`               |
+| `ENTIRE_ORDER` + `apply-once-per-order` (PERCENTAGE) | Converted to `FIXED` | Converted to `FIXED`                  | Retained as `PERCENTAGE`               |
+
+
+By default:
+- **Existing channels** have legacy propagation **enabled**
+- **New channels** will have it **disabled**, unless explicitly configured otherwise.
+
+
+:::note  
+Changing the `useLegacyLineVoucherPropagation` flag affects how voucher discounts are returned in the API for **all orders created since version 3.21**.  
+However, this flag **does not** affect percentage-based vouchers that were already converted to fixed-value discounts. Toggling the flag will **not** retroactively change their discount type.  
+:::
+
+
+#### Creating new channel with legacy flow enabled
+If you need to create a new channel with the **legacy voucher propagation** flow active, you must explicitly set `useLegacyLineVoucherPropagation` in the `channelCreate` mutation input:
+
+```graphql
+mutation {
+  channelCreate(
+    input: {
+      name: "New channel"
+      slug: "new-channel"
+      currencyCode: USD
+      defaultCountry: PL
+      orderSettings: {
+        useLegacyLineVoucherPropagation: true
+      }
+    }
+  ) {
+    channel {
+      id
+    }
+    errors {
+      field
+      message
+    }
+  }
+}
+```
+By default, new channels have legacy propagation **disabled** unless this field is explicitly set to `true`.
+
+### Example responses
+
+#### With `useLegacyLineVoucherPropagation` **enabled**:
 
 ```json
 {
@@ -394,15 +461,11 @@ By default, legacy line voucher propagation is active for all existing channels.
       ],
       "lines": [
         {
-          "unitDiscount": {
-            "amount": 3.67
-          },
+          "unitDiscount": { "amount": 3.67 },
           "discounts": []
         },
         {
-          "unitDiscount": {
-            "amount": 0
-          },
+          "unitDiscount": { "amount": 0 },
           "discounts": []
         }
       ]
@@ -411,7 +474,7 @@ By default, legacy line voucher propagation is active for all existing channels.
 }
 ```
 
-#### Order with `ENTIRE_ORDER` voucher (apply-once-per-order) and `useLegacyLineVoucherPropagation` disabled:
+#### With `useLegacyLineVoucherPropagation` **disabled**:
 
 ```json
 {
@@ -421,28 +484,20 @@ By default, legacy line voucher propagation is active for all existing channels.
       "discounts": [],
       "lines": [
         {
-          "unitDiscount": {
-            "amount": 3.67
-          },
+          "unitDiscount": { "amount": 3.67 },
           "discounts": [
             {
               "name": "My voucher",
               "type": "VOUCHER",
               "valueType": "FIXED",
               "value": 11,
-              "unit": {
-                "amount": 3.67
-              },
-              "total": {
-                "amount": 11
-              }
+              "unit": { "amount": 3.67 },
+              "total": { "amount": 11 }
             }
           ]
         },
         {
-          "unitDiscount": {
-            "amount": 0
-          },
+          "unitDiscount": { "amount": 0 },
           "discounts": []
         }
       ]
@@ -450,22 +505,22 @@ By default, legacy line voucher propagation is active for all existing channels.
   }
 }
 ```
-:::note
-Switching the `useLegacyLineVoucherPropagation` flag will affect how voucher discounts are returned via API for all orders created since version 3.21.
-:::
 
-#### Steps to adapt to the new flow:
 
-- Extend your webhook subscriptions to include `OrderLineDiscount` objects (`order.lines[].discounts[]`).
-- Extend your queries to include `OrderLineDiscount` objects (`order.lines[].discounts[]`).
-- Update internal logic to handle discounts in `order.lines[].discounts[]` field.
-- Turn off legacy propagation:
+### How to migrate to the new flow
+
+To fully support the updated propagation model:
+
+- Extend webhook subscriptions to include: `order.lines[].discounts[]`
+- Update all queries to retrieve `OrderLineDiscount` data from `order.lines[].discounts[]`
+- Adjust internal logic to rely on line-level discount data
+- Disable legacy propagation using the following mutation:
 
 ```graphql
 mutation {
   channelUpdate(
     id: "<channel-id>"
-    input: {orderSettings: {useLegacyLineVoucherPropagation: false}}
+    input: { orderSettings: { useLegacyLineVoucherPropagation: false } }
   ) {
     channel {
       orderSettings {

--- a/docs/upgrade-guides/core/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/core/3-20-to-3-21.mdx
@@ -336,3 +336,142 @@ The `change_user_address` method has been removed from the Plugin Manager and is
 In previous versions, orders that had any unapproved fulfillments and no returns, were given status `PARTIALLY_FULFILLED`. This happened even when no items were actually fulfilled. 
 Currently, fulfillments with `WAITING_FOR_APPROVAL` status are excluded from determination of order status. Adding unapproved fulfillment to order will no longer result in a status change.
 Order can only receive `PARTIALLY_FULFILLED` status if there exists `FULFILLED` fulfillment and there are some items that are either unfulfilled or awaiting approval. 
+
+
+## Changes to voucher propagation in orders created from checkout
+
+In versions before 3.21, orders created from checkout with vouchers such as `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` (with apply-once-per-order) were represented as `OrderDiscount` objects, which were assigned to the `Order` and available in `order.discounts`. 
+
+Orders created from draft orders with vouchers (i.e., `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` with apply-once-per-order) had the voucher discount represented as `OrderLineDiscount` objects, attached to individual order lines.
+
+#### Voucher propagation before version 3.21:
+
+| Creating Order        | Voucher: SPECIFIC_PRODUCT                                                                                     | Voucher: ENTIRE_ORDER with apply-once-per-order                                                                    |
+|-----------------------|----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| From Checkout         | `OrderDiscount` in `order.discounts` holds discount details                                                     | `OrderDiscount` in `order.discounts` holds discount details                                                        |
+| From Draft Order      | `OrderLineDiscount` in `OrderLine.discounts` holds discount details — `order.discounts` does not contain discounts | `OrderLineDiscount` in `OrderLine.discounts` holds discount details — `order.discounts` does not contain discounts  |
+
+#### Changes in version 3.21:
+
+Starting from version 3.21, all orders created from checkout that use vouchers like `SPECIFIC_PRODUCT` or `ENTIRE_ORDER` (with apply-once-per-order) will follow the same logic as draft orders. Specifically, instead of using the `OrderDiscount` object, the discount will be applied at the line level using `OrderLineDiscount` objects for each specific order line.
+
+#### Backward compatibility:
+
+To ensure backward compatibility, version 3.21 introduces a flag `useLegacyLineVoucherPropagation` that allows you to control how voucher discounts are returned via API.
+
+| Creating Order from Checkout with:                   | 3.20                                                      | 3.21 with `useLegacyLineVoucherPropagation` enabled         | 3.21 with `useLegacyLineVoucherPropagation` disabled                                                                |
+|------------------------------------------------------|-----------------------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| Voucher: SPECIFIC_PRODUCT                            | `OrderDiscount` in `order.discounts` holds discount details | `OrderDiscount` in `order.discounts` holds discount details | `OrderLineDiscount` in `OrderLine.discounts` holds discount details — `order.discounts` does not contain discounts |
+| Voucher: ENTIRE_ORDER with apply-once-per-order      | `OrderDiscount` in `order.discounts` holds discount details | `OrderDiscount` in `order.discounts` holds discount details | `OrderLineDiscount` in `OrderLine.discounts` holds discount details — `order.discounts` does not contain discounts |
+
+By default, legacy line voucher propagation is active for all existing channels. However, for newly created channels, it will be disabled by default unless explicitly configured otherwise.
+
+#### Example:
+
+#### Order with `ENTIRE_ORDER` voucher (apply-once-per-order) and `useLegacyLineVoucherPropagation` enabled:
+
+```json
+{
+  "data": {
+    "order": {
+      "id": "T3JkZXI6NzJiM2NhNjktNzJmYS00ZjQ5LWE3ZGMtOTgxZGI4MDIwNmJj",
+      "discounts": [
+        {
+          "id": "T3JkZXJEaXNjb3VudDo1NjhhMGE5OS1hY2Y1LTQ1NzctYjE2YS0zNjFlMjU3MTAyYmE=",
+          "name": "My voucher",
+          "type": "VOUCHER",
+          "valueType": "FIXED",
+          "value": 11,
+          "total": {
+            "amount": 11,
+            "currency": "USD"
+          },
+          "amount": {
+            "amount": 11,
+            "currency": "USD"
+          }
+        }
+      ],
+      "lines": [
+        {
+          "unitDiscount": {
+            "amount": 3.67
+          },
+          "discounts": []
+        },
+        {
+          "unitDiscount": {
+            "amount": 0
+          },
+          "discounts": []
+        }
+      ]
+    }
+  }
+}
+```
+
+#### Order with `ENTIRE_ORDER` voucher (apply-once-per-order) and `useLegacyLineVoucherPropagation` disabled:
+
+```json
+{
+  "data": {
+    "order": {
+      "id": "T3JkZXI6NzJiM2NhNjktNzJmYS00ZjQ5LWE3ZGMtOTgxZGI4MDIwNmJj",
+      "discounts": [],
+      "lines": [
+        {
+          "unitDiscount": {
+            "amount": 3.67
+          },
+          "discounts": [
+            {
+              "name": "My voucher",
+              "type": "VOUCHER",
+              "valueType": "FIXED",
+              "value": 11,
+              "unit": {
+                "amount": 3.67
+              },
+              "total": {
+                "amount": 11
+              }
+            }
+          ]
+        },
+        {
+          "unitDiscount": {
+            "amount": 0
+          },
+          "discounts": []
+        }
+      ]
+    }
+  }
+}
+```
+:::note
+Switching the `useLegacyLineVoucherPropagation` flag will affect how voucher discounts are returned via API for all orders created since version 3.21.
+:::
+
+#### Steps to adapt to the new flow:
+
+- Extend your webhook subscriptions to include `OrderLineDiscount` objects (`order.lines[].discounts[]`).
+- Extend your queries to include `OrderLineDiscount` objects (`order.lines[].discounts[]`).
+- Update internal logic to handle discounts in `order.lines[].discounts[]` field.
+- Turn off legacy propagation:
+
+```graphql
+mutation {
+  channelUpdate(
+    id: "<channel-id>"
+    input: {orderSettings: {useLegacyLineVoucherPropagation: false}}
+  ) {
+    channel {
+      orderSettings {
+        useLegacyLineVoucherPropagation
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
Covers the changes introduced in:

https://github.com/saleor/saleor/pull/17587
& https://github.com/saleor/saleor/pull/17622
