### PR TITLE
docs(gift-cards): document customer assignment and balance adjustment

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -123,6 +123,7 @@
     "Tomé",
     "turborepo",
     "Türkiye",
+    "unassigning",
     "undiscounted",
     "Uyghur",
     "Volapük",

--- a/docs/api-reference/gift-cards/mutations/gift-card-assign-user.mdx
+++ b/docs/api-reference/gift-cards/mutations/gift-card-assign-user.mdx
@@ -1,0 +1,102 @@
+---
+api_reference: true
+id: gift-card-assign-user
+title: giftCardAssignUser
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import FeaturePreview from "@site/components/FeaturePreview";
+import Permissions from "@site/components/Permissions";
+
+Restrict a gift card so only the given customer can use it.
+
+Added in Saleor 3.23.
+
+<Permissions
+  permissions={"MANAGE_GIFT_CARD"}
+  text={"Requires one of the following permissions"}
+/>
+
+Triggers the following webhook events:
+
+- GIFT_CARD_UPDATED (async): A gift card was updated.
+
+```graphql
+giftCardAssignUser(
+  id: ID!
+  userId: ID!
+): GiftCardAssignUser
+```
+
+<Details dataOpen="Hide return type" dataClose="Show return type">
+
+```graphql
+type GiftCardAssignUser {
+  giftCard: GiftCard
+  giftCardErrors: [GiftCardError!]! @deprecated
+  errors: [GiftCardError!]!
+}
+```
+
+</Details>
+
+### Arguments
+
+#### [<code>id</code>](#id)<Bullet />[<code>ID!</code>](/api-reference/miscellaneous/scalars/id.mdx) \{#id\}
+
+ID of the gift card.
+
+#### [<code>userId</code>](#user-id)<Bullet />[<code>ID!</code>](/api-reference/miscellaneous/scalars/id.mdx) \{#user-id\}
+
+ID of the customer to restrict the card to.
+
+### Type
+
+#### [<code>GiftCardAssignUser</code>](/api-reference/gift-cards/objects/gift-card-assign-user.mdx)
+
+Restrict a gift card so only the given customer can use it.
+
+Added in Saleor 3.23.
+
+<Permissions
+  permissions={"MANAGE_GIFT_CARD"}
+  text={"Requires one of the following permissions"}
+/>
+
+Triggers the following webhook events:
+
+- GIFT_CARD_UPDATED (async): A gift card was updated.

--- a/docs/api-reference/gift-cards/mutations/gift-card-balance-adjust.mdx
+++ b/docs/api-reference/gift-cards/mutations/gift-card-balance-adjust.mdx
@@ -1,0 +1,104 @@
+---
+api_reference: true
+id: gift-card-balance-adjust
+title: giftCardBalanceAdjust
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import FeaturePreview from "@site/components/FeaturePreview";
+import Permissions from "@site/components/Permissions";
+
+Adjust a gift card's balance by a signed delta atomically.
+
+Added in Saleor 3.23.
+
+<Permissions
+  permissions={"MANAGE_GIFT_CARD"}
+  text={"Requires one of the following permissions"}
+/>
+
+Triggers the following webhook events:
+
+- GIFT_CARD_UPDATED (async): A gift card was updated.
+
+```graphql
+giftCardBalanceAdjust(
+  amount: Decimal!
+  id: ID!
+): GiftCardBalanceAdjust
+```
+
+<Details dataOpen="Hide return type" dataClose="Show return type">
+
+```graphql
+type GiftCardBalanceAdjust {
+  giftCard: GiftCard
+  giftCardErrors: [GiftCardError!]! @deprecated
+  errors: [GiftCardError!]!
+}
+```
+
+</Details>
+
+### Arguments
+
+#### [<code>amount</code>](#amount)<Bullet />[<code>Decimal!</code>](/api-reference/miscellaneous/scalars/decimal.mdx) \{#amount\}
+
+Signed amount to adjust the current balance by. Positive tops up, negative deducts. A deduction below zero clamps the balance to zero. A top-up above the initial balance raises the initial balance to the new current balance.
+
+Added in Saleor 3.23.
+
+#### [<code>id</code>](#id)<Bullet />[<code>ID!</code>](/api-reference/miscellaneous/scalars/id.mdx) \{#id\}
+
+ID of the gift card to adjust.
+
+### Type
+
+#### [<code>GiftCardBalanceAdjust</code>](/api-reference/gift-cards/objects/gift-card-balance-adjust.mdx)
+
+Adjust a gift card's balance by a signed delta atomically.
+
+Added in Saleor 3.23.
+
+<Permissions
+  permissions={"MANAGE_GIFT_CARD"}
+  text={"Requires one of the following permissions"}
+/>
+
+Triggers the following webhook events:
+
+- GIFT_CARD_UPDATED (async): A gift card was updated.

--- a/docs/api-reference/gift-cards/mutations/gift-card-unassign-user.mdx
+++ b/docs/api-reference/gift-cards/mutations/gift-card-unassign-user.mdx
@@ -1,0 +1,97 @@
+---
+api_reference: true
+id: gift-card-unassign-user
+title: giftCardUnassignUser
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import FeaturePreview from "@site/components/FeaturePreview";
+import Permissions from "@site/components/Permissions";
+
+Remove a customer restriction from a gift card.
+
+Added in Saleor 3.23.
+
+<Permissions
+  permissions={"MANAGE_GIFT_CARD"}
+  text={"Requires one of the following permissions"}
+/>
+
+Triggers the following webhook events:
+
+- GIFT_CARD_UPDATED (async): A gift card was updated.
+
+```graphql
+giftCardUnassignUser(
+  id: ID!
+): GiftCardUnassignUser
+```
+
+<Details dataOpen="Hide return type" dataClose="Show return type">
+
+```graphql
+type GiftCardUnassignUser {
+  giftCard: GiftCard
+  giftCardErrors: [GiftCardError!]! @deprecated
+  errors: [GiftCardError!]!
+}
+```
+
+</Details>
+
+### Arguments
+
+#### [<code>id</code>](#id)<Bullet />[<code>ID!</code>](/api-reference/miscellaneous/scalars/id.mdx) \{#id\}
+
+ID of the gift card.
+
+### Type
+
+#### [<code>GiftCardUnassignUser</code>](/api-reference/gift-cards/objects/gift-card-unassign-user.mdx)
+
+Remove a customer restriction from a gift card.
+
+Added in Saleor 3.23.
+
+<Permissions
+  permissions={"MANAGE_GIFT_CARD"}
+  text={"Requires one of the following permissions"}
+/>
+
+Triggers the following webhook events:
+
+- GIFT_CARD_UPDATED (async): A gift card was updated.

--- a/docs/api-reference/gift-cards/objects/gift-card-assign-user.mdx
+++ b/docs/api-reference/gift-cards/objects/gift-card-assign-user.mdx
@@ -1,0 +1,92 @@
+---
+api_reference: true
+id: gift-card-assign-user
+title: GiftCardAssignUser
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import FeaturePreview from "@site/components/FeaturePreview";
+import Permissions from "@site/components/Permissions";
+
+Restrict a gift card so only the given customer can use it.
+
+Added in Saleor 3.23.
+
+<Permissions
+  permissions={"MANAGE_GIFT_CARD"}
+  text={"Requires one of the following permissions"}
+/>
+
+Triggers the following webhook events:
+
+- GIFT_CARD_UPDATED (async): A gift card was updated.
+
+```graphql
+type GiftCardAssignUser {
+  giftCard: GiftCard
+  giftCardErrors: [GiftCardError!]! @deprecated
+  errors: [GiftCardError!]!
+}
+```
+
+### Fields
+
+#### [<code>giftCard</code>](#gift-card)<Bullet />[<code>GiftCard</code>](/api-reference/gift-cards/objects/gift-card.mdx) \{#gift-card\}
+
+The assigned gift card.
+
+#### [<code>errors</code>](#errors)<Bullet />[<code>[GiftCardError!]!</code>](/api-reference/gift-cards/objects/gift-card-error.mdx) \{#errors\}
+
+<details class="graphql-markdown-details">
+<summary>
+<span class="graphql-markdown-details-label-closed">Show deprecated</span>
+<span class="graphql-markdown-details-label-open">Hide deprecated</span>
+</summary>
+
+#### [<code>giftCardErrors</code>](#gift-card-errors)<Bullet />[<code>[GiftCardError!]!</code>](/api-reference/gift-cards/objects/gift-card-error.mdx) \{#gift-card-errors\}
+
+:::warning[DEPRECATED]
+
+Use `errors` field instead.
+
+:::
+
+</details>
+
+### Returned By
+
+[`giftCardAssignUser`](/api-reference/gift-cards/mutations/gift-card-assign-user.mdx) <Badge class="badge badge--secondary badge--relation" text="mutation"/>

--- a/docs/api-reference/gift-cards/objects/gift-card-balance-adjust.mdx
+++ b/docs/api-reference/gift-cards/objects/gift-card-balance-adjust.mdx
@@ -1,0 +1,92 @@
+---
+api_reference: true
+id: gift-card-balance-adjust
+title: GiftCardBalanceAdjust
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import FeaturePreview from "@site/components/FeaturePreview";
+import Permissions from "@site/components/Permissions";
+
+Adjust a gift card's balance by a signed delta atomically.
+
+Added in Saleor 3.23.
+
+<Permissions
+  permissions={"MANAGE_GIFT_CARD"}
+  text={"Requires one of the following permissions"}
+/>
+
+Triggers the following webhook events:
+
+- GIFT_CARD_UPDATED (async): A gift card was updated.
+
+```graphql
+type GiftCardBalanceAdjust {
+  giftCard: GiftCard
+  giftCardErrors: [GiftCardError!]! @deprecated
+  errors: [GiftCardError!]!
+}
+```
+
+### Fields
+
+#### [<code>giftCard</code>](#gift-card)<Bullet />[<code>GiftCard</code>](/api-reference/gift-cards/objects/gift-card.mdx) \{#gift-card\}
+
+The adjusted gift card.
+
+#### [<code>errors</code>](#errors)<Bullet />[<code>[GiftCardError!]!</code>](/api-reference/gift-cards/objects/gift-card-error.mdx) \{#errors\}
+
+<details class="graphql-markdown-details">
+<summary>
+<span class="graphql-markdown-details-label-closed">Show deprecated</span>
+<span class="graphql-markdown-details-label-open">Hide deprecated</span>
+</summary>
+
+#### [<code>giftCardErrors</code>](#gift-card-errors)<Bullet />[<code>[GiftCardError!]!</code>](/api-reference/gift-cards/objects/gift-card-error.mdx) \{#gift-card-errors\}
+
+:::warning[DEPRECATED]
+
+Use `errors` field instead.
+
+:::
+
+</details>
+
+### Returned By
+
+[`giftCardBalanceAdjust`](/api-reference/gift-cards/mutations/gift-card-balance-adjust.mdx) <Badge class="badge badge--secondary badge--relation" text="mutation"/>

--- a/docs/api-reference/gift-cards/objects/gift-card-unassign-user.mdx
+++ b/docs/api-reference/gift-cards/objects/gift-card-unassign-user.mdx
@@ -1,0 +1,92 @@
+---
+api_reference: true
+id: gift-card-unassign-user
+title: GiftCardUnassignUser
+---
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span className={props.class}>{props.text}</span>
+  </>
+);
+
+import FeaturePreview from "@site/components/FeaturePreview";
+import Permissions from "@site/components/Permissions";
+
+Remove a customer restriction from a gift card.
+
+Added in Saleor 3.23.
+
+<Permissions
+  permissions={"MANAGE_GIFT_CARD"}
+  text={"Requires one of the following permissions"}
+/>
+
+Triggers the following webhook events:
+
+- GIFT_CARD_UPDATED (async): A gift card was updated.
+
+```graphql
+type GiftCardUnassignUser {
+  giftCard: GiftCard
+  giftCardErrors: [GiftCardError!]! @deprecated
+  errors: [GiftCardError!]!
+}
+```
+
+### Fields
+
+#### [<code>giftCard</code>](#gift-card)<Bullet />[<code>GiftCard</code>](/api-reference/gift-cards/objects/gift-card.mdx) \{#gift-card\}
+
+The unassigned gift card.
+
+#### [<code>errors</code>](#errors)<Bullet />[<code>[GiftCardError!]!</code>](/api-reference/gift-cards/objects/gift-card-error.mdx) \{#errors\}
+
+<details class="graphql-markdown-details">
+<summary>
+<span class="graphql-markdown-details-label-closed">Show deprecated</span>
+<span class="graphql-markdown-details-label-open">Hide deprecated</span>
+</summary>
+
+#### [<code>giftCardErrors</code>](#gift-card-errors)<Bullet />[<code>[GiftCardError!]!</code>](/api-reference/gift-cards/objects/gift-card-error.mdx) \{#gift-card-errors\}
+
+:::warning[DEPRECATED]
+
+Use `errors` field instead.
+
+:::
+
+</details>
+
+### Returned By
+
+[`giftCardUnassignUser`](/api-reference/gift-cards/mutations/gift-card-unassign-user.mdx) <Badge class="badge badge--secondary badge--relation" text="mutation"/>

--- a/docs/developer/gift-cards.mdx
+++ b/docs/developer/gift-cards.mdx
@@ -680,7 +680,7 @@ mutation giftCardAssignUser($id: ID!, $userId: ID!) {
 A card cannot be assigned when it has already been used in an order, or when it is attached to a checkout that has payments. In those cases the mutation returns a `CANNOT_ASSIGN` error. If the card is attached to a checkout that has no payments, the card is detached from that checkout as part of the assignment.
 
 :::note
-The `assignedTo` field on `GiftCard` requires the `MANAGE_USERS` permission (or the card's owner), while `assignedToEmail` requires `MANAGE_GIFT_CARD` (or the owner). Enforcement at checkout is intentionally generic: a restricted card that does not match the customer is rejected with the same error as any unusable code, so it never reveals whether a card is assigned or to whom.
+The `assignedTo` field on `GiftCard` requires the `MANAGE_USERS` permission (or the card's owner), while `assignedToEmail` requires `MANAGE_GIFT_CARD` (or being the owner of that gift card). Enforcement at checkout is intentionally generic: a restricted card that does not match the customer is rejected with the same error as any unusable code, so it never reveals whether a card is assigned or to whom.
 :::
 
 ### Unassigning a Customer
@@ -706,7 +706,7 @@ mutation giftCardUnassignUser($id: ID!) {
 }
 ```
 
-:::important
+:::tip
 Deleting the customer a card is assigned to does **not** lift the restriction. Saleor keeps the assignment trace so the card stays locked rather than silently becoming spendable by anyone again. To make the card usable, reassign it to another customer or unassign it explicitly.
 :::
 

--- a/docs/developer/gift-cards.mdx
+++ b/docs/developer/gift-cards.mdx
@@ -422,7 +422,7 @@ mutation giftCardUpdate($id: ID!, $input: GiftCardUpdateInput!) {
 
 Added in Saleor 3.23.
 
-Use the `giftCardBalanceAdjust` mutation to change a card's current balance by an `amount` instead of overwriting it. A positive amount tops the card up, and a negative amount deducts from it.
+Use the [`giftCardBalanceAdjust`](/api-reference/gift-cards/mutations/gift-card-balance-adjust) mutation to change a card's current balance by an `amount` instead of overwriting it. A positive amount tops the card up, and a negative amount deducts from it.
 
 Unlike `giftCardUpdate` (which sets `balanceAmount` to an absolute value and records a `BALANCE_RESET` event), the adjustment is applied atomically at the database level. This makes it safe to run while a card is being charged in a concurrent checkout, so no update is silently lost. Each adjustment records a `BALANCE_ADJUSTED` event.
 
@@ -604,7 +604,7 @@ Assignment is manual only. Saleor never auto-assigns a card to whoever pays with
 
 ### Assigning a Customer
 
-You can restrict a card to a customer at creation time by passing `assignedTo` (a customer's user ID) to [`giftCardCreate`](/api-reference/gift-cards/mutations/gift-card-create), or afterwards with the `giftCardAssignUser` mutation. Both require the `MANAGE_GIFT_CARD` permission and trigger the `GIFT_CARD_UPDATED` webhook.
+You can restrict a card to a customer at creation time by passing `assignedTo` (a customer's user ID) to [`giftCardCreate`](/api-reference/gift-cards/mutations/gift-card-create), or afterwards with the [`giftCardAssignUser`](/api-reference/gift-cards/mutations/gift-card-assign-user) mutation. Both require the `MANAGE_GIFT_CARD` permission and trigger the `GIFT_CARD_UPDATED` webhook.
 
 Assigning a customer records an `ASSIGNED_TO_USER` event and stores the customer's email on the card.
 
@@ -685,7 +685,7 @@ The `assignedTo` field on `GiftCard` requires the `MANAGE_USERS` permission (or 
 
 ### Unassigning a Customer
 
-Use the `giftCardUnassignUser` mutation to remove the restriction and return the card to bearer behavior. It requires the `MANAGE_GIFT_CARD` permission, triggers the `GIFT_CARD_UPDATED` webhook, and records an `UNASSIGNED_FROM_USER` event.
+Use the [`giftCardUnassignUser`](/api-reference/gift-cards/mutations/gift-card-unassign-user) mutation to remove the restriction and return the card to bearer behavior. It requires the `MANAGE_GIFT_CARD` permission, triggers the `GIFT_CARD_UPDATED` webhook, and records an `UNASSIGNED_FROM_USER` event.
 
 ```graphql
 mutation giftCardUnassignUser($id: ID!) {

--- a/docs/developer/gift-cards.mdx
+++ b/docs/developer/gift-cards.mdx
@@ -422,7 +422,7 @@ mutation giftCardUpdate($id: ID!, $input: GiftCardUpdateInput!) {
 
 Added in Saleor 3.23.
 
-Use the [`giftCardBalanceAdjust`](/api-reference/gift-cards/mutations/gift-card-balance-adjust) mutation to change a card's current balance by a signed `amount` instead of overwriting it. A positive amount tops the card up, and a negative amount deducts from it.
+Use the `giftCardBalanceAdjust` mutation to change a card's current balance by a signed `amount` instead of overwriting it. A positive amount tops the card up, and a negative amount deducts from it.
 
 Unlike `giftCardUpdate` (which sets `balanceAmount` to an absolute value and records a `BALANCE_RESET` event), the adjustment is applied atomically at the database level. This makes it safe to run while a card is being charged in a concurrent checkout, so no update is silently lost. Each adjustment records a `BALANCE_ADJUSTED` event.
 
@@ -604,7 +604,7 @@ Assignment is manual only. Saleor never auto-assigns a card to whoever pays with
 
 ### Assigning a Customer
 
-You can restrict a card to a customer at creation time by passing `assignedTo` (a customer's user ID) to [`giftCardCreate`](/api-reference/gift-cards/mutations/gift-card-create), or afterwards with the [`giftCardAssignUser`](/api-reference/gift-cards/mutations/gift-card-assign-user) mutation. Both require the `MANAGE_GIFT_CARD` permission and trigger the `GIFT_CARD_UPDATED` webhook.
+You can restrict a card to a customer at creation time by passing `assignedTo` (a customer's user ID) to [`giftCardCreate`](/api-reference/gift-cards/mutations/gift-card-create), or afterwards with the `giftCardAssignUser` mutation. Both require the `MANAGE_GIFT_CARD` permission and trigger the `GIFT_CARD_UPDATED` webhook.
 
 Assigning a customer records an `ASSIGNED_TO_USER` event and stores the customer's email on the card.
 
@@ -685,7 +685,7 @@ The `assignedTo` field on `GiftCard` requires the `MANAGE_USERS` permission (or 
 
 ### Unassigning a Customer
 
-Use the [`giftCardUnassignUser`](/api-reference/gift-cards/mutations/gift-card-unassign-user) mutation to remove the restriction and return the card to bearer behavior. It requires the `MANAGE_GIFT_CARD` permission, triggers the `GIFT_CARD_UPDATED` webhook, and records an `UNASSIGNED_FROM_USER` event.
+Use the `giftCardUnassignUser` mutation to remove the restriction and return the card to bearer behavior. It requires the `MANAGE_GIFT_CARD` permission, triggers the `GIFT_CARD_UPDATED` webhook, and records an `UNASSIGNED_FROM_USER` event.
 
 ```graphql
 mutation giftCardUnassignUser($id: ID!) {

--- a/docs/developer/gift-cards.mdx
+++ b/docs/developer/gift-cards.mdx
@@ -418,6 +418,108 @@ mutation giftCardUpdate($id: ID!, $input: GiftCardUpdateInput!) {
 </TabItem>
 </Tabs>
 
+#### Adjusting the Balance
+
+Added in Saleor 3.23.
+
+Use the [`giftCardBalanceAdjust`](/api-reference/gift-cards/mutations/gift-card-balance-adjust) mutation to change a card's current balance by a signed `amount` instead of overwriting it. A positive amount tops the card up, and a negative amount deducts from it.
+
+Unlike `giftCardUpdate` (which sets `balanceAmount` to an absolute value and records a `BALANCE_RESET` event), the adjustment is applied atomically at the database level. This makes it safe to run while a card is being charged in a concurrent checkout, so no update is silently lost. Each adjustment records a `BALANCE_ADJUSTED` event.
+
+The mutation applies two clamping rules:
+
+- A deduction that would take the balance below zero clamps the current balance to zero.
+- A top-up above the current initial balance raises the initial balance to the new current balance.
+
+The `amount` cannot be zero and must match the currency precision of the card. The staff member or app needs the `MANAGE_GIFT_CARD` permission.
+
+<Tabs>
+<TabItem value="Mutation">
+```graphql
+mutation giftCardBalanceAdjust($id: ID!, $amount: Decimal!) {
+  giftCardBalanceAdjust(id: $id, amount: $amount) {
+    giftCard {
+      id
+      initialBalance {
+        currency
+        amount
+      }
+      currentBalance {
+        currency
+        amount
+      }
+      events {
+        type
+        balance {
+          currentBalance {
+            amount
+            currency
+          }
+          oldCurrentBalance {
+            amount
+            currency
+          }
+        }
+      }
+    }
+    errors {
+      field
+      code
+      message
+    }
+  }
+}
+```
+</TabItem>
+
+<TabItem value={"Variables"}>
+```json
+{
+  "id": "R2lmdENhcmQ6MjUw",
+  "amount": -20
+}
+```
+</TabItem>
+
+<TabItem value={"Result"}>
+```json
+{
+  "data": {
+    "giftCardBalanceAdjust": {
+      "giftCard": {
+        "id": "R2lmdENhcmQ6MjUw",
+        "initialBalance": {
+          "currency": "USD",
+          "amount": 70
+        },
+        "currentBalance": {
+          "currency": "USD",
+          "amount": 50
+        },
+        "events": [
+          {
+            "type": "BALANCE_ADJUSTED",
+            "balance": {
+              "currentBalance": {
+                "amount": 50,
+                "currency": "USD"
+              },
+              "oldCurrentBalance": {
+                "amount": 70,
+                "currency": "USD"
+              }
+            }
+          }
+        ],
+        "errors": []
+      }
+    }
+  }
+}
+```
+</TabItem>
+</Tabs>
+
 #### Activating and Deactivating Gift Cards
 Cards can be activated and deactivated at any time, either individually or in bulk.
 
@@ -484,6 +586,146 @@ mutation giftCardDeactivate($id: ID!) {
 
 
 For bulk operations, use [`giftCardBulkActivate`](/api-reference/gift-cards/mutations/gift-card-bulk-activate.mdx) and [`giftCardBulkDeactivate`](/api-reference/gift-cards/mutations/gift-card-bulk-deactivate.mdx) mutations.
+
+## Restricting Gift Cards to a Customer
+
+Added in Saleor 3.23.
+
+By default, a gift card is a **bearer instrument**: whoever holds the code can redeem it, including in guest checkout. Customer assignment is an **opt-in restriction** layered on top of this default. Once a card is restricted to a customer, only that customer's account can use it, and the card can no longer be redeemed in guest checkout.
+
+Assignment is distinct from `usedBy`:
+
+- `assignedTo` is forward-looking — the customer who is **allowed** to spend the card. It is a restriction that staff set on purpose.
+- `usedBy` is historical — the last customer who **spent** the card. It is an audit record and is deprecated.
+
+:::note
+Assignment is manual only. Saleor never auto-assigns a card to whoever pays with it. A card stays unrestricted until staff explicitly assign it.
+:::
+
+### Assigning a Customer
+
+You can restrict a card to a customer at creation time by passing `assignedTo` (a customer's user ID) to [`giftCardCreate`](/api-reference/gift-cards/mutations/gift-card-create), or afterwards with the [`giftCardAssignUser`](/api-reference/gift-cards/mutations/gift-card-assign-user) mutation. Both require the `MANAGE_GIFT_CARD` permission and trigger the `GIFT_CARD_UPDATED` webhook.
+
+Assigning a customer records an `ASSIGNED_TO_USER` event and stores the customer's email on the card.
+
+<Tabs>
+<TabItem value="Mutation">
+```graphql
+mutation giftCardAssignUser($id: ID!, $userId: ID!) {
+  giftCardAssignUser(id: $id, userId: $userId) {
+    giftCard {
+      id
+      assignedTo {
+        id
+        email
+      }
+      assignedToEmail
+      events {
+        type
+        assignedTo {
+          oldAssignedToEmail
+          currentAssignedToEmail
+        }
+      }
+    }
+    errors {
+      field
+      code
+      message
+    }
+  }
+}
+```
+</TabItem>
+
+<TabItem value={"Variables"}>
+```json
+{
+  "id": "R2lmdENhcmQ6MjUw",
+  "userId": "VXNlcjoyMg=="
+}
+```
+</TabItem>
+
+<TabItem value={"Result"}>
+```json
+{
+  "data": {
+    "giftCardAssignUser": {
+      "giftCard": {
+        "id": "R2lmdENhcmQ6MjUw",
+        "assignedTo": {
+          "id": "VXNlcjoyMg==",
+          "email": "customer@example.com"
+        },
+        "assignedToEmail": "customer@example.com",
+        "events": [
+          {
+            "type": "ASSIGNED_TO_USER",
+            "assignedTo": {
+              "oldAssignedToEmail": null,
+              "currentAssignedToEmail": "customer@example.com"
+            }
+          }
+        ],
+        "errors": []
+      }
+    }
+  }
+}
+```
+</TabItem>
+</Tabs>
+
+A card cannot be assigned when it has already been used in an order, or when it is attached to a checkout that has payments. In those cases the mutation returns a `CANNOT_ASSIGN` error. If the card is attached to a checkout that has no payments, the card is detached from that checkout as part of the assignment.
+
+:::note
+The `assignedTo` field on `GiftCard` requires the `MANAGE_USERS` permission (or the card's owner), while `assignedToEmail` requires `MANAGE_GIFT_CARD` (or the owner). Enforcement at checkout is intentionally generic: a restricted card that does not match the customer is rejected with the same error as any unusable code, so it never reveals whether a card is assigned or to whom.
+:::
+
+### Unassigning a Customer
+
+Use the [`giftCardUnassignUser`](/api-reference/gift-cards/mutations/gift-card-unassign-user) mutation to remove the restriction and return the card to bearer behavior. It requires the `MANAGE_GIFT_CARD` permission, triggers the `GIFT_CARD_UPDATED` webhook, and records an `UNASSIGNED_FROM_USER` event.
+
+```graphql
+mutation giftCardUnassignUser($id: ID!) {
+  giftCardUnassignUser(id: $id) {
+    giftCard {
+      id
+      assignedTo {
+        id
+      }
+      assignedToEmail
+    }
+    errors {
+      field
+      code
+      message
+    }
+  }
+}
+```
+
+:::important
+Deleting the customer a card is assigned to does **not** lift the restriction. Saleor keeps the assignment trace so the card stays locked rather than silently becoming spendable by anyone again. To make the card usable, reassign it to another customer or unassign it explicitly.
+:::
+
+### Filtering by Assigned Customer
+
+The `giftCards` query accepts an `assignedTo` filter that returns the cards restricted to the given customers. This replaces the deprecated `usedBy` filter.
+
+```graphql
+query {
+  giftCards(first: 10, filter: { assignedTo: ["VXNlcjoyMg=="] }) {
+    edges {
+      node {
+        id
+        assignedToEmail
+      }
+    }
+  }
+}
+```
 
 ## Setting Up Gift Cards as Products
 

--- a/docs/developer/gift-cards.mdx
+++ b/docs/developer/gift-cards.mdx
@@ -422,7 +422,7 @@ mutation giftCardUpdate($id: ID!, $input: GiftCardUpdateInput!) {
 
 Added in Saleor 3.23.
 
-Use the `giftCardBalanceAdjust` mutation to change a card's current balance by a signed `amount` instead of overwriting it. A positive amount tops the card up, and a negative amount deducts from it.
+Use the `giftCardBalanceAdjust` mutation to change a card's current balance by an `amount` instead of overwriting it. A positive amount tops the card up, and a negative amount deducts from it.
 
 Unlike `giftCardUpdate` (which sets `balanceAmount` to an absolute value and records a `BALANCE_RESET` event), the adjustment is applied atomically at the database level. This makes it safe to run while a card is being charged in a concurrent checkout, so no update is silently lost. Each adjustment records a `BALANCE_ADJUSTED` event.
 


### PR DESCRIPTION
Document the Saleor 3.23 gift card changes in the developer guide:

- giftCardBalanceAdjust: atomic signed-delta balance changes, clamping rules, and the BALANCE_ADJUSTED event.
- Customer assignment: assignedTo on giftCardCreate, giftCardAssignUser and giftCardUnassignUser mutations, CANNOT_ASSIGN conditions, the assignedTo filter replacing deprecated usedBy, and enforcement notes.

## Description

<!-- What does this PR do? -->

## Checklist

- [ ] I have read and followed the [guidelines](../GUIDELINES.md)
