### PR TITLE
Upgrade guide: add instructions for GCP breaking change

### DIFF
--- a/docs/upgrade-guides/core/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/core/3-20-to-3-21.mdx
@@ -576,3 +576,12 @@ mutation {
   }
 }
 ```
+
+## Google Cloud Platform (GCP): Configuration Changes
+
+The environment variable `GS_MEDIA_BUCKET_NAME` no [longer applies](https://github.com/saleor/saleor/pull/17660) for files that may contain sensitive information. The following steps should be taken:
+
+1. Keep the original configuration for `GS_MEDIA_BUCKET_NAME` - it will still be used for public media files, such as product images.
+2. Set a new environment variable `GS_MEDIA_PRIVATE_BUCKET_NAME` - it should point to private bucket that's not exposed to the Internet.
+
+For more information, see [Storing Files on Google Cloud Storage (GCS)](/setup/media-gcs.mdx#environment-variables).

--- a/docs/upgrade-guides/core/3-20-to-3-21.mdx
+++ b/docs/upgrade-guides/core/3-20-to-3-21.mdx
@@ -579,9 +579,9 @@ mutation {
 
 ## Google Cloud Platform (GCP): Configuration Changes
 
-The environment variable `GS_MEDIA_BUCKET_NAME` no [longer applies](https://github.com/saleor/saleor/pull/17660) for files that may contain sensitive information. The following steps should be taken:
+The environment variable `GS_MEDIA_BUCKET_NAME` [no longer applies](https://github.com/saleor/saleor/pull/17660) for files that may contain sensitive information. The following steps should be taken:
 
 1. Keep the original configuration for `GS_MEDIA_BUCKET_NAME` - it will still be used for public media files, such as product images.
-2. Set a new environment variable `GS_MEDIA_PRIVATE_BUCKET_NAME` - it should point to private bucket that's not exposed to the Internet.
+2. Set a new environment variable `GS_MEDIA_PRIVATE_BUCKET_NAME` - it should point to a private bucket that's not exposed to the Internet.
 
 For more information, see [Storing Files on Google Cloud Storage (GCS)](/setup/media-gcs.mdx#environment-variables).


### PR DESCRIPTION
The pull request https://github.com/saleor/saleor/pull/17660 renamed the environment variable `GS_MEDIA_BUCKET_NAME` for the GCP private storage bucket to `GS_MEDIA_PRIVATE_BUCKET_NAME` but wasn't documented as a breaking change.

Related PRs:
- https://github.com/saleor/saleor/pull/17660 (breaking change)
- https://github.com/saleor/saleor/pull/17671 (changelogs)

## Description

<!-- What does this PR do? -->

## Checklist

- [ ] I have read and followed the [guidelines](../GUIDELINES.md)
