### PR TITLE
Add link to AppManifest type in @saleor/app-sdk

### DIFF
--- a/docs/developer/extending/apps/architecture/manifest.mdx
+++ b/docs/developer/extending/apps/architecture/manifest.mdx
@@ -76,7 +76,7 @@ Apps can be installed via manifest using [`appFetchManifest`](/api-reference/app
 
 ## Typings
 
-App Manifest is typed in TypeScript in [@saleor/app-sdk](https://github.com/saleor/saleor-app-sdk) package.
+App Manifest is typed in TypeScript in [@saleor/app-sdk](https://github.com/saleor/app-sdk/blob/abe1b50b997a3314a4bb0311adc06f9db77a4145/src/types.ts#L238) package.
 
 Use it with
 


### PR DESCRIPTION
Small improvement that changes link from root of `@saleor/app-sdk` package repo, to a link to `AppManifest` type
