### PR TITLE
Add draft orders overview

### DIFF
--- a/docs/developer/app-store/plugins/oidc.mdx
+++ b/docs/developer/app-store/plugins/oidc.mdx
@@ -68,7 +68,7 @@ The flow is shown in the chart below:
 graph TD
  A[The user login via OIDC]
  A --> K[Get or create user in Saleor]
- K --> B{The user email match any domain from <br> `Staff user domains`}
+ K --> B{The user email match any domain from <br> Staff user domains}
  B --> |No| C{The user has any Saleor's permission <br> assigned on the OAuth side}
  C --> |No| D{The user is marked as staff on OAuth side}
  D --> |Yes| E[Mark user as a staff user]

--- a/docs/developer/order/draft-order.mdx
+++ b/docs/developer/order/draft-order.mdx
@@ -1,0 +1,85 @@
+---
+title: Draft Orders
+description: Create and manage draft orders in Saleor
+---
+
+## Overview
+
+Draft Orders in Saleor allow to create and manage orders on behalf of customers—either 
+through the Saleor Dashboard or programmatically via API. 
+They are ideal for cases where the customer is not initiating the order themselves, 
+such as phone sales, in-person purchases, or email requests. 
+Once a draft order is completed, Saleor handles the rest—triggering notifications, 
+updating inventory, and transitioning the order into the standard fulfillment pipeline.
+
+Common use cases include:
+
+- **Phone Orders:** Customer service teams can create orders directly for customers calling in, 
+capturing details like variants, addresses, and shipping methods.
+- **Custom Quotes and Negotiations:** Generate draft orders with special pricing or 
+configurations for B2B sales or negotiated deals, and confirm them once approved.
+- **Item Replacements and Exchanges:** Automatically pre-fill draft orders with customer 
+and order context for faster handling of returns, damaged items, or goodwill shipments—without altering the original order.
+
+
+## API
+### Core Draft Order Management
+
+- [`draftOrderCreate`](/api-reference/orders/mutations/draft-order-create): 
+This mutation is the starting point for creating a new draft order.
+
+- [`draftOrderUpdate`](/api-reference/orders/mutations/draft-order-update): Modify various 
+aspects of an existing draft order. This includes:
+    - Setting or updating the customer and their associated shipping and billing addresses.
+    - Applying vouchers to the draft order to include discounts.
+    -  Adding customer notes (visible to the customer).
+
+- [`orderUpdateShipping`](/api-reference/orders/mutations/order-update-shipping): 
+Assign or change the shipping method for the draft order. This requires a valid shipping method ID.
+
+- [`draftOrderComplete`](/api-reference/orders/mutations/draft-order-complete): 
+Transition into a regular order. This action triggers several important processes:
+    - Inventory allocations are created for variants with inventory tracking enabled, 
+    reducing the available stock.
+    - Order-related webhooks (beyond draft order specific ones) are triggered.
+    - The order becomes eligible for the standard order fulfillment and payment processes.
+
+- [`draftOrderDelete`](/api-reference/orders/mutations/draft-order-delete) / [`draftOrderBulkDelete`](/api-reference/orders/mutations/draft-order-bulk-delete): 
+Remove one or multiple draft orders.
+
+### Managing Order Lines
+
+- [`orderLinesCreate`](/api-reference/orders/mutations/order-lines-create): 
+Add new product variants as lines to the draft order. You specify the variant, the quantity and override current price.
+- [`orderLineUpdate`](/api-reference/orders/mutations/order-line-update): 
+Modify the quantity or the selected variant of an existing order line in the draft order.
+- [`orderLineDelete`](/api-reference/orders/mutations/order-line-delete): 
+Remove a specific product line from the draft order.
+
+### Manage discounts
+
+**Order-Level Discounts:**
+    - [`orderDiscountAdd`](/api-reference/orders/mutations/order-discount-add): 
+    Apply a discount to the entire draft order, either as a fixed amount or a percentage.
+    - [`orderDiscountUpdate`](/api-reference/orders/mutations/order-discount-update): 
+    Modify the value or reason of an existing order-level discount.
+    - [`orderDiscountDelete`](/api-reference/orders/mutations/order-discount-delete): 
+    Remove an order-level discount.
+
+
+**Order Line-Level Discounts:**
+    - [`orderLineDiscountUpdate`](/api-reference/orders/mutations/order-line-discount-update): 
+    Apply or modify a discount on a specific order line.
+    - [`orderLineDiscountRemove`](/api-reference/orders/mutations/order-line-discount-remove): 
+    Remove a discount from a specific order line.
+
+For more information about adding manual discounts, see the [Manual Discounts](/developer/discounts/manual-discounts) documentation.
+
+
+## Webhooks
+
+- `DRAFT_ORDER_CREATED`
+- `DRAFT_ORDER_UPDATED`
+- `DRAFT_ORDER_DELETED`
+- `ORDER_CALCULATE_TAXES` (sync): Allows external services to calculate taxes for the draft order based on its details.
+- `ORDER_FILTER_SHIPPING_METHODS` (sync): Enables filtering (excluding) available shipping methods for the draft order.

--- a/docs/developer/order/draft-order.mdx
+++ b/docs/developer/order/draft-order.mdx
@@ -5,11 +5,11 @@ description: Create and manage draft orders in Saleor
 
 ## Overview
 
-Draft Orders in Saleor allow to create and manage orders on behalf of customers—either 
+Draft Orders in Saleor allow to create and manage orders on behalf of customers: either 
 through the Saleor Dashboard or programmatically via API. 
 They are ideal for cases where the customer is not initiating the order themselves, 
 such as phone sales, in-person purchases, or email requests. 
-Once a draft order is completed, Saleor handles the rest—triggering notifications, 
+Once a draft order is completed, Saleor handles the rest: triggering notifications, 
 updating inventory, and transitioning the order into the standard fulfillment pipeline.
 
 Common use cases include:
@@ -73,7 +73,7 @@ Modify the quantity or the selected variant of an existing order line in the dra
 - [`orderLineDelete`](/api-reference/orders/mutations/order-line-delete): 
 Remove a specific product line from the draft order.
 
-### Manage discounts
+### Manage Discounts
 
 **Order-Level Discounts:**
     - [`orderDiscountAdd`](/api-reference/orders/mutations/order-discount-add): 

--- a/docs/developer/order/draft-order.mdx
+++ b/docs/developer/order/draft-order.mdx
@@ -21,7 +21,24 @@ configurations for B2B sales or negotiated deals, and confirm them once approved
 - **Item Replacements and Exchanges:** Automatically pre-fill draft orders with customer 
 and order context for faster handling of returns, damaged items, or goodwill shipments—without altering the original order.
 
-
+## Fulfillment Lifecycle
+```mermaid
+graph TD
+    A[Create draft order **draftOrderCreate**] --> B[ Add user email, shipping and billing address **draftOrderUpdate**]
+    B --> C[Add / Modify Products **orderLinesCreate/Update/Delete**];
+    C --> D{Is Shipping Required?};
+    D --> | Yes | E[Assign shipping method **orderUpdateShipping**];
+    D --> | No & No Discount | F[Complete Draft Order **draftOrderComplete**];
+    E --> G{Add Discount?}
+    G --> | No | F;
+    G --> | For total | H[Add order-level manual discount **orderDiscountAdd/Update/Delete**];
+    G --> | For line | I[Add line-level manual discount **orderLineDiscountUpdate/Remove**];
+    G --> | Use voucher | J[Add voucher code **draftOrderUpdate**];
+    H --> F;
+    I --> F;
+    J --> F;
+    F --> K(Ready for Payment & Fulfillment)
+```
 ## API
 ### Core Draft Order Management
 

--- a/docs/developer/order/draft-order.mdx
+++ b/docs/developer/order/draft-order.mdx
@@ -21,11 +21,11 @@ configurations for B2B sales or negotiated deals, and confirm them once approved
 - **Item Replacements and Exchanges:** Automatically pre-fill draft orders with customer 
 and order context for faster handling of returns, damaged items, or goodwill shipments—without altering the original order.
 
-## Fulfillment Lifecycle
+## Draft Orders Lifecycle
 ```mermaid
 graph TD
-    A[Create draft order **draftOrderCreate**] --> B[ Add user email, shipping and billing address **draftOrderUpdate**]
-    B --> C[Add / Modify Products **orderLinesCreate/Update/Delete**];
+    A[Create draft order **draftOrderCreate**] --> B[Add / Modify Products **orderLinesCreate/Update/Delete**];
+    B --> C[Add user email, shipping and billing address **draftOrderUpdate**]
     C --> D{Is Shipping Required?};
     D --> | Yes | E[Assign shipping method **orderUpdateShipping**];
     D --> | No & No Discount | F[Complete Draft Order **draftOrderComplete**];

--- a/docs/developer/order/order-status.mdx
+++ b/docs/developer/order/order-status.mdx
@@ -19,9 +19,9 @@ flowchart TD
     CreatedDraft[Draft order created] --> DRAFT(DRAFT)
     CheckoutCompleted[Checkout Completed]
 
-    DRAFT -->|Confirm order| UNFULFILLED(UNFULFILLED)
+    DRAFT -->| Draft order complete | isAutomated{Is automated<br> order confirmation turned on?}
 
-    CheckoutCompleted --> isAutomated{Is automated<br> order confirmation turned on?}
+    CheckoutCompleted --> isAutomated
     isAutomated -->|Yes| UNFULFILLED
     isAutomated -->|No| UNCONFIRMED(UNCONFIRMED)
 
@@ -49,7 +49,6 @@ flowchart TD
     isNotReturned -->|No| RETURNED(RETURNED)
 
     PARTIALLY_RETURNED -->|Return products| isNotReturned
-
 
 ```
 

--- a/sidebars/core-concepts.js
+++ b/sidebars/core-concepts.js
@@ -46,6 +46,7 @@ export const coreConcepts = [
   "developer/order/order-update",
   "developer/order/order-expiration",
   "developer/order/order-to-checkout",
+  "developer/order/draft-order",
   "developer/order/address",
   "developer/price-freeze-period",
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Explain draft orders use case 
Update Order status graph based on changes introduced in https://linear.app/saleor/issue/BCK-456/use-automaticallyconfirmallneworders-with-draft-orders
Fix graph in OIDC docs 

Build: https://saleor-docs-git-cxe-884-draft-orders-saleorcommerce.vercel.app/developer/order/draft-order

## Checklist

- [x] I have read and followed the [guidelines](../GUIDELINES.md)
