### PR TITLE
Fix misleading info on shippingMethods fetching in subscription queries

### DIFF
--- a/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
@@ -54,8 +54,23 @@ Due to circular reference, subscription queries should not contain fields:
 - `checkout.shippingMethods`
 - `checkout.deliveryMethod`
 
-Instead fetch checkout via GraphQL query with those fields if you need them in your webhook handling logic.
-
+Instead you should fetch shipping methods using root level `shippingMethods` field, e.g.:
+```graphql
+subscription {
+  event {
+    ... on ShippingListMethodsForCheckout {
+      __typename
+      shippingMethods {
+        id
+        name
+      }
+      checkout {
+        id
+      }
+    }
+  }
+}
+```
 :::
 
 #### Request format
@@ -255,6 +270,22 @@ Due to circular reference, subscription queries should not contain fields:
 - `order.shippingMethods`
 - `order.deliveryMethod`
 
+Instead you should fetch shipping methods using root level `shippingMethods` field, e.g.:
+```graphql
+subscription {
+  event {
+    ... on CheckoutFilterShippingMethods {
+      __typename
+      shippingMethods {
+        id
+        name
+      }
+      checkout {
+        id
+      }
+    }
+  }
+}
 :::
 
 #### Request format

--- a/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
+++ b/docs/developer/extending/webhooks/synchronous-events/shipping.mdx
@@ -49,28 +49,12 @@ shipping methods are queried for a checkout object.
 ```
 
 :::warning
-Due to circular reference, subscription queries should not contain fields:
+Due to circular reference, `ShippingListMethodsForCheckout` subscription queries should not contain fields:
 
 - `checkout.shippingMethods`
 - `checkout.deliveryMethod`
+- `shippingMethods`
 
-Instead you should fetch shipping methods using root level `shippingMethods` field, e.g.:
-```graphql
-subscription {
-  event {
-    ... on ShippingListMethodsForCheckout {
-      __typename
-      shippingMethods {
-        id
-        name
-      }
-      checkout {
-        id
-      }
-    }
-  }
-}
-```
 :::
 
 #### Request format
@@ -263,7 +247,7 @@ Saleor Apps can subscribe to the synchronous webhooks:
 - `ORDER_FILTER_SHIPPING_METHODS` is called whenever shipping methods are listed for an editable order, such as a [draft order](api-reference/orders/enums/order-status.mdx#orderstatusdraft) or an [unconfirmed order](api-reference/orders/enums/order-status.mdx#orderstatusunconfirmed)
 
 :::warning
-Due to circular reference, subscription queries should not contain fields:
+Due to circular reference, `CheckoutFilterShippingMethods` and `OrderFilterShippingMethods` subscription queries should not contain fields:
 
 - `checkout.shippingMethods`
 - `checkout.deliveryMethod`


### PR DESCRIPTION
## Description

This PR adds specifics on how to fetch shipping method IDs when using synchronous shipping events without creating a circular reference

## Checklist

- [ ] I have read and followed the [guidelines](../GUIDELINES.md)
