### PR TITLE
Document OpenPopup App Bridge action and extension identifier

### DIFF
--- a/docs/developer/extending/apps/developing-apps/app-sdk/app-bridge.mdx
+++ b/docs/developer/extending/apps/developing-apps/app-sdk/app-bridge.mdx
@@ -203,6 +203,7 @@ handleRedirect();
 | `PopupClose` (>=3.22.31)      |                                                                                                                                                                         | Ask Dashboard to close the popup. If the app is running in a popup, Dashboard will close it. If the app is not in a popup, this action does nothing and responds with `ok: true`.                             |
 | `WidgetResize`                | `height` - widget content height in pixels (positive, finite)                                                                                                           | Ask Dashboard to resize the widget iframe to match the app's content height. Only affects `*_DETAILS_WIDGETS` extensions. See [Sizing sidebar widgets](#sizing-sidebar-widgets) for the recommended helpers. |
 | `RefreshEntity` (>=3.23.9)      |                                                                                                                                                                         | Ask Dashboard to refresh the entity active in the current context (e.g. the currently open Order or Product), without a full page reload. Requires `@saleor/app-sdk` 1.11 or newer and Saleor Dashboard 3.23.9 or newer. |
+| `OpenPopup` (>=3.23)          | `extensionIdentifier` (string) - app-defined `identifier` of the target `POPUP` extension to open. `params` (optional, JSON-serializable) - arbitrary payload forwarded to the opened popup                              | Ask Dashboard to open one of the **same app's** `POPUP` extensions in full (modal) mode. Intended to be dispatched from a `WIDGET` extension to open a co-located `POPUP`. Requires `@saleor/app-sdk` 1.12 or newer and Saleor 3.23 or newer. See [Opening a popup extension](#opening-a-popup-extension). |
 
 ## Refreshing the active entity
 
@@ -224,6 +225,85 @@ The action takes no arguments: the Dashboard already knows which entity is open 
 
 :::info
 Requires `@saleor/app-sdk` 1.11 or newer. Dashboard support for handling this action was added in [Saleor Dashboard 3.23.9](https://github.com/saleor/saleor-dashboard/releases/tag/3.23.9) — coordinate SDK and Dashboard upgrades.
+:::
+
+## Opening a popup extension
+
+A sidebar [`WIDGET`](../../extending-dashboard-with-apps.mdx#widget-target-from-322) is small by design, so complex flows don't fit well inside it. Instead of cramming everything into the widget, you can dispatch `actions.OpenPopup()` to ask the Dashboard to open one of your app's [`POPUP`](../../extending-dashboard-with-apps.mdx#popup-target) extensions in full (modal) mode — a "compact widget that expands into a full view" pattern.
+
+The Dashboard resolves the target popup by its `identifier` and renders it in a modal dialog as a regular app iframe.
+
+### Declaring the popup extension
+
+The target `POPUP` must belong to the **same app** and declare a stable `identifier` in the manifest. The `identifier` is what you pass to the action as `extensionIdentifier`:
+
+```json
+{
+  "extensions": [
+    {
+      "label": "Order tools",
+      "mount": "ORDER_DETAILS_WIDGETS",
+      "target": "WIDGET",
+      "permissions": ["MANAGE_ORDERS"],
+      "url": "/widgets/order"
+    },
+    {
+      "label": "Order tools (full view)",
+      "identifier": "order-tools-popup",
+      "mount": "ORDER_DETAILS_MORE_ACTIONS",
+      "target": "POPUP",
+      "permissions": ["MANAGE_ORDERS"],
+      "url": "/popups/order-tools"
+    }
+  ]
+}
+```
+
+The `identifier` must be unique within a single app (an app cannot reuse the same `identifier` for two of its extensions), but the same value may be used by different apps. See [extension `identifier`](../../extending-dashboard-with-apps.mdx#extension-identifier).
+
+### Dispatching the action
+
+Dispatch `actions.OpenPopup()` from the widget, referencing the popup's `identifier`:
+
+```ts
+import { actions, useAppBridge } from "@saleor/app-sdk/app-bridge";
+
+const { appBridge } = useAppBridge();
+
+const handleExpand = async () => {
+  await appBridge.dispatch(
+    actions.OpenPopup({
+      extensionIdentifier: "order-tools-popup",
+      // Optional: forward arbitrary, JSON-serializable data to the popup
+      params: { mode: "full", focusLineId: "T3JkZXJMaW5lOjE=" },
+    }),
+  );
+};
+```
+
+`extensionIdentifier` is required and must be a non-empty string — the SDK throws synchronously otherwise. `params` is optional.
+
+### Passing data to the popup
+
+The optional `params` payload is forwarded to the opened popup. The Dashboard `JSON.stringify`s it and appends it to the popup iframe URL as a single `appParams` query parameter; the popup reads it back and parses it:
+
+```ts
+// Inside the POPUP extension page
+const url = new URL(window.location.href);
+const raw = url.searchParams.get("appParams");
+const params = raw ? JSON.parse(raw) : undefined;
+```
+
+Because `params` travels in the URL, it must be JSON-serializable and is size-limited (the serialized string is capped at ~2 KB). Use it for small references (IDs, a mode flag), not for bulk data — fetch larger data from your backend using those references.
+
+### Constraints
+
+- **Widget-only.** The action is only honored when dispatched from a `WIDGET` extension. Requests from other targets are rejected.
+- **Same app.** A widget can only open a `POPUP` that belongs to the same app — you cannot open another app's extension.
+- **Co-located.** The target popup must be one of the app's extensions registered on the current page. If no matching `POPUP` with the given `identifier` is found, the action fails (resolves with `ok: false`).
+
+:::info
+Requires `@saleor/app-sdk` 1.12 or newer and Saleor 3.23 or newer (the manifest `identifier` field is available from Saleor 3.23). The Dashboard must also handle the `openPopup` action — older Dashboard versions ignore it. Coordinate SDK, Core, and Dashboard upgrades.
 :::
 
 ## Sizing sidebar widgets

--- a/docs/developer/extending/apps/developing-apps/app-sdk/app-bridge.mdx
+++ b/docs/developer/extending/apps/developing-apps/app-sdk/app-bridge.mdx
@@ -285,16 +285,20 @@ const handleExpand = async () => {
 
 ### Passing data to the popup
 
-The optional `params` payload is forwarded to the opened popup. The Dashboard `JSON.stringify`s it and appends it to the popup iframe URL as a single `appParams` query parameter; the popup reads it back and parses it:
+The optional `params` payload is forwarded to the opened popup. The Dashboard serializes it into the popup iframe URL, and the SDK decodes it on load and exposes it on the App Bridge state as `appParams`. Read it via `useAppBridge()` — no URL parsing required:
 
-```ts
-// Inside the POPUP extension page
-const url = new URL(window.location.href);
-const raw = url.searchParams.get("appParams");
-const params = raw ? JSON.parse(raw) : undefined;
+```tsx
+import { useAppBridge } from "@saleor/app-sdk/app-bridge";
+
+const OrderToolsPopup = () => {
+  const { appBridgeState } = useAppBridge();
+  const params = appBridgeState?.appParams; // { mode: "full", focusLineId: "..." } | undefined
+
+  // ...render based on params
+};
 ```
 
-Because `params` travels in the URL, it must be JSON-serializable and is size-limited (the serialized string is capped at ~2 KB). Use it for small references (IDs, a mode flag), not for bulk data — fetch larger data from your backend using those references.
+`appParams` is `undefined` when the app wasn't opened via `OpenPopup`. Because `params` travels in the URL, it must be JSON-serializable and is size-limited (the serialized JSON is capped at ~2 KB). Use it for small references (IDs, a mode flag), not for bulk data — fetch larger data from your backend using those references.
 
 ### Constraints
 

--- a/docs/developer/extending/apps/developing-apps/app-sdk/app-bridge.mdx
+++ b/docs/developer/extending/apps/developing-apps/app-sdk/app-bridge.mdx
@@ -203,7 +203,7 @@ handleRedirect();
 | `PopupClose` (>=3.22.31)      |                                                                                                                                                                         | Ask Dashboard to close the popup. If the app is running in a popup, Dashboard will close it. If the app is not in a popup, this action does nothing and responds with `ok: true`.                             |
 | `WidgetResize`                | `height` - widget content height in pixels (positive, finite)                                                                                                           | Ask Dashboard to resize the widget iframe to match the app's content height. Only affects `*_DETAILS_WIDGETS` extensions. See [Sizing sidebar widgets](#sizing-sidebar-widgets) for the recommended helpers. |
 | `RefreshEntity` (>=3.23.9)      |                                                                                                                                                                         | Ask Dashboard to refresh the entity active in the current context (e.g. the currently open Order or Product), without a full page reload. Requires `@saleor/app-sdk` 1.11 or newer and Saleor Dashboard 3.23.9 or newer. |
-| `OpenPopup` (>=3.23)          | `extensionIdentifier` (string) - app-defined `identifier` of the target `POPUP` extension to open. `params` (optional, JSON-serializable) - arbitrary payload forwarded to the opened popup                              | Ask Dashboard to open one of the **same app's** `POPUP` extensions in full (modal) mode. Intended to be dispatched from a `WIDGET` extension to open a co-located `POPUP`. Requires `@saleor/app-sdk` 1.12 or newer and Saleor 3.23 or newer. See [Opening a popup extension](#opening-a-popup-extension). |
+| `OpenPopup` (>=3.23.19)       | `extensionIdentifier` (string) - app-defined `identifier` of the target `POPUP` extension to open. `params` (optional, JSON-serializable) - arbitrary payload forwarded to the opened popup                              | Ask Dashboard to open one of the **same app's** `POPUP` extensions in full (modal) mode. Intended to be dispatched from a `WIDGET` extension to open a co-located `POPUP`. Requires `@saleor/app-sdk` 1.12 or newer and Saleor 3.23.19 or newer. See [Opening a popup extension](#opening-a-popup-extension). |
 
 ## Refreshing the active entity
 
@@ -303,7 +303,7 @@ Because `params` travels in the URL, it must be JSON-serializable and is size-li
 - **Co-located.** The target popup must be one of the app's extensions registered on the current page. If no matching `POPUP` with the given `identifier` is found, the action fails (resolves with `ok: false`).
 
 :::info
-Requires `@saleor/app-sdk` 1.12 or newer and Saleor 3.23 or newer (the manifest `identifier` field is available from Saleor 3.23). The Dashboard must also handle the `openPopup` action — older Dashboard versions ignore it. Coordinate SDK, Core, and Dashboard upgrades.
+Requires `@saleor/app-sdk` 1.12 or newer and Saleor 3.23.19 or newer (the manifest `identifier` field is available from Saleor 3.23.19). The Dashboard must also handle the `openPopup` action — older Dashboard versions ignore it. Coordinate SDK, Core, and Dashboard upgrades.
 :::
 
 ## Sizing sidebar widgets

--- a/docs/developer/extending/apps/extending-dashboard-with-apps.mdx
+++ b/docs/developer/extending/apps/extending-dashboard-with-apps.mdx
@@ -57,6 +57,17 @@ The example manifest below defines two extensions, one providing a custom produc
 - `url`: The URL of the view to display. You can skip the domain and protocol when `target` is set to `APP_PAGE`, or when your manifest defines an `appUrl`.
 When `target` is set to `POPUP`, the `url` will be used to render an `<iframe>`.
 - `options` depending on the target, additional properties to control the behavior.
+- `identifier` (optional, from 3.23): A stable, app-defined identifier used to reference a specific extension programmatically. See [Extension identifier](#extension-identifier).
+
+### Extension identifier
+
+From Saleor 3.23, an extension can declare an optional `identifier` — a stable, app-defined string that lets other parts of your app reference that specific extension instead of relying on its label or position.
+
+- It must be **unique per app** (an app cannot reuse the same `identifier` for two of its extensions), but the same value may be used by different apps.
+- Blank or whitespace-only values are treated as not provided.
+- It is exposed on the [`AppExtension`](/api-reference/apps/objects/app-extension.mdx) GraphQL type via the `identifier` field.
+
+The main use case is opening a `POPUP` extension from a `WIDGET` of the same app: the widget dispatches the [`OpenPopup` App Bridge action](/developer/extending/apps/developing-apps/app-sdk/app-bridge#opening-a-popup-extension) with `extensionIdentifier` set to the popup's `identifier`.
 
 ## Target types
 

--- a/docs/developer/extending/apps/extending-dashboard-with-apps.mdx
+++ b/docs/developer/extending/apps/extending-dashboard-with-apps.mdx
@@ -57,11 +57,11 @@ The example manifest below defines two extensions, one providing a custom produc
 - `url`: The URL of the view to display. You can skip the domain and protocol when `target` is set to `APP_PAGE`, or when your manifest defines an `appUrl`.
 When `target` is set to `POPUP`, the `url` will be used to render an `<iframe>`.
 - `options` depending on the target, additional properties to control the behavior.
-- `identifier` (optional, from 3.23): A stable, app-defined identifier used to reference a specific extension programmatically. See [Extension identifier](#extension-identifier).
+- `identifier` (optional, from 3.23.19): A stable, app-defined identifier used to reference a specific extension programmatically. See [Extension identifier](#extension-identifier).
 
 ### Extension identifier
 
-From Saleor 3.23, an extension can declare an optional `identifier` — a stable, app-defined string that lets other parts of your app reference that specific extension instead of relying on its label or position.
+From Saleor 3.23.19, an extension can declare an optional `identifier` — a stable, app-defined string that lets other parts of your app reference that specific extension instead of relying on its label or position.
 
 - It must be **unique per app** (an app cannot reuse the same `identifier` for two of its extensions), but the same value may be used by different apps.
 - Blank or whitespace-only values are treated as not provided.


### PR DESCRIPTION
Add a section on the OpenPopup App Bridge action, which lets a WIDGET extension open a co-located POPUP extension of the same app in full mode, referenced by a new per-app extension identifier. Document the manifest identifier field it depends on (Saleor 3.23+).

## Description

<!-- What does this PR do? -->

## Checklist

- [ ] I have read and followed the [guidelines](../GUIDELINES.md)
