### PR TITLE
fix(cloud): clarify Allowed API Origins are CORS settings

### DIFF
--- a/docs/cloud/restricting-api-access.mdx
+++ b/docs/cloud/restricting-api-access.mdx
@@ -18,9 +18,9 @@ Example:
 https://mystorefront.example.com
 ```
 
-## Allowed API origins
+## Allowed API origins (CORS)
 
-If the list of the origins you expect to call your API is known in advance, you can automatically reject the unknown ones.
+This controls the [Cross-Origin Resource Sharing (CORS)] settings. If the list of the origins you expect to call your API is known in advance, you can automatically reject the unknown ones.
 
 In the environment view, you can customize the allowed origins. The default option is to "Allow All" but you can also specify a list of origins or set it to "Dashboard only".
 
@@ -37,6 +37,8 @@ Changing the settings to only allow the selected origins can affect the installe
 :::
 
 You don't need to specify the Saleor Cloud dashboard origin, as it is always allowed to call the Saleor API.
+
+[Cross-Origin Resource Sharing (CORS)]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS
 
 ## API Password Protection
 


### PR DESCRIPTION
This clarifies that the 'Allowed API Origins' setting controls the CORS and nothing more than that. Before this change it was unclear what this setting actually does (unless the user would go into the Cloud Console to read the description in the UI)

Preview: https://saleor-docs-git-nyankiyoshi-patch-3-saleorcommerce.vercel.app/cloud/restricting-api-access#allowed-api-origins-cors



## Checklist

- [x] I have read and followed the [guidelines](../GUIDELINES.md)
