### PR TITLE
fix(stripe): update permission names

### DIFF
--- a/docs/developer/app-store/apps/stripe/configuration.mdx
+++ b/docs/developer/app-store/apps/stripe/configuration.mdx
@@ -30,8 +30,8 @@ Once you get there, you will have to fill the following:
 - **Stripe Publishable Key**: A public key Stripe provides in the Dashboard that will be used by Stripe SDK
 - **Stripe Restricted Key**: A fine-grained token that must be generated in Stripe Dashboard with permissions:
     - **"Payment Intents"**: *Write*
-    - **"All Webhook"**: *Write*
-    - **"Charges"**: *Write*
+    - **"Webhook Endpoints"**: *Write*
+    - **"Charges and Refunds"**: *Write*
 
 App will try to validate tokens if possible; it can’t promise it can check if every permission is correct.
 


### PR DESCRIPTION
Stripe appears to have renamed permission names in the UI, thus this commit reflects those changes in order help users know which permission to select (as this is currently unclear)



## Checklist

- [x] I have read and followed the [guidelines](../GUIDELINES.md)
