### PR TITLE
Adjust upgrade guide for making transactionId in OrderGrantRefundCreateInput required

### DIFF
--- a/docs/upgrade-guides/core/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/core/3-20-to-3-21.mdx
@@ -149,6 +149,11 @@ This adjustment ensures that the event is only fired when there are actual updat
 The `OrderUpdate` mutation no longer triggers the `ORDER_UPDATED` webhook event if there are no changes to the draft order.
 This adjustment ensures that the event is only fired when there are actual updates to the order, reducing unnecessary event emissions.
 
+## Required `transactionId` field in `OrderGrantRefundCreateInput`
+The `OrderGrantRefundCreateInput` now requires a `transactionId` field.
+This change affects the `OrderGrantRefundCreate` mutation.
+The `transactionId` must be provided as part of the input; otherwise, the mutation will return an error. 
+
 ## Plugin changes
 
 ### Removed plugins


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Adjust the upgrade guide for the following changes: https://github.com/saleor/saleor/pull/17635

## Checklist

- [ ] I have read and followed the [guidelines](../GUIDELINES.md)
