### PR TITLE
fix: wrong input type in `checkoutPaymentCreate()`

### DIFF
--- a/docs/developer/app-store/legacy-plugins/dummy-credit-card.mdx
+++ b/docs/developer/app-store/legacy-plugins/dummy-credit-card.mdx
@@ -40,7 +40,7 @@ Let's see an example for a token that causes Card Expired error.
 mutation {
   checkoutPaymentCreate(
     input: {
-      amount: "15.00"
+      amount: 15.00
       gateway: "mirumee.payments.dummy"
       token: "4000000000000069"
     }


### PR DESCRIPTION
`checkoutPaymentCreate()` expects the amount input to be a decimal value (aka `PositiveDecimal`), but the docs was putting a string thus causing an error to be returned.

This was returning the following:

```
{
  "errors": [
    {
      "message": "Argument \"input\" has invalid value {amount: \"0.01\", gateway: \"mirumee.payments.dummy\", token: \"4000000000000069\"}.\nIn field \"amount\": Expected type \"PositiveDecimal\", found \"0.01\".",
```


## Checklist

- [x] I have read and followed the [guidelines](../GUIDELINES.md)
