### PR TITLE
docs(adyen): add warning that credentials must be saved

### DIFF
--- a/docs/developer/app-store/apps/adyen/configuration.mdx
+++ b/docs/developer/app-store/apps/adyen/configuration.mdx
@@ -25,6 +25,17 @@ In **Server settings -> Authentication** section generate a new API key.
 In **Client settings -> Authentication** section generate a new client key.
 
 :::caution
+The credentials will not work until you click 'Save changes' in Adyen.
+
+When configuring our Adyen application, if you see the following error message, then
+it may indicate you didn't click "Save changes" in Adyen:
+
+```
+Provided API key is not a valid Adyen API Key. Please check if the key you've provided was copied correctly.
+```
+:::
+
+:::caution
 The API Key provided inside the configuration must have the following permissions set in the Adyen Dashboard:
 
 - "Management API - Accounts read and write"


### PR DESCRIPTION
Adds a warning that clicking "Save changes" is required for Adyen credentials to work (which isn't obvious & uncommon)

Adyen shows the following:

<img width="600" alt="Screenshot 2026-07-08 at 14 46 36" src="https://github.com/user-attachments/assets/2e45f18e-1ada-43c1-911e-c9c7bde087c7" />

However, this may not be obvious to users as applications usually never ask to click "Save" for credentials to start working

## Description

<!-- What does this PR do? -->

## Checklist

- [ ] I have read and followed the [guidelines](../GUIDELINES.md)
