### PR TITLE
Document behavior change for creating a Payment for a Checkout object with an an existing Transaction

### DIFF
--- a/docs/upgrade-guides/core/3-21-to-3-22.mdx
+++ b/docs/upgrade-guides/core/3-21-to-3-22.mdx
@@ -43,3 +43,7 @@ Preconditions:
 Upon processing a transaction, the checkout would have been completed because then, it was not considered fully paid. Transaction logic recognized the authorization status change, which triggered automatic checkout completion.
 
 Now, upon processing a transaction, the checkout will not get completed because checkout is already considered fully paid; therefore, transaction logic does not recognize any authorization status change thus automatic checkout completion is not triggered.
+
+## Behavior change for creating a Payment (old API) for a Checkout object with an existing Transaction (new API)
+
+Creating a Payment (old API) for a Checkout object with an existing Transaction (new API) is no longer permitted as it leads to inconsistent behavior.


### PR DESCRIPTION
## Description

Documents a behavior change in Saleor Core (https://github.com/saleor/saleor/pull/18069).

## Checklist

- [x] I have read and followed the [guidelines](../GUIDELINES.md)