### PR TITLE
Rename "pages" to "models" and "menus" to "structures"

### DIFF
--- a/docs/developer/extending/apps/extending-dashboard-with-apps.mdx
+++ b/docs/developer/extending/apps/extending-dashboard-with-apps.mdx
@@ -199,7 +199,7 @@ Saleor requires extensions to define a mounting place. The table below explains 
 | NAVIGATION_CUSTOMERS              | Customers section in the navigation bar.                | `POPUP`, `APP_PAGE`, `NEW_TAB`            |                |
 | NAVIGATION_DISCOUNTS              | Discounts section in the navigation bar.                | `POPUP`, `APP_PAGE`, `NEW_TAB`            |                |
 | NAVIGATION_TRANSLATIONS           | Translations section in the navigation bar.             | `POPUP`, `APP_PAGE`, `NEW_TAB`            |                |
-| NAVIGATION_PAGES                  | Pages section in the navigation bar.                    | `POPUP`, `APP_PAGE`, `NEW_TAB`            |                |
+| NAVIGATION_PAGES                  | Models section in the navigation bar.                   | `POPUP`, `APP_PAGE`, `NEW_TAB`            |                |
 | ORDER_DETAILS_MORE_ACTIONS        | Order's detail page under the more action button.       | `POPUP`, `APP_PAGE`, `NEW_TAB`            |                |
 | ORDER_OVERVIEW_CREATE             | Order's list page under the create button.              | `POPUP`, `APP_PAGE`, `NEW_TAB`            |                |
 | ORDER_OVERVIEW_MORE_ACTIONS       | Order's list page under the more action button.         | `POPUP`, `APP_PAGE`, `NEW_TAB`            |                |

--- a/docs/developer/extending/apps/extending-dashboard-with-apps.mdx
+++ b/docs/developer/extending/apps/extending-dashboard-with-apps.mdx
@@ -221,9 +221,9 @@ Saleor requires extensions to define a mounting place. The table below explains 
 | PAGE_TYPE_OVERVIEW_CREATE         | Page type's list page under the create button.          | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |
 | PAGE_TYPE_OVERVIEW_MORE_ACTIONS   | Page type's list page under the more action button.     | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |
 | PAGE_TYPE_DETAILS_MORE_ACTIONS    | Page type's detail page under the more action button.   | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |
-| MENU_OVERVIEW_CREATE              | Menu's list page under the create button.               | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |
-| MENU_OVERVIEW_MORE_ACTIONS        | Menu's list page under the more action button.          | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |
-| MENU_DETAILS_MORE_ACTIONS         | Menu's detail page under the more action button.        | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |
+| MENU_OVERVIEW_CREATE              | Structure's list page under the create button.          | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |
+| MENU_OVERVIEW_MORE_ACTIONS        | Structure's list page under the more action button.     | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |
+| MENU_DETAILS_MORE_ACTIONS         | Structure's detail page under the more action button.   | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |
 
 ## More resources
 

--- a/docs/developer/menu.mdx
+++ b/docs/developer/menu.mdx
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem";
 
 ## Overview
 
-Menus are assembly structures that group and organize entities in your store. They create hierarchical relationships between categories, collections, and pages. The most common use case is storefront navigation.
+Menus are assembly structures that group and organize entities in your store. They create hierarchical relationships between categories, collections, and models. The most common use case is storefront navigation.
 
 You can create menus in the Saleor Dashboard in the _Configuration_ → _Navigation_ page.
 
@@ -13,7 +13,7 @@ You can create menus in the Saleor Dashboard in the _Configuration_ → _Navigat
 
 **Modeling Curated Guides in Online Electronics Store**
 
-Consider an online electronics store that wants to create guided content helping customers choose and set up products for specific needs, like a "Home Office Setup Guide". This guide needs to link specific setup advice Pages, relevant Product Categories, and perhaps a key Collection.
+Consider an online electronics store that wants to create guided content helping customers choose and set up products for specific needs, like a "Home Office Setup Guide". This guide needs to link specific setup advice Models, relevant Product Categories, and perhaps a key Collection.
 
 Menus can model this curated, hierarchical structure:
 
@@ -22,11 +22,11 @@ graph TD
     MenuGuide["Menu: Home Office Setup Guide<br/>"]
 
     subgraph MenuItems
-        ItemPageErgonomics["Item 1: Ergonomics Tips (Page)"]
+        ItemPageErgonomics["Item 1: Ergonomics Tips (Model)"]
         ItemCatMonitors["Item 2: Monitors (Category)"]
         ItemSubNetworking["Item 3: Networking Setup (Parent)"]
-            ItemPageWifi["Item 3a: Wi-Fi Basics (Page)"]
-            ItemPageCable["Item 3b: Cable Management (Page)"]
+            ItemPageWifi["Item 3a: Wi-Fi Basics (Model)"]
+            ItemPageCable["Item 3b: Cable Management (Model)"]
             ItemCatRouters["Item 3c: Routers (Category)"]
         ItemCollBundles["Item 4: Office Bundles (Collection)"]
     end
@@ -49,16 +49,16 @@ graph TD
 
 - **Menu:** A Menu is created with the name "Home Office Setup Guide" and slug `home-office-guide`. This Menu itself represents the structured guide.
 - **Menu Items:**
-  - An item links directly to a `Page` titled "Ergonomics Tips" (perhaps a custom Page modeled for guides).
+  - An item links directly to a `Model` titled "Ergonomics Tips" (perhaps a custom Model modeled for guides).
     - Another item links to the existing `Category` "Monitors".
     - A parent item "Networking Setup" (linking perhaps to a generic URL or another Page) has child items:
-      - A child item linking to a "Wi-Fi Basics" `Page`.
-      - A child item linking to a "Cable Management" `Page`.
+      - A child item linking to a "Wi-Fi Basics" `Model`.
+      - A child item linking to a "Cable Management" `Model`.
       - A child item linking to the "Routers" `Category`.
     - A final item links to a curated `Collection` named "Office Bundles".
 
 
-Instead of just being top-level navigation, this Menu (`home-office-guide`) **models a specific, curated relationship** between different types of content and commerce entities (Pages, Categories, Collections). It defines a specific structure for the "Home Office Setup" topic that isn't captured by standard product categorization alone.
+Instead of just being top-level navigation, this Menu (`home-office-guide`) **models a specific, curated relationship** between different types of content and commerce entities (Models, Categories, Collections). It defines a specific structure for the "Home Office Setup" topic that isn't captured by standard product categorization alone.
 
 By querying this specific menu slug, an application can retrieve this curated structure and present the guide content in the intended order and hierarchy, demonstrating how Menus can assemble entities into a structured whole for purposes beyond simple site navigation.
 
@@ -79,7 +79,7 @@ A menu item can link to one of the following entities:
 
 - Category
 - Collection
-- Page
+- Model
 - URL
 
 <Tabs>

--- a/docs/developer/modeling.mdx
+++ b/docs/developer/modeling.mdx
@@ -6,23 +6,23 @@ sidebar_label: Overview
 
 ## Overview
 
-While Saleor includes standard commerce entities (Products, Categories, Collections), specific business domains often require representing additional concepts (e.g., Brands, Ingredients, [Scent Profiles](./pages.mdx#example-use-case)).
+While Saleor includes standard commerce entities (Products, Categories, Collections), specific business domains often require representing additional concepts (e.g., Brands, Ingredients, [Scent Profiles](./models.mdx#example-use-case)).
 
 Modeling in Saleor refers to the use of built-in features to extend the standard commerce object model. This involves defining custom structured data types and organizational structures, making them queryable via the standard GraphQL API.
 
 The primary mechanisms for domain modeling in Saleor are:
 
-## Pages
+## Models
 
-Pages and Attributes enable the definition of custom structured data entities. `REFERENCE` attributes can be used to link entities to each other.
+Models and Attributes enable the definition of custom structured data entities. `REFERENCE` attributes can be used to link entities to each other.
 
-To learn more about Pages, refer to the [Pages documentation](./pages.mdx).
+To learn more about Models, refer to the [Models documentation](./models.mdx).
 
 ## Menus
 
 Menus function as hierarchical assembly structures for grouping and organizing various entities.
 
-They can link Categories, Collections, Pages (including custom Page instances created via modeling), and external URLs into ordered hierarchies.
+They can link Categories, Collections, Models (including custom Model instances created via modeling), and external URLs into ordered hierarchies.
 
 While commonly applied for storefront navigation, menus can be used for any scenario requiring curated, structured lists or trees of linked entities.
 

--- a/docs/developer/modeling.mdx
+++ b/docs/developer/modeling.mdx
@@ -18,13 +18,13 @@ Models and Attributes enable the definition of custom structured data entities. 
 
 To learn more about Models, refer to the [Models documentation](./models.mdx).
 
-## Menus
+## Structures
 
-Menus function as hierarchical assembly structures for grouping and organizing various entities.
+Structures function as hierarchical assembly mechanisms for grouping and organizing various entities.
 
 They can link Categories, Collections, Models (including custom Model instances created via modeling), and external URLs into ordered hierarchies.
 
-While commonly applied for storefront navigation, menus can be used for any scenario requiring curated, structured lists or trees of linked entities.
+While commonly applied for storefront navigation, structures can be used for any scenario requiring curated, structured lists or trees of linked entities.
 
-To learn more about Menus, refer to the [Menus documentation](./menu.mdx).
+To learn more about Structures, refer to the [Structures documentation](./structures.mdx).
 

--- a/docs/developer/models.mdx
+++ b/docs/developer/models.mdx
@@ -1,38 +1,44 @@
-# Pages
+# Models
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+:::warning API Compatibility Notice
+
+While we've updated the terminology in the documentation to use "Models" and "Model Types", the API endpoints and GraphQL schema still use `pages` and `pageTypes`. This is temporary, and we plan to update the API to match the new terminology soon.
+
+:::
+
 ## Overview
 
-Pages provide a flexible mechanism for managing both traditional content and structured data entities that extend your commerce domain beyond the standard Product/Category/Collection model. Think of them as structured documents within Saleor.
+Models provide a flexible mechanism for managing both traditional content and structured data entities that extend your commerce domain beyond the standard Product/Category/Collection model. Think of them as structured documents within Saleor.
 
 ## Core Concepts
 
-### Page Types
+### Model Types
 
-A Page Type defines the schema for a group of pages. It determines what attributes a page will have and how the page can be used. Think of Page Types as templates or models. For instance, a "Blog Post" page type might have attributes like `Author`, `PublishedDate`, and `Tags`.
+A Model Type defines the schema for a group of models. It determines what attributes a model will have and how the model can be used. Think of Model Types as templates or schemas. For instance, a "Blog Post" model type might have attributes like `Author`, `PublishedDate`, and `Tags`.
 
-You must create a Page Type before you can create any Page.
+You must create a Model Type before you can create any Model.
 
 :::info
 
-You can manage Page Types in the Dashboard's -> _Configuration_ -> _Page Types_ view.
+You can manage Model Types in the Dashboard's -> Modeling -> _Model Types_ view.
 
 :::
 
 ### Attributes
 
-Attributes define typed fields that can be reused across products and pages. When creating an attribute, it must be explicitly [assigned to either `PRODUCT` or `PAGE` type](api-reference/attributes/enums/attribute-type-enum.mdx).
+Attributes define typed fields that can be reused across products and models. When creating an attribute, it must be explicitly [assigned to either `PRODUCT` or `PAGE` type](api-reference/attributes/enums/attribute-type-enum.mdx).
 
-### Pages
+### Models
 
-A Page is an instance of a Page Type, enriched with specific attribute values and optionally a rich content block. Pages can be created, linked to other entities, published, or removed.
+A Model is an instance of a Model Type, enriched with specific attribute values and optionally a rich content block. Models can be created, linked to other entities, published, or removed.
 
 
 :::info
 
-You can manage Pages in the Dashboard's -> _Content_ view.
+You can manage Models in the Dashboard's -> Modeling -> _Models_ view.
 
 :::
 
@@ -49,24 +55,24 @@ graph TD
   ProductTypeFragrance["Product Type: Fragrance"]
   ProductFragrance["Product: Sunlit Grove"]
   AttributeScentProfiles["Product Attribute: Scent Profiles (REFERENCE)"]
-  PageTypeScentProfile["Page Type: Scent Profile"]
-  PageCitrus["Page: Citrus Zest"]
-  PageGreen["Page: Green Woods"]
+  ModelTypeScentProfile["Model Type: Scent Profile"]
+  ModelCitrus["Model: Citrus Zest"]
+  ModelGreen["Model: Green Woods"]
   AttrFamily["Attribute: Scent Family (Dropdown)"]
   AttrNotes["Attribute: Notes Description (Rich Text)"]
 
   ProductTypeFragrance --> ProductFragrance
   ProductFragrance --> AttributeScentProfiles
-  AttributeScentProfiles --> PageCitrus
-  AttributeScentProfiles --> PageGreen
+  AttributeScentProfiles --> ModelCitrus
+  AttributeScentProfiles --> ModelGreen
 
-  PageCitrus --> AttrFamily
-  PageCitrus --> AttrNotes
-  PageGreen --> AttrFamily
-  PageGreen --> AttrNotes
+  ModelCitrus --> AttrFamily
+  ModelCitrus --> AttrNotes
+  ModelGreen --> AttrFamily
+  ModelGreen --> AttrNotes
 
-  PageTypeScentProfile --> PageCitrus
-  PageTypeScentProfile --> PageGreen
+  ModelTypeScentProfile --> ModelCitrus
+  ModelTypeScentProfile --> ModelGreen
 ```
 
 
@@ -74,8 +80,8 @@ graph TD
 - **Product Attribute:** `Scent Profiles`
   - Type: `REFERENCE`
   - Entity: `Page`
-- **Page Type:** `Scent Profile`
-- **Page Attributes:**
+- **Model Type:** `Scent Profile`
+- **Model Attributes:**
   - `Scent Family` – Dropdown field (e.g., _Citrus_, _Woody_, _Floral_)
   - `Notes Description` – Rich text field (e.g., _Bright and zesty with a hint of green bitterness_)
 
@@ -84,20 +90,20 @@ For the fragrance **Sunlit Grove**, the following scent profiles might be select
 - `Citrus Zest`
 - `Green Woods`
 
-Each of these is a **Page** of type `Scent Profile`, reused across multiple products and enriched with structured attributes.
+Each of these is a **Model** of type `Scent Profile`, reused across multiple products and enriched with structured attributes.
 
 In the storefront UI, this structure enables rich product pages that showcase the fragrance's composition. For example, the Sunlit Grove product page might display its scent profiles in a dedicated section, with each profile (Citrus Zest, Green Woods) showing its family type and detailed notes description.
 
 ## Lifecycle
 
-### Creating a Page
+### Creating a Model
 
-To [create a page](/api-reference/pages/mutations/page-create.mdx) through API, you must first define the [page type](/api-reference/pages/mutations/page-type-create) and any required attributes.
+To [create a model](/api-reference/pages/mutations/page-create.mdx) through API, you must first define the [model type](/api-reference/pages/mutations/page-type-create) and any required attributes.
 
 
 :::info
 
-Creating a page requires the [`MANAGE_PAGES` permission](developer/permissions.mdx#available-permissions).
+Creating a model requires the [`MANAGE_PAGES` permission](developer/permissions.mdx#available-permissions).
 
 :::
 
@@ -134,9 +140,9 @@ mutation PageCreate($input: PageCreateInput!) {
 </Tabs>
 
 
-### Getting Pages
+### Getting Models
 
-You can get individual page details using the [`page`](/api-reference/pages/queries/page.mdx) query:
+You can get individual model details using the [`page`](/api-reference/pages/queries/page.mdx) query:
 
 <Tabs>
 <TabItem value="Query">
@@ -169,7 +175,7 @@ query GetPage($id: ID!) {
 </TabItem>
 </Tabs>
 
-or you can get multiple pages using the [`pages`](/api-reference/pages/queries/pages.mdx) query:
+or you can get multiple models using the [`pages`](/api-reference/pages/queries/pages.mdx) query:
 
 <Tabs>
 <TabItem value="Query">
@@ -210,9 +216,9 @@ query GetPages($first: Int, $filter: PageFilterInput) {
 </Tabs>
 
 
-### Linking Pages
+### Linking Models
 
-Pages can reference or be referenced by other entities through attribute of type 
+Models can reference or be referenced by other entities through attribute of type 
 [REFERENCE](api-reference/attributes/enums/attribute-input-type-enum.mdx#attributeinputtypeenumreference). 
 The selection of referenceable entities is determined by [`AttributeEntityTypeEnum`](api-reference/attributes/enums/attribute-entity-type-enum.mdx) 
 and currently includes `PAGE`, `PRODUCT` and `PRODUCT_VARIANT`.
@@ -244,7 +250,7 @@ mutation ProductUpdate($id: ID, $input: ProductInput!) {
       {
         "id": "QXR0cmlidXRlSWQ=",   # Product Attribute of type REFERENCE for scent profiles
         "references": [
-          "UGFnZUlE"   # ID of the Citrus Zest page
+          "UGFnZUlE"   # ID of the Citrus Zest model
         ]
       }
     ]
@@ -256,7 +262,7 @@ mutation ProductUpdate($id: ID, $input: ProductInput!) {
 </Tabs>
 
 
-You can also model relationships between Pages using a reference attribute or by embedding slugs/IDs in the page metadata.
+You can also model relationships between Models using a reference attribute or by embedding slugs/IDs in the model metadata.
 
 #### Querying Linked Entities
 
@@ -273,20 +279,20 @@ query GetProductWithScentProfiles($productId: ID!) {
         slug # We are looking for "scent-profiles"
       }
       values {
-        reference # This gives the Page ID
+        reference # This gives the Model ID
       }
     }
   }
 }
 ```
 
-The response will contain the ids of the linked pages. You can then use the [`page` query](#getting-pages) to get the details of the linked pages.
+The response will contain the ids of the linked models. You can then use the [`page` query](#getting-models) to get the details of the linked models.
 
-### Publishing Pages
+### Publishing Models
 
-Pages can be visible or hidden. You can control their visibility using:
+Models can be visible or hidden. You can control their visibility using:
 - `isPublished` (Boolean): Sets current visibility.
-- `publicationDate` (Date): Can schedule a future publication. The page won't appear on the storefront until this date.
+- `publicationDate` (Date): Can schedule a future publication. The model won't appear on the storefront until this date.
 
 :::info
 
@@ -329,11 +335,11 @@ mutation PageUpdate($id: ID!, $input: PageInput!) {
 </Tabs>
 
 
-### Deleting Pages
+### Deleting Models
 
-Use [`pageDelete`](/api-reference/pages/mutations/page-delete.mdx) for single pages 
+Use [`pageDelete`](/api-reference/pages/mutations/page-delete.mdx) for single models 
 or [`pageBulkDelete`](/api-reference/pages/mutations/page-bulk-delete.mdx) for multiple. 
-Deleting a Page is permanent. Deleting a Page Type might be restricted if Pages are using it.
+Deleting a Model is permanent. Deleting a Model Type might be restricted if Models are using it.
 
 ```graphql
 mutation DeletePage($id: ID!) {
@@ -365,7 +371,7 @@ mutation DeleteMultiplePages($ids: [ID!]!) {
 
 ## Webhooks
 
-Here are the webhooks that are available for pages:
+Here are the webhooks that are available for models:
 
 - [`PAGE_TYPE_CREATED`](/api-reference/pages/objects/page-type-created.mdx)
 - [`PAGE_TYPE_UPDATED`](/api-reference/pages/objects/page-type-updated.mdx)
@@ -373,3 +379,4 @@ Here are the webhooks that are available for pages:
 - [`PAGE_CREATED`](/api-reference/pages/objects/page-created.mdx)
 - [`PAGE_UPDATED`](/api-reference/pages/objects/page-updated.mdx)
 - [`PAGE_DELETED`](/api-reference/pages/objects/page-deleted.mdx)
+

--- a/docs/developer/payments/refunds.mdx
+++ b/docs/developer/payments/refunds.mdx
@@ -363,7 +363,7 @@ Currently, `RefundSettings` type controls a single behavior: whether the `reason
 
 ### Setting Refund Reason Type Requirement
 
-You can decide you want a strict policy to require a reason reference for every refund. Such reference will be a relation to a `Page` type. To enable that, you need first to create a Page Type dedicated for such refunds. You can do that in the Dashboard or by `pageTypeCreate` mutation.
+You can decide you want a strict policy to require a reason reference for every refund. Such reference will be a relation to a `Model` type. To enable that, you need first to create a Model Type dedicated for such refunds. You can do that in the Dashboard or by `pageTypeCreate` mutation.
 
 Once you have a `PageType` ID, you can set it in the `refundSettingsUpdate` mutation.
 

--- a/docs/developer/structures.mdx
+++ b/docs/developer/structures.mdx
@@ -1,13 +1,19 @@
-# Menu
+# Structures
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+:::info API Compatibility Notice
+
+While we've updated the terminology in the documentation to use "Structures", the API endpoints and GraphQL schema still use "menus" and "menu items". This is temporary, and we plan to update the API to match the new terminology soon.
+
+:::
+
 ## Overview
 
-Menus are assembly structures that group and organize entities in your store. They create hierarchical relationships between categories, collections, and models. The most common use case is storefront navigation.
+Structures are assembly mechanisms that group and organize entities in your store. They create hierarchical relationships between categories, collections, and models. The most common use case is storefront navigation.
 
-You can create menus in the Saleor Dashboard in the _Configuration_ → _Navigation_ page.
+You can create structures in the Saleor Dashboard in the _Configuration_ → _Navigation_ page.
 
 ## Example Use Case
 
@@ -15,67 +21,67 @@ You can create menus in the Saleor Dashboard in the _Configuration_ → _Navigat
 
 Consider an online electronics store that wants to create guided content helping customers choose and set up products for specific needs, like a "Home Office Setup Guide". This guide needs to link specific setup advice Models, relevant Product Categories, and perhaps a key Collection.
 
-Menus can model this curated, hierarchical structure:
+Structures can model this curated, hierarchical organization:
 
 ```mermaid
 graph TD
-    MenuGuide["Menu: Home Office Setup Guide<br/>"]
+    StructureGuide["Structure: Home Office Setup Guide<br/>"]
 
-    subgraph MenuItems
-        ItemPageErgonomics["Item 1: Ergonomics Tips (Model)"]
+    subgraph StructureItems
+        ItemModelErgonomics["Item 1: Ergonomics Tips (Model)"]
         ItemCatMonitors["Item 2: Monitors (Category)"]
         ItemSubNetworking["Item 3: Networking Setup (Parent)"]
-            ItemPageWifi["Item 3a: Wi-Fi Basics (Model)"]
-            ItemPageCable["Item 3b: Cable Management (Model)"]
+            ItemModelWifi["Item 3a: Wi-Fi Basics (Model)"]
+            ItemModelCable["Item 3b: Cable Management (Model)"]
             ItemCatRouters["Item 3c: Routers (Category)"]
         ItemCollBundles["Item 4: Office Bundles (Collection)"]
     end
 
     %% Relationships
-    MenuGuide --> ItemPageErgonomics
-    MenuGuide --> ItemCatMonitors
-    MenuGuide --> ItemSubNetworking
-    MenuGuide --> ItemCollBundles
+    StructureGuide --> ItemModelErgonomics
+    StructureGuide --> ItemCatMonitors
+    StructureGuide --> ItemSubNetworking
+    StructureGuide --> ItemCollBundles
 
-    ItemSubNetworking --> ItemPageWifi
-    ItemSubNetworking --> ItemPageCable
+    ItemSubNetworking --> ItemModelWifi
+    ItemSubNetworking --> ItemModelCable
     ItemSubNetworking --> ItemCatRouters
 
-    classDef Menu fill:#fffbe6,stroke:#333,stroke-width:1px;
+    classDef Structure fill:#fffbe6,stroke:#333,stroke-width:1px;
     classDef Item fill:#e3f2fd,stroke:#333,stroke-width:1px;
-    class MenuGuide Menu;
-    class ItemPageErgonomics,ItemCatMonitors,ItemSubNetworking,ItemCollBundles,ItemPageWifi,ItemPageCable,ItemCatRouters Item;
+    class StructureGuide Structure;
+    class ItemModelErgonomics,ItemCatMonitors,ItemSubNetworking,ItemCollBundles,ItemModelWifi,ItemModelCable,ItemCatRouters Item;
 ```
 
-- **Menu:** A Menu is created with the name "Home Office Setup Guide" and slug `home-office-guide`. This Menu itself represents the structured guide.
-- **Menu Items:**
+- **Structure:** A Structure is created with the name "Home Office Setup Guide" and slug `home-office-guide`. This Structure itself represents the organized guide.
+- **Structure Items:**
   - An item links directly to a `Model` titled "Ergonomics Tips" (perhaps a custom Model modeled for guides).
     - Another item links to the existing `Category` "Monitors".
-    - A parent item "Networking Setup" (linking perhaps to a generic URL or another Page) has child items:
+    - A parent item "Networking Setup" (linking perhaps to a generic URL or another Model) has child items:
       - A child item linking to a "Wi-Fi Basics" `Model`.
       - A child item linking to a "Cable Management" `Model`.
       - A child item linking to the "Routers" `Category`.
     - A final item links to a curated `Collection` named "Office Bundles".
 
 
-Instead of just being top-level navigation, this Menu (`home-office-guide`) **models a specific, curated relationship** between different types of content and commerce entities (Models, Categories, Collections). It defines a specific structure for the "Home Office Setup" topic that isn't captured by standard product categorization alone.
+Instead of just being top-level navigation, this Structure (`home-office-guide`) **models a specific, curated relationship** between different types of content and commerce entities (Models, Categories, Collections). It defines a specific organization for the "Home Office Setup" topic that isn't captured by standard product categorization alone.
 
-By querying this specific menu slug, an application can retrieve this curated structure and present the guide content in the intended order and hierarchy, demonstrating how Menus can assemble entities into a structured whole for purposes beyond simple site navigation.
+By querying this specific structure slug, an application can retrieve this curated organization and present the guide content in the intended order and hierarchy, demonstrating how Structures can assemble entities into a structured whole for purposes beyond simple site navigation.
 
 ## Lifecycle
 
 :::info
 
-Menu operations require the [`MANAGE_MENUS`](developer/permissions.mdx#available-permissions) permission.
+Structure operations require the [`MANAGE_MENUS`](developer/permissions.mdx#available-permissions) permission.
 
 :::
 
-### Creating a Menu
+### Creating a Structure
 
-A menu requires a name and can optionally have a slug. 
+A structure requires a name and can optionally have a slug. 
 
-You can create a menu with or without items with the [`menuCreate`](/api-reference/menu/mutations/menu-create) mutation.
-A menu item can link to one of the following entities:
+You can create a structure with or without items with the [`menuCreate`](/api-reference/menu/mutations/menu-create) mutation.
+A structure item can link to one of the following entities:
 
 - Category
 - Collection
@@ -111,23 +117,23 @@ mutation CreateMenu($input: MenuCreateInput!) {
 ```json
 {
   "input": {
-    "name": "Example Menu Item",
-    "slug": "example-menu-item",
+    "name": "Example Structure Item",
+    "slug": "example-structure-item",
     "items": [
       {
-        "name": "Category Menu Item",
+        "name": "Category Structure Item",
         "category": "Q2F0ZWdvcnk6MjY="
       },
       {
-        "name": "Collection Menu Item",
+        "name": "Collection Structure Item",
         "collection": "Q29sbGVjdGlvbjozMjA="
       },
       {
-        "name": "Page Menu Item",
+        "name": "Model Structure Item",
         "page": "UGFnZToxMjM="
       },
       {
-        "name": "URL Menu Item",
+        "name": "URL Structure Item",
         "url": "https://www.saleor.io"
       }
     ]
@@ -137,9 +143,9 @@ mutation CreateMenu($input: MenuCreateInput!) {
 </TabItem>
 </Tabs>
 
-You can also create the menu item itself through the [`menuItemCreate`](/api-reference/menu/mutations/menu-item-create) mutation.
+You can also create the structure item itself through the [`menuItemCreate`](/api-reference/menu/mutations/menu-item-create) mutation.
 
-Menu items can be nested to create a hierarchy. For example, the following input creates a menu item as a child of another menu item:
+Structure items can be nested to create a hierarchy. For example, the following input creates a structure item as a child of another structure item:
 
 <Tabs>
 <TabItem value="Mutation">
@@ -166,7 +172,7 @@ mutation CreateMenuItem($input: MenuItemCreateInput!) {
 {
   "input": {
     "menu": "TWVudToy",
-    "name": "Parent Menu Item",
+    "name": "Parent Structure Item",
     "url": "https://www.saleor.io",
     "parent": "Q2F0ZWdvcnk6MjY="
   }
@@ -175,9 +181,9 @@ mutation CreateMenuItem($input: MenuItemCreateInput!) {
 </TabItem>
 </Tabs>
 
-### Getting Menus
+### Getting Structures
 
-To retrieve all menus, use the [`menus`](/api-reference/menu/queries/menus) query:
+To retrieve all structures, use the [`menus`](/api-reference/menu/queries/menus) query:
 
 
 <Tabs>
@@ -228,7 +234,7 @@ query Menus($first: Int) {
 </TabItem>
 </Tabs>
 
-To get a specific menu by ID, name, or slug, use the [`menu`](/api-reference/menu/queries/menu) query:
+To get a specific structure by ID, name, or slug, use the [`menu`](/api-reference/menu/queries/menu) query:
 
 <Tabs>
 <TabItem value="Query">
@@ -270,9 +276,9 @@ query GetMenuBySlug($slug: String, $channel: String) {
 </TabItem>
 </Tabs>
 
-### Deleting a Menu
+### Deleting a Structure
 
-To remove a menu and all its items, use the [`menuDelete`](/api-reference/menu/mutations/menu-delete) mutation:
+To remove a structure and all its items, use the [`menuDelete`](/api-reference/menu/mutations/menu-delete) mutation:
 
 <Tabs>
 <TabItem value="Mutation">
@@ -306,7 +312,7 @@ mutation DeleteMenu($id: ID!) {
 
 ## Webhooks
 
-Here are the webhooks that are available for menus:
+Here are the webhooks that are available for structures:
 
 - [`MENU_CREATED`](/api-reference/menu/objects/menu-created)
 - [`MENU_UPDATED`](/api-reference/menu/objects/menu-updated)

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -66,7 +66,7 @@ Learn about Saleor using tutorials, API reference, and developer guides.
 
         [<BadgePercent size={16} strokeWidth={1.5}/> **Promotions** _Vouchers and discounts._](developer/discounts/promotions.mdx)
 
-        [<TableProperties size={16} strokeWidth={1.5}/> **Attributes** _Custom fields._](developer/attributes/overview.mdx)
+        [<TableProperties size={16} strokeWidth={1.5}/> **Modeling** _Extending the core commerce model._](developer/modeling.mdx)
 
         [<CreditCard size={16} strokeWidth={1.5}/> **Payments** _Payment integrations and API._](developer/payments/overview.mdx)
 

--- a/sidebars/core-concepts.js
+++ b/sidebars/core-concepts.js
@@ -27,7 +27,7 @@ export const coreConcepts = [
   title("Modeling"),
   "developer/modeling",
   "developer/models",
-  "developer/menu",
+  "developer/structures",
 
   title("Checkout"),
   "developer/checkout/overview",

--- a/sidebars/core-concepts.js
+++ b/sidebars/core-concepts.js
@@ -26,7 +26,7 @@ export const coreConcepts = [
 
   title("Modeling"),
   "developer/modeling",
-  "developer/pages",
+  "developer/models",
   "developer/menu",
 
   title("Checkout"),

--- a/vercel.json
+++ b/vercel.json
@@ -683,6 +683,10 @@
     {
       "source": "/developer/pages",
       "destination": "/developer/models"
+    },
+    {
+      "source": "/developer/menu",
+      "destination": "/developer/structures"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -679,6 +679,10 @@
     {
       "source": "/overview/why-saleor/saas-self-host",
       "destination": "/cloud/saas-self-host"
+    },
+    {
+      "source": "/developer/pages",
+      "destination": "/developer/models"
     }
   ]
 }


### PR DESCRIPTION
## Description

Renames "pages" to "models" and "menus" to "structures" with API compatibility note.
 
## Checklist

- [X] I have read and followed the [guidelines](../GUIDELINES.md)
