### PR TITLE
Remove note about using order token in updateMetadata

### DIFF
--- a/docs/api-usage/metadata.mdx
+++ b/docs/api-usage/metadata.mdx
@@ -21,7 +21,9 @@ All objects support two sets of metadata:
 - `metadata` is public and visible to the unauthenticated users.
 - `privateMetadata` is protected and visible only to the staff users, plugins, and Apps with appropriate permissions.
 
+:::info
 Modifying both requires permission to manage the item that metadata is attached to.
+::: 
 
 ## Querying metadata
 
@@ -155,11 +157,6 @@ type Mutation {
 }
 ```
 
-:::note
-For `Order` and `Checkout` types, it is recommended to use `token` as the `id` input value; for other types, use GraphQL ID.
-
-Changing the `Order` metadata is possible only with the use of `token`.
-:::
 
 All resulting types have the same shape:
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Remove note to use checkout or order token as id in updateMetadata 
Highlight that updateMetadata require permission for updating object

## Checklist

- [x] I have read and followed the [guidelines](../GUIDELINES.md)
