### PR TITLE
fix: missing sidebar in AI docs

### DIFF
--- a/docs/developer/ai.mdx
+++ b/docs/developer/ai.mdx
@@ -1,5 +1,6 @@
 ---
 tags: [AI, "Artificial Intelligence"]
+displayed_sidebar: main
 ---
 
 # Using AI with Saleor


### PR DESCRIPTION
This fixes the missing sidebar in our AI documentation.

| Before | After |
| --- | --- |
| <img width="899" alt="Screenshot 2025-05-23 at 11 58 26 AM" src="https://github.com/user-attachments/assets/3b41e4c1-5176-428f-b2e9-ec0e9d44c4f7" /> | <img width="899" alt="Screenshot 2025-05-23 at 11 58 15 AM" src="https://github.com/user-attachments/assets/204b2ff4-9a5f-4800-895d-98164d323717" /> |