### PR TITLE
Extend filtering section - add filter vs where section

### DIFF
--- a/docs/api-usage/filtering.mdx
+++ b/docs/api-usage/filtering.mdx
@@ -4,6 +4,9 @@ title: Filtering
 
 The `where` filtering allows specifying more complex conditions with the use of `AND` and `OR` operators,
 combined with operations like equal (`eq`), one of, and range. It's available under the `where` option.
+The `where` filtering is a new and more flexible solution compared to the older `filter` option. 
+Whenever possible, we recommend using `where` filtering where is available for its advanced capabilities and flexibility. 
+Read more in the [`Filter vs Where Filtering`](#filter-vs-where-filtering) section.
 
 :::info
 
@@ -559,3 +562,26 @@ Query variables:
 ```
 
 **INSTEAD:** Use the `eq` or `oneOf` operation.
+
+
+### `Filter` vs `Where` Filtering
+
+The `where` filtering is a new and more flexible solution compared to the older `filter` option.
+While both approaches allow filtering data, there are key differences and recommendations for their usage:
+
+- **`filter`**: 
+  - The older filtering mechanism.
+  - Limited in flexibility and does not support complex conditions like `AND`/`OR` operators or nested conditions.
+  - Still available for backward compatibility and in areas where `where` filtering is not yet implemented.
+
+- **`where`**:
+  - The recommended and more powerful filtering mechanism.
+  - Supports advanced filtering capabilities such as:
+    - Combining conditions with `AND` and `OR` operators.
+    - Filtering by specific values (`eq`) or lists of values (`oneOf`).
+    - Nested conditions for more complex queries.
+  - Provides a more consistent and structured approach to filtering.
+
+:::note
+You cannot use both `filter` and `where` options in the same query. If both are provided, an error will be raised. ([See the example](#mixing-filter-and-where-options)).
+:::


### PR DESCRIPTION
## Description
Explain what is the difference between `filter` and `where` option.

New paragraph:
https://saleor-docs-git-extend-filtering-page-saleorcommerce.vercel.app/api-usage/filtering#filter-vs-where-filtering

<!-- What does this PR do? -->

## Checklist

- [x] I have read and followed the [guidelines](../GUIDELINES.md)
