### PR TITLE
Add upgrade guide for behaviour change in authorization status and automatic checkout completion for an edge case where checkout has total equal to 0 and there is an ongoing transaction for the checkout

### DIFF
--- a/docs/upgrade-guides/core/3-21-to-3-22.mdx
+++ b/docs/upgrade-guides/core/3-21-to-3-22.mdx
@@ -30,3 +30,16 @@ The following changes were implemented to orders with a zero total amount:
 
 - No manual charge (`Transaction` or `Payment`) object will be created.
 - The `OrderEvents.ORDER_MARKED_AS_PAID` event will no longer be emitted.
+
+## Automatic checkout completion behavior change for checkouts with total being 0
+
+Before version 3.22, the following scenario would result in automatic checkout completion. In version 3.22 and onwards, this behavior has changed.
+
+Preconditions:
+- Channel has an automatic checkout completion feature enabled
+- Checkout has a total amount equal to zero
+- Checkout has lines
+
+Upon processing a transaction, the checkout would have been completed because then, it was not considered fully paid. Transaction logic recognized the authorization status change, which triggered automatic checkout completion.
+
+Now, upon processing a transaction, the checkout will not get completed because checkout is already considered fully paid; therefore, transaction logic does not recognize any authorization status change thus automatic checkout completion is not triggered.


### PR DESCRIPTION
Complementary guide to https://github.com/saleor/saleor/pull/18019.