### PR TITLE
Revert Docusaurus to 3.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
-        "@docusaurus/core": "^3.7.0",
-        "@docusaurus/faster": "^3.7.0",
-        "@docusaurus/preset-classic": "^3.7.0",
-        "@docusaurus/theme-classic": "^3.7.0",
-        "@docusaurus/theme-mermaid": "^3.7.0",
-        "@docusaurus/types": "^3.7.0",
+        "@docusaurus/core": "^3.6.3",
+        "@docusaurus/faster": "^3.6.3",
+        "@docusaurus/preset-classic": "^3.6.3",
+        "@docusaurus/theme-classic": "^3.6.3",
+        "@docusaurus/theme-mermaid": "^3.6.3",
+        "@docusaurus/types": "^3.6.3",
         "@graphql-markdown/diff": "^1.1.8",
         "@graphql-markdown/docusaurus": "^1.26.2",
         "@graphql-tools/graphql-file-loader": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "check-spelling": "cspell '**/*.{jsx,js,md,mdx}'"
   },
   "devDependencies": {
-    "@docusaurus/core": "^3.7.0",
-    "@docusaurus/faster": "^3.7.0",
-    "@docusaurus/preset-classic": "^3.7.0",
-    "@docusaurus/theme-classic": "^3.7.0",
-    "@docusaurus/theme-mermaid": "^3.7.0",
-    "@docusaurus/types": "^3.7.0",
+    "@docusaurus/core": "^3.6.3",
+    "@docusaurus/faster": "^3.6.3",
+    "@docusaurus/preset-classic": "^3.6.3",
+    "@docusaurus/theme-classic": "^3.6.3",
+    "@docusaurus/theme-mermaid": "^3.6.3",
+    "@docusaurus/types": "^3.6.3",
     "@graphql-markdown/diff": "^1.1.8",
     "@graphql-markdown/docusaurus": "^1.26.2",
     "@graphql-tools/graphql-file-loader": "^8.0.1",


### PR DESCRIPTION
Due to visual errors with menus, we are downgrading to the previously used version