### PR TITLE
Bump unreleased version

### DIFF
--- a/scripts/highlight.js
+++ b/scripts/highlight.js
@@ -31,7 +31,7 @@ const highlightSaleorVersion = (file) => {
       let badgeText = version.replace(/\.$/, "");
 
       // Change that upon releasing a new version
-      if (badgeText.includes("3.21")) {
+      if (badgeText.includes("3.22")) {
         badgeText = badgeText + " (unreleased)";
       }
       if (block.startsWith(">")) {


### PR DESCRIPTION
Bump the number of the unreleased version, which can be displayed in the API reference.