### PR TITLE
fix(style): format recipes .mdx files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,11 @@
-**/*.mdx
 build/
 .docusaurus/
 
+# Temporarily excludes all .mdx files except fixed files until we are done
+# formatting all files
+**/*.mdx
 !docs/api-usage/**/*.mdx
 !docs/cloud/**/*.mdx
 !docs/demos/**/*.mdx
 !docs/overview/**/*.mdx
+!docs/recipes/**/*.mdx

--- a/docs/recipes/click-and-collect.mdx
+++ b/docs/recipes/click-and-collect.mdx
@@ -3,7 +3,7 @@ title: Click and Collect
 ---
 
 import CompactCard from "@site/components/CompactCard";
-import RecipeResourceGrid from "@site/components/RecipeResourceGrid"
+import RecipeResourceGrid from "@site/components/RecipeResourceGrid";
 
 # Click and Collect Recipe
 
@@ -16,11 +16,11 @@ Each physical location where customers can collect orders must be represented as
 In the Warehouse screen's "Pickup" section, select "all warehouses" if you want to consider other warehouses when showing availability for this location.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Warehouses Documentation"
-        description="Learn how to configure warehouses."
-        link="/developer/stock/overview#warehouse-creation"
-    />
+  <CompactCard
+    name="Warehouses Documentation"
+    description="Learn how to configure warehouses."
+    link="/developer/stock/overview#warehouse-creation"
+  />
 </RecipeResourceGrid>
 
 ## Storefront Changes
@@ -28,16 +28,16 @@ In the Warehouse screen's "Pickup" section, select "all warehouses" if you want 
 You can find available collection points in the `Checkout.availableCollectionPoints` field. To select a collection point, use the `checkoutDeliveryMethodUpdate` mutation. This will update the checkout's shipping address to the chosen collection point.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Storefront Quickstart"
-        description="Get started with the NextJS example storefront."
-        link="/quickstart/storefront"
-    />
-    <CompactCard
-        name="Checkout Shipping Documentation"
-        description="Learn about shipping and checkout APIs."
-        link="/developer/checkout/address"
-    />
+  <CompactCard
+    name="Storefront Quickstart"
+    description="Get started with the NextJS example storefront."
+    link="/quickstart/storefront"
+  />
+  <CompactCard
+    name="Checkout Shipping Documentation"
+    description="Learn about shipping and checkout APIs."
+    link="/developer/checkout/address"
+  />
 </RecipeResourceGrid>
 
 ## Delivery Status
@@ -58,5 +58,5 @@ To integrate with your existing order management system, you can create an app t
         description="Learn about order fulfillment APIs."
         link="/developer/order/order-fulfillment"
     />
-</RecipeResourceGrid>
 
+</RecipeResourceGrid>

--- a/docs/recipes/custom-shipping.mdx
+++ b/docs/recipes/custom-shipping.mdx
@@ -15,19 +15,24 @@ Saleor provides tools for defining shipping options directly within the dashboar
 
 The configuration process starts with creating Shipping Zones. These zones group together relevant warehouses, destination countries, and sales channels. Within each zone, you can then define multiple Shipping Methods, specifying details such as the carrier and applicable order weight ranges. For finer control, you can further restrict methods to specific postal code ranges or exclude certain products from being eligible for a particular shipping method.
 
-<div style={{display: 'flex', gap: '1rem', flexWrap: 'wrap', paddingBottom: '4rem'}}>
-    <CompactCard
-        name="Shipping Zone Documentation"
-        description="Learn how to configure shipping zones."
-        link="/developer/shipping/shipping-zone"
-    />
-
-    <CompactCard
-        name="Shipping Method Documentation"
-        description="Learn how to configure shipping methods."
-        link="/developer/shipping/shipping-method"
-    />
-
+<div
+  style={{
+    display: "flex",
+    gap: "1rem",
+    flexWrap: "wrap",
+    paddingBottom: "4rem",
+  }}
+>
+  <CompactCard
+    name="Shipping Zone Documentation"
+    description="Learn how to configure shipping zones."
+    link="/developer/shipping/shipping-zone"
+  />
+  <CompactCard
+    name="Shipping Method Documentation"
+    description="Learn how to configure shipping methods."
+    link="/developer/shipping/shipping-method"
+  />
 </div>
 
 ## Custom Logic with Apps
@@ -35,6 +40,7 @@ The configuration process starts with creating Shipping Zones. These zones group
 Saleor Apps provide granular control over all shipping logic. Through synchronous subscriptions, they offer a unified interface that enables you to offload business logic to a separate application. Saleor remains the coordinating API, simplifying testing and development by decoupling these components.
 
 <div style={{paddingTop: '2rem', paddingBottom: '2rem'}}>
+
 ```mermaid
 flowchart LR
     n1(["Customer"]) -- Wants to choose shipping method --> A("Storefront")
@@ -43,6 +49,7 @@ flowchart LR
     D -- Available shipping methods --> B
     B -- Build-in and App Shipping methods --> A
 ```
+
 </div>
 
 Follow the quickstart guide to create a boilerplate App from the template.

--- a/docs/recipes/custom-shipping.mdx
+++ b/docs/recipes/custom-shipping.mdx
@@ -1,14 +1,13 @@
 ---
 title: Custom Shipping
 ---
+
 import CompactCard from "@site/components/CompactCard";
-import RecipeResourceGrid from "@site/components/RecipeResourceGrid"
+import RecipeResourceGrid from "@site/components/RecipeResourceGrid";
 
-
-# Custom Shipping Recipe 
+# Custom Shipping Recipe
 
 Saleor embraces the complexities of modern e-commerce and solutions beyond standard configurations. When your business requires unique rate calculations, specific carrier integrations, dynamic rules based on cart contents, or location-specific logic, the ability to implement custom shipping methods becomes essential. This guide will walk you through the process of extending Saleor's capabilities, leveraging its flexible architecture to create bespoke shipping solutions tailored precisely to your operational needs and customer expectations.
-
 
 ## Built-in Shipping Methods
 
@@ -28,12 +27,12 @@ The configuration process starts with creating Shipping Zones. These zones group
         description="Learn how to configure shipping methods."
         link="/developer/shipping/shipping-method"
     />
+
 </div>
 
 ## Custom Logic with Apps
 
 Saleor Apps provide granular control over all shipping logic. Through synchronous subscriptions, they offer a unified interface that enables you to offload business logic to a separate application. Saleor remains the coordinating API, simplifying testing and development by decoupling these components.
-
 
 <div style={{paddingTop: '2rem', paddingBottom: '2rem'}}>
 ```mermaid
@@ -49,16 +48,16 @@ flowchart LR
 Follow the quickstart guide to create a boilerplate App from the template.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Apps Quickstart"
-        description="Learn how to create Saleor Apps."
-        link="/developer/extending/apps/quickstart"
-    />
-   <CompactCard
-        name="Shipping Events"
-        description="Learn about synchronous shipping events."
-        link="/developer/extending/webhooks/synchronous-events/shipping"
-    />
+  <CompactCard
+    name="Apps Quickstart"
+    description="Learn how to create Saleor Apps."
+    link="/developer/extending/apps/quickstart"
+  />
+  <CompactCard
+    name="Shipping Events"
+    description="Learn about synchronous shipping events."
+    link="/developer/extending/webhooks/synchronous-events/shipping"
+  />
 </RecipeResourceGrid>
 
 ### Filtering Methods
@@ -73,16 +72,16 @@ This handler must process the payload data and return a formatted JSON response.
 Add the webhook subscription details to your app's manifest. This ensures Saleor registers the webhook when the app is installed.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="App SDK Webhook Helpers"
-        description="Learn about webhook utilities."
-        link="/developer/extending/apps/developing-apps/app-sdk/saleor-webhook"
-    />
-   <CompactCard
-        name="Shipping Events"
-        description="Learn about the synchronous shipping webhooks."
-        link="/developer/extending/webhooks/synchronous-events/shipping"
-    />
+  <CompactCard
+    name="App SDK Webhook Helpers"
+    description="Learn about webhook utilities."
+    link="/developer/extending/apps/developing-apps/app-sdk/saleor-webhook"
+  />
+  <CompactCard
+    name="Shipping Events"
+    description="Learn about the synchronous shipping webhooks."
+    link="/developer/extending/webhooks/synchronous-events/shipping"
+  />
 </RecipeResourceGrid>
 
 ### Dynamic Shipping Methods
@@ -100,19 +99,19 @@ Manual Creation: Use the Saleor Dashboard to create fulfillments. Go to the orde
 Automated Creation: Apps can also automate the creation of fulfillments, typically triggered by data from external shipping or warehouse systems.
 
 <RecipeResourceGrid>
-   <CompactCard
-        name="Fulfillment Lifecycle"
-        description="Learn how fulfillments change over time."
-        link="/developer/order/order-fulfillment"
-    />
-   <CompactCard
-        name="App Communication"
-        description="Learn about synchronizing status between services."
-        link="/developer/extending/apps/architecture/communication-between-app-and-saleor#app-to-saleor-api"
-    />
-    <CompactCard
-        name="External Webhooks"
-        description="Learn about handling webhooks in multi-tenant environments."
-        link="/developer/extending/apps/developing-apps/apps-patterns/handling-external-webhooks"
-    />
+  <CompactCard
+    name="Fulfillment Lifecycle"
+    description="Learn how fulfillments change over time."
+    link="/developer/order/order-fulfillment"
+  />
+  <CompactCard
+    name="App Communication"
+    description="Learn about synchronizing status between services."
+    link="/developer/extending/apps/architecture/communication-between-app-and-saleor#app-to-saleor-api"
+  />
+  <CompactCard
+    name="External Webhooks"
+    description="Learn about handling webhooks in multi-tenant environments."
+    link="/developer/extending/apps/developing-apps/apps-patterns/handling-external-webhooks"
+  />
 </RecipeResourceGrid>

--- a/docs/recipes/digital-products.mdx
+++ b/docs/recipes/digital-products.mdx
@@ -1,14 +1,13 @@
 ---
 title: Digital Products
 ---
+
 import CompactCard from "@site/components/CompactCard";
-import RecipeResourceGrid from "@site/components/RecipeResourceGrid"
+import RecipeResourceGrid from "@site/components/RecipeResourceGrid";
 
-
-# Digital Products Recipe 
+# Digital Products Recipe
 
 Learn how to set up and manage digital products (like software, e-books, or services) in Saleor with this guide. Since these items don't require shipping, the focus is on configuring specific product types and setting up automated asset delivery after purchase.
-
 
 ## Create Product Type for Digital Goods
 
@@ -17,37 +16,37 @@ A Product Type acts as a template for creating products. It defines the structur
 Set up a new Product Type. Make sure to disable the "Requires Shipping" setting for this type, so the shipping step is skipped during checkout if the cart only contains these digital products.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Product Types"
-        description="Read more about structuring and organizing product data."
-        link="/developer/products/overview"
-    />
-    <CompactCard
-        name="Product Configuration"
-        description="Learn how to configure products."
-        link="/developer/products/configuration"
-    />
+  <CompactCard
+    name="Product Types"
+    description="Read more about structuring and organizing product data."
+    link="/developer/products/overview"
+  />
+  <CompactCard
+    name="Product Configuration"
+    description="Learn how to configure products."
+    link="/developer/products/configuration"
+  />
 </RecipeResourceGrid>
 
 ## Create Your Products
 
-Create products using your new product type. Fill in the product details, such as name, description, category and add variants. 
+Create products using your new product type. Fill in the product details, such as name, description, category and add variants.
 
 For each variant, you need to create stock entries. Products without stock won't be available for purchase. If your product has unlimited stock, disable the "track inventory" setting.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Stock Tracking"
-        description="Learn how to track inventory in Saleor."
-        link="/developer/stock/stock-tracking"
-    />
+  <CompactCard
+    name="Stock Tracking"
+    description="Learn how to track inventory in Saleor."
+    link="/developer/stock/stock-tracking"
+  />
 </RecipeResourceGrid>
 
 ## Make Changes in Your Storefront
 
 Your storefront needs to adapt its checkout flow based on whether shipping is required.
 
-When a cart contains *only* digital products (where `isShippingRequired` is false), the checkout process should skip shipping address collection and shipping method selection.
+When a cart contains _only_ digital products (where `isShippingRequired` is false), the checkout process should skip shipping address collection and shipping method selection.
 
 <RecipeResourceGrid>
     <CompactCard
@@ -61,6 +60,7 @@ When a cart contains *only* digital products (where `isShippingRequired` is fals
         description="Learn about shipping and checkout APIs."
         link="/developer/checkout/address"
     />
+
 </RecipeResourceGrid>
 
 ## Asset Delivery
@@ -68,7 +68,6 @@ When a cart contains *only* digital products (where `isShippingRequired` is fals
 When an order is paid, you need to make the digital content accessible to the customer. Use webhooks to integrate with your business backend.
 
 Create a webhook in the dashboard. Choose `Order fully paid` event, define the subscription query, and target URL. When an order is paid, Saleor will send data defined by subscription query to the provided address. Now recipient application will be able to perform necessary operations like updating subscription details or sending an email with a download link.
-
 
 ```mermaid
 flowchart LR
@@ -90,5 +89,5 @@ flowchart LR
         description="Learn how to create custom event subscriptions."
         link="/developer/extending/webhooks/subscription-webhook-payloads"
     />
-</RecipeResourceGrid>
 
+</RecipeResourceGrid>

--- a/docs/recipes/digital-products.mdx
+++ b/docs/recipes/digital-products.mdx
@@ -49,18 +49,16 @@ Your storefront needs to adapt its checkout flow based on whether shipping is re
 When a cart contains _only_ digital products (where `isShippingRequired` is false), the checkout process should skip shipping address collection and shipping method selection.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Storefront Quickstart"
-        description="Get started with the NextJS example storefront."
-        link="/quickstart/storefront"
-    />
-
-    <CompactCard
-        name="Checkout Shipping"
-        description="Learn about shipping and checkout APIs."
-        link="/developer/checkout/address"
-    />
-
+  <CompactCard
+    name="Storefront Quickstart"
+    description="Get started with the NextJS example storefront."
+    link="/quickstart/storefront"
+  />
+  <CompactCard
+    name="Checkout Shipping"
+    description="Learn about shipping and checkout APIs."
+    link="/developer/checkout/address"
+  />
 </RecipeResourceGrid>
 
 ## Asset Delivery
@@ -78,16 +76,14 @@ flowchart LR
 ```
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Apps Overview"
-        description="Learn how to build Saleor Apps."
-        link="/developer/extending/apps/overview"
-    />
-
-    <CompactCard
-        name="Webhook Payloads"
-        description="Learn how to create custom event subscriptions."
-        link="/developer/extending/webhooks/subscription-webhook-payloads"
-    />
-
+  <CompactCard
+    name="Apps Overview"
+    description="Learn how to build Saleor Apps."
+    link="/developer/extending/apps/overview"
+  />
+  <CompactCard
+    name="Webhook Payloads"
+    description="Learn how to create custom event subscriptions."
+    link="/developer/extending/webhooks/subscription-webhook-payloads"
+  />
 </RecipeResourceGrid>

--- a/docs/recipes/extending-dashboard.mdx
+++ b/docs/recipes/extending-dashboard.mdx
@@ -1,9 +1,9 @@
 ---
 title: Extending Dashboard
 ---
-import CompactCard from "@site/components/CompactCard";
-import RecipeResourceGrid from "@site/components/RecipeResourceGrid"
 
+import CompactCard from "@site/components/CompactCard";
+import RecipeResourceGrid from "@site/components/RecipeResourceGrid";
 
 # Extending Dashboard Recipe
 
@@ -28,7 +28,7 @@ To prevent XSS attacts, the App's interface is rendered inside an iframe sandbox
 
 ## Create a New App
 
-Follow the quickstart to create a new application using our template. 
+Follow the quickstart to create a new application using our template.
 
 You can also check the source code of our community examples for reference.
 
@@ -44,6 +44,7 @@ You can also check the source code of our community examples for reference.
         description="Browse open source apps and examples."
         link="/developer/extending/apps/developing-apps/app-examples"
     />
+
 </RecipeResourceGrid>
 
 ## Building UI
@@ -62,6 +63,7 @@ Use the MacawUI library to maintain a consistent look and feel with the Saleor D
         description="Explore available components."
         link="https://macaw-ui.vercel.app/"
     />
+
 </RecipeResourceGrid>
 
 ## Security Considerations
@@ -71,27 +73,26 @@ Client-side calls to the Saleor API should use the token provided by the AppBrid
 Use `createProtectedHandler` from App SDK to ensure proper permissions and headers of the requests.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="App Authentication"
-        description="Learn about secure app communication."
-        link="/developer/extending/apps/architecture/server-and-client-side-calls"
-    />
-    <CompactCard
-        name="App Bridge"
-        description="Learn about the Dashboard integration layer."
-        link="/developer/extending/apps/developing-apps/app-sdk/app-bridge"
-    />
-    <CompactCard
-        name="Protected Handlers"
-        description="Learn how to use App SDK helpers."
-        link="/developer/extending/apps/developing-apps/app-sdk/protected-handlers"
-    />
+  <CompactCard
+    name="App Authentication"
+    description="Learn about secure app communication."
+    link="/developer/extending/apps/architecture/server-and-client-side-calls"
+  />
+  <CompactCard
+    name="App Bridge"
+    description="Learn about the Dashboard integration layer."
+    link="/developer/extending/apps/developing-apps/app-sdk/app-bridge"
+  />
+  <CompactCard
+    name="Protected Handlers"
+    description="Learn how to use App SDK helpers."
+    link="/developer/extending/apps/developing-apps/app-sdk/protected-handlers"
+  />
 </RecipeResourceGrid>
 
 ## Data Storage with Metadata
 
 Additional database for your application data might not be required. Metadata fields available in many Saleor entities can be used to store it. Additionally other parts of your stack can use them too. For example - custom SEO app can store data in the product metadata and storefront use it during the page render. Each installed app has its own metadata fields which can be used to store its configuration.
-
 
 <RecipeResourceGrid>
     <CompactCard
@@ -105,6 +106,7 @@ Additional database for your application data might not be required. Metadata fi
         description="Learn how to store configuration in metadata."
         link="/developer/extending/apps/developing-apps/app-sdk/settings-manager"
     />
+
 </RecipeResourceGrid>
 
 ## App Configuration View
@@ -127,6 +129,7 @@ Depending on your App's complexity, this configuration view might encompass the 
         description="Browse open source apps and examples."
         link="/developer/extending/apps/developing-apps/app-examples"
     />
+
 </RecipeResourceGrid>
 
 ## Adding New Views
@@ -161,18 +164,19 @@ Choose which permissions are required from staff users to access the view and ch
         description="Let detail-page widgets resize with your content."
         link="/developer/extending/apps/developing-apps/app-sdk/app-bridge#sizing-sidebar-widgets"
     />
+
 </RecipeResourceGrid>
 
 ## Forking the Dashboard
 
 For projects requiring complete control over the whole Dashboard, there's one more solution available - making a fork, which is a copy of the official repository. The source code of the Saleor Dashboard is available publicly and can be modified and hosted in your infrastructure.
 
-Such approach should be taken with consideration of effort needed to maintain compability with new versions of the API and synchronizing changes from the Dashboard repository. 
+Such approach should be taken with consideration of effort needed to maintain compability with new versions of the API and synchronizing changes from the Dashboard repository.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Dashboard Repository"
-        description="Access the Dashboard source code."
-        link="/developer/extending/apps/quickstart"
-    />
+  <CompactCard
+    name="Dashboard Repository"
+    description="Access the Dashboard source code."
+    link="/developer/extending/apps/quickstart"
+  />
 </RecipeResourceGrid>

--- a/docs/recipes/extending-dashboard.mdx
+++ b/docs/recipes/extending-dashboard.mdx
@@ -33,18 +33,16 @@ Follow the quickstart to create a new application using our template.
 You can also check the source code of our community examples for reference.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Apps Quickstart"
-        description="Learn how to create Saleor Apps."
-        link="/developer/extending/apps/quickstart"
-    />
-
-    <CompactCard
-        name="Community Examples"
-        description="Browse open source apps and examples."
-        link="/developer/extending/apps/developing-apps/app-examples"
-    />
-
+  <CompactCard
+    name="Apps Quickstart"
+    description="Learn how to create Saleor Apps."
+    link="/developer/extending/apps/quickstart"
+  />
+  <CompactCard
+    name="Community Examples"
+    description="Browse open source apps and examples."
+    link="/developer/extending/apps/developing-apps/app-examples"
+  />
 </RecipeResourceGrid>
 
 ## Building UI
@@ -95,18 +93,16 @@ Use `createProtectedHandler` from App SDK to ensure proper permissions and heade
 Additional database for your application data might not be required. Metadata fields available in many Saleor entities can be used to store it. Additionally other parts of your stack can use them too. For example - custom SEO app can store data in the product metadata and storefront use it during the page render. Each installed app has its own metadata fields which can be used to store its configuration.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Metadata"
-        description="Learn about the Metadata interface."
-        link="/api-usage/metadata"
-    />
-
-    <CompactCard
-        name="Settings Manager"
-        description="Learn how to store configuration in metadata."
-        link="/developer/extending/apps/developing-apps/app-sdk/settings-manager"
-    />
-
+  <CompactCard
+    name="Metadata"
+    description="Learn about the Metadata interface."
+    link="/api-usage/metadata"
+  />
+  <CompactCard
+    name="Settings Manager"
+    description="Learn how to store configuration in metadata."
+    link="/developer/extending/apps/developing-apps/app-sdk/settings-manager"
+  />
 </RecipeResourceGrid>
 
 ## App Configuration View
@@ -118,18 +114,16 @@ We strongly recommend implementing this configuration interface early in the dev
 Depending on your App's complexity, this configuration view might encompass the primary interface for managing its settings and operations. For examples of effective UI patterns and design approaches for configuration views, we encourage you to review Saleor's official and community example applications.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Apps Quickstart"
-        description="Learn how to create Saleor Apps."
-        link="/developer/extending/apps/quickstart"
-    />
-
-    <CompactCard
-        name="Community Examples"
-        description="Browse open source apps and examples."
-        link="/developer/extending/apps/developing-apps/app-examples"
-    />
-
+  <CompactCard
+    name="Apps Quickstart"
+    description="Learn how to create Saleor Apps."
+    link="/developer/extending/apps/quickstart"
+  />
+  <CompactCard
+    name="Community Examples"
+    description="Browse open source apps and examples."
+    link="/developer/extending/apps/developing-apps/app-examples"
+  />
 </RecipeResourceGrid>
 
 ## Adding New Views
@@ -147,24 +141,21 @@ To make it available in the Dashboard, add a new entry to the `extensions` list 
 Choose which permissions are required from staff users to access the view and choose if view should be displayed as full page view or modal window.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Dashboard Extensions"
-        description="Learn about dashboard extension options."
-        link="/developer/extending/apps/extending-dashboard-with-apps"
-    />
-
-    <CompactCard
-        name="App Manifest"
-        description="Learn about the app manifest."
-        link="/developer/extending/apps/architecture/manifest"
-    />
-
-    <CompactCard
-        name="Sizing sidebar widgets"
-        description="Let detail-page widgets resize with your content."
-        link="/developer/extending/apps/developing-apps/app-sdk/app-bridge#sizing-sidebar-widgets"
-    />
-
+  <CompactCard
+    name="Dashboard Extensions"
+    description="Learn about dashboard extension options."
+    link="/developer/extending/apps/extending-dashboard-with-apps"
+  />
+  <CompactCard
+    name="App Manifest"
+    description="Learn about the app manifest."
+    link="/developer/extending/apps/architecture/manifest"
+  />
+  <CompactCard
+    name="Sizing sidebar widgets"
+    description="Let detail-page widgets resize with your content."
+    link="/developer/extending/apps/developing-apps/app-sdk/app-bridge#sizing-sidebar-widgets"
+  />
 </RecipeResourceGrid>
 
 ## Forking the Dashboard

--- a/docs/recipes/marketplace.mdx
+++ b/docs/recipes/marketplace.mdx
@@ -3,7 +3,7 @@ title: Marketplace
 ---
 
 import CompactCard from "@site/components/CompactCard";
-import RecipeResourceGrid from "@site/components/RecipeResourceGrid"
+import RecipeResourceGrid from "@site/components/RecipeResourceGrid";
 
 # Marketplace Recipe
 
@@ -16,21 +16,22 @@ In Saleor, vendors are not a built-in entity type. Instead, we implement them as
 The marketplace architecture is built around the concept of linking products to these vendor models through attribute references. Each product can have a "Vendor" attribute reference that links to a vendor model, which can contain descriptive information like photos and bios.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Modeling Overview"
-        description="Learn more about modeling in Saleor."
-        link="/developer/modeling"
-    />
-    <CompactCard
-        name="Attributes Overview"
-        description="Learn more about attributes in Saleor."
-        link="/developer/attributes"
-    />
+  <CompactCard
+    name="Modeling Overview"
+    description="Learn more about modeling in Saleor."
+    link="/developer/modeling"
+  />
+  <CompactCard
+    name="Attributes Overview"
+    description="Learn more about attributes in Saleor."
+    link="/developer/attributes"
+  />
 </RecipeResourceGrid>
 
 Based on our experience with marketplace modeling, we distinguish two main approaches:
 
 ### Commodity Marketplace
+
 A commodity marketplace, similar to Amazon's model, is designed for scenarios where multiple vendors sell the same product.
 
 In this approach, you create a top-level "product model" that serves as the main product listing. This model contains all the descriptive information about the product, while individual vendor offers contain specific details like pricing and availability.
@@ -42,6 +43,7 @@ When building a commodity marketplace, keep in mind that you'll need to use mode
 :::
 
 In this architecture:
+
 - **Product Page**: Model entity that contains the main product information (description, images, specifications)
 - **Vendor Offer**: Product entity that contains vendor-specific details (price, stock, shipping)
 - **Vendor**: Model entity that contains vendor information (profile, bio, contact details)
@@ -54,17 +56,17 @@ graph LR
     B --Attribute Reference--> E[**Vendor 1**<br/>_Saleor Model_]
     C --Attribute Reference--> F[**Vendor 2**<br/>_Saleor Model_]
     D --Attribute Reference--> G[**Vendor 3**<br/>_Saleor Model_]
-    
+
     subgraph "Product Information"
     A
     end
-    
+
     subgraph "Vendor Offers"
     B
     C
     D
     end
-    
+
     subgraph "Vendors"
     E
     F
@@ -73,9 +75,11 @@ graph LR
 ```
 
 ### Boutique Marketplace
+
 A boutique marketplace, exemplified by platforms like Etsy, is simpler in structure.
 
 In this approach, each product is unique and directly linked to its vendor without the need for a top-level product model:
+
 - **Product**: A Saleor Product entity that contains both product information and vendor-specific details
 - **Vendor**: A Saleor Model entity that contains vendor information (profile, bio, contact details)
 
@@ -84,13 +88,13 @@ graph LR
     A[**Product 1**<br/>_Saleor Product_] --Attribute Reference--> B[**Vendor 1**<br/>_Saleor Model_]
     C[**Product 2**<br/>_Saleor Product_] --Attribute Reference--> D[**Vendor 2**<br/>_Saleor Model_]
     E[**Product 3**<br/>_Saleor Product_] --Attribute Reference--> F[**Vendor 3**<br/>_Saleor Model_]
-    
+
     subgraph "Products"
     A
     C
     E
     end
-    
+
     subgraph "Vendors"
     B
     D
@@ -137,7 +141,7 @@ The Vendor Portal must always validate that the vendor is only able to mutate th
 
 The marketplace fulfillment process is based on the vendor-product relationship. Since each product is linked to its vendor, order lines contain all necessary information for vendor-specific fulfillment. This structure enables each vendor to handle their own shipping independently.
 
-### Example 
+### Example
 
 1. Get attributes from the order lines
 
@@ -164,7 +168,7 @@ query GetOrderLines($id: ID!) {
 
 ```javascript
 const vendor = order.lines.variant.attributes.values.find(
-  (attribute) => attribute.name === "Vendor"
+  (attribute) => attribute.name === "Vendor",
 );
 ```
 
@@ -179,21 +183,21 @@ query GetVendor($id: ID!) {
 }
 ```
 
-4. Fulfill the order by vendor 
+4. Fulfill the order by vendor
 
 The final fulfillment step depends on your marketplace's policy. With the vendor details, you can implement any fulfillment strategy that fits your business needs, e.g., fulfilling from the vendor's warehouse or using a central warehouse.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Warehouses"
-        description="Learn about warehouse management."
-        link="/developer/stock/overview#warehouse-creation"
-    />
-    <CompactCard
-        name="Fulfillment Overview"
-        description="Learn more about fulfillment in Saleor."
-        link="/developer/order/order-fulfillment"
-    />
+  <CompactCard
+    name="Warehouses"
+    description="Learn about warehouse management."
+    link="/developer/stock/overview#warehouse-creation"
+  />
+  <CompactCard
+    name="Fulfillment Overview"
+    description="Learn more about fulfillment in Saleor."
+    link="/developer/order/order-fulfillment"
+  />
 </RecipeResourceGrid>
 
 ## Shipping
@@ -203,11 +207,11 @@ If each vendor ships their products separately, you can implement a shipping app
 The app would sum shipping methods (including their prices) for each vendor while providing detailed shipping price breakdowns through metafields.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Custom Shipping Recipe"
-        description="Learn how to implement custom shipping solutions."
-        link="/recipes/custom-shipping"
-    />
+  <CompactCard
+    name="Custom Shipping Recipe"
+    description="Learn how to implement custom shipping solutions."
+    link="/recipes/custom-shipping"
+  />
 </RecipeResourceGrid>
 
 ## Payments
@@ -219,11 +223,11 @@ Customer payments are handled through a regular payment app that processes trans
 We recommend reaching for payment providers designed specifically for marketplace operations, such as [Stripe Connect](https://stripe.com/connect).
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="How to Build a Payment App"
-        description="Learn how to create custom payment solutions."
-        link="/developer/extending/apps/building-payment-app"
-    />    
+  <CompactCard
+    name="How to Build a Payment App"
+    description="Learn how to create custom payment solutions."
+    link="/developer/extending/apps/building-payment-app"
+  />
 </RecipeResourceGrid>
 
 ## Taxes
@@ -231,11 +235,11 @@ We recommend reaching for payment providers designed specifically for marketplac
 Tax management in a marketplace requires handling vendor-specific tax rules. Different vendors may be subject to different tax rates based on their location or business type. To handle this complexity, you can implement a custom tax app that calculates tax rates specific to each vendor. This is particularly important for marketplaces operating across multiple regions or jurisdictions.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Taxes Overview"
-        description="Learn about tax configuration in Saleor."
-        link="/developer/taxes"
-    />    
+  <CompactCard
+    name="Taxes Overview"
+    description="Learn about tax configuration in Saleor."
+    link="/developer/taxes"
+  />
 </RecipeResourceGrid>
 
 ## Vendor Portal
@@ -272,21 +276,22 @@ The operator portal is essential for marketplace governance and cannot be implem
 Operator Portal can be a Dashboard Extension or a separate application.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Extending Dashboard"
-        description="Learn how to extend the Saleor dashboard."
-        link="/recipes/extending-dashboard"
-    />    
+  <CompactCard
+    name="Extending Dashboard"
+    description="Learn how to extend the Saleor dashboard."
+    link="/recipes/extending-dashboard"
+  />
 </RecipeResourceGrid>
 
 ## Architecture Overview
+
 Here is a high-level overview of the essential services for a Saleor-based marketplace:
 
 ```mermaid
 architecture-beta
   service storefront(internet)[Storefront]
-  service vendor_portal(cloud)[Vendor Portal] 
-  service operator_portal(cloud)[Operator Portal] 
+  service vendor_portal(cloud)[Vendor Portal]
+  service operator_portal(cloud)[Operator Portal]
   service payment_service(cloud)[Payment Service]
   service saleor(server)[Saleor]
   service oidc(cloud)[OpenID Provider]

--- a/docs/recipes/multi-region.mdx
+++ b/docs/recipes/multi-region.mdx
@@ -3,10 +3,9 @@ title: Multi-Region
 ---
 
 import CompactCard from "@site/components/CompactCard";
-import RecipeResourceGrid from "@site/components/RecipeResourceGrid"
+import RecipeResourceGrid from "@site/components/RecipeResourceGrid";
 
-
-# Multi-Region Recipe 
+# Multi-Region Recipe
 
 Saleor provides a flexible approach to multi-region commerce through its channels' management capabilities, allowing businesses to operate across various regions, currencies, and markets from a single backend instance. This recipe explores how to set up and manage a multi-region shop using Saleor's channel architecture.
 
@@ -17,16 +16,16 @@ Saleor's approach to multi-region commerce is built around the concept of Channe
 Create channels for individual countries or entire regions. Note that each channel supports only one currency. If you operate in regions with different currencies, create separate channels for each currency.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Channels"
-        description="Learn about channel management."
-        link="/developer/channels/overview"
-    />
-    <CompactCard
-        name="Channel Configuration"
-        description="Learn about channel settings."
-        link="/developer/channels/overview"
-    />
+  <CompactCard
+    name="Channels"
+    description="Learn about channel management."
+    link="/developer/channels/overview"
+  />
+  <CompactCard
+    name="Channel Configuration"
+    description="Learn about channel settings."
+    link="/developer/channels/overview"
+  />
 </RecipeResourceGrid>
 
 ## Warehouses and Shipping Zones
@@ -38,23 +37,23 @@ Shipping zones define where products can be shipped and what shipping methods ar
 Assign warehouse and shipping zone to their channels.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Shipping and Warehouses"
-        description="Learn how to configure shipping."
-        link="/developer/stock/stock-allocation"
-    />
+  <CompactCard
+    name="Shipping and Warehouses"
+    description="Learn how to configure shipping."
+    link="/developer/stock/stock-allocation"
+  />
 </RecipeResourceGrid>
 
 ## Product Channel Availability
 
-Update channel availability and stocks of your products.  
+Update channel availability and stocks of your products.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Products API"
-        description="Learn how to manage products across channels."
-        link="/developer/products/api"
-    />
+  <CompactCard
+    name="Products API"
+    description="Learn how to manage products across channels."
+    link="/developer/products/api"
+  />
 </RecipeResourceGrid>
 
 ## Translations
@@ -64,13 +63,12 @@ Use translations to provide localized names and descriptions. You can translate 
 To ensure email communication follows chosen language of the customer, use `Checkout.languageCode` field to store that information. It will be also available in Order entity, giving your email integration info which language should be used.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Product Configuration"
-        description="Learn how to set up products."
-        link="/developer/products/configuration"
-    />
+  <CompactCard
+    name="Product Configuration"
+    description="Learn how to set up products."
+    link="/developer/products/configuration"
+  />
 </RecipeResourceGrid>
-
 
 ## Payments and Taxes
 
@@ -79,23 +77,22 @@ Each region has it's popular payment gateways. Use one of the gateways available
 Taxes often vary significantly between regions. If flat rates are not enough, you may want to use one of the existing apps or create your own. Each channel can be configured separately.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="App Store"
-        description="Browse available integrations."
-        link="https://apps.saleor.io/"
-    />
-    <CompactCard
-        name="Taxes"
-        description="Learn about tax configuration."
-        link="/developer/taxes"
-    />
-    <CompactCard
-        name="Apps Overview"
-        description="Learn how to build custom apps."
-        link="/developer/extending/apps/overview"
-    />
+  <CompactCard
+    name="App Store"
+    description="Browse available integrations."
+    link="https://apps.saleor.io/"
+  />
+  <CompactCard
+    name="Taxes"
+    description="Learn about tax configuration."
+    link="/developer/taxes"
+  />
+  <CompactCard
+    name="Apps Overview"
+    description="Learn how to build custom apps."
+    link="/developer/extending/apps/overview"
+  />
 </RecipeResourceGrid>
-
 
 ## Storefront Implementation
 
@@ -106,14 +103,14 @@ Channel Selection in Storefront: Use different subdomains, automatically redirec
 Multiple Storefront deployments: Some businesses might want to build separate storefronts aligned with a particular region. In this scenario channel will be hardcoded and multiple deployments will still use the same API.
 
 <RecipeResourceGrid>
-    <CompactCard
-        name="Storefront Quickstart"
-        description="Get started with the NextJS example."
-        link="/quickstart/storefront"
-    />
-    <CompactCard
-        name="Products API"
-        description="Learn about multi-channel product management."
-        link="/developer/products/api"
-    />
+  <CompactCard
+    name="Storefront Quickstart"
+    description="Get started with the NextJS example."
+    link="/quickstart/storefront"
+  />
+  <CompactCard
+    name="Products API"
+    description="Learn about multi-channel product management."
+    link="/developer/products/api"
+  />
 </RecipeResourceGrid>

--- a/docs/recipes/overview.mdx
+++ b/docs/recipes/overview.mdx
@@ -6,47 +6,50 @@ sidebar_title: Overview
 import { Block } from "@site/components/Block/Block";
 import Chapters from "@site/components/Chapters";
 import {
-    Download,
-    Earth,
-    Package,
-    LayoutDashboard,
-    Truck,
-    Store,
-    Languages
+  Download,
+  Earth,
+  Package,
+  LayoutDashboard,
+  Truck,
+  Store,
+  Languages,
 } from "lucide-react";
 
 # Recipes
 
 Welcome to Saleor Recipes! This section provides concise guides to help you achieve specific goals and implement common e-commerce functionalities with Saleor. Think of these as practical, focused "how-to" articles designed to get you up and running quickly.
 
-
 ## Available Recipes
 
 Here's a list of our current recipes. Dive in to learn how to implement these features in your Saleor store:
 
 <Block title="Recipes" >
-    <Chapters>
-        [<Earth size={16} strokeWidth={1.5}/> **Multi-region** _Build global experience with regions, currencies, and storefronts._](/recipes/multi-region.mdx)
 
-        [<Download size={16} strokeWidth={1.5}/> **Digital Products** _Sell licenses, services, and other non-physical goods._](/recipes/digital-products.mdx)
+  <Chapters>
 
-        [<Truck size={16} strokeWidth={1.5}/> **Custom shipping** _Shipping options tailored to your customers._](/recipes/custom-shipping.mdx)
+    [<Earth size={16} strokeWidth={1.5}/> **Multi-region** _Build global experience with regions, currencies, and storefronts._](/recipes/multi-region.mdx)
 
-        [<Package size={16} strokeWidth={1.5}/> **Click and Collect** _Managing in-store order pickup._](/recipes/click-and-collect.mdx)
+    [<Download size={16} strokeWidth={1.5}/> **Digital Products** _Sell licenses, services, and other non-physical goods._](/recipes/digital-products.mdx)
 
-        [<LayoutDashboard size={16} strokeWidth={1.5}/> **Extending dashboard** _Add new management views to the Dashboard._](/recipes/extending-dashboard.mdx)
+    [<Truck size={16} strokeWidth={1.5}/> **Custom shipping** _Shipping options tailored to your customers._](/recipes/custom-shipping.mdx)
 
-        [<Store size={16} strokeWidth={1.5}/> **Marketplace** _Create a marketplace platform where multiple sellers can sell their products._](/recipes/marketplace.mdx)
+    [<Package size={16} strokeWidth={1.5}/> **Click and Collect** _Managing in-store order pickup._](/recipes/click-and-collect.mdx)
 
-        [<Languages size={16} strokeWidth={1.5}/> **Translations chaining** _Leverage Saleor multi-dialect translations_](/recipes/translations-chaining.mdx)
-    </Chapters>
+    [<LayoutDashboard size={16} strokeWidth={1.5}/> **Extending dashboard** _Add new management views to the Dashboard._](/recipes/extending-dashboard.mdx)
+
+    [<Store size={16} strokeWidth={1.5}/> **Marketplace** _Create a marketplace platform where multiple sellers can sell their products._](/recipes/marketplace.mdx)
+
+    [<Languages size={16} strokeWidth={1.5}/> **Translations chaining** _Leverage Saleor multi-dialect translations_](/recipes/translations-chaining.mdx)
+
+  </Chapters>
+
 </Block>
-
 
 ## Have a Recipe Idea?
 
 Is there a specific task or feature you'd like to see a recipe for? We're always looking to expand this section with relevant and helpful content. Please let us know by:
-*   Opening an issue on our [Saleor Docs GitHub repository](https://github.com/saleor/saleor-docs/issues).
-*   Joining the discussion on our [Saleor Community Discord](https://saleor.io/discord).
+
+- Opening an issue on our [Saleor Docs GitHub repository](https://github.com/saleor/saleor-docs/issues).
+- Joining the discussion on our [Saleor Community Discord](https://saleor.io/discord).
 
 Happy building!

--- a/docs/recipes/translations-chaining.mdx
+++ b/docs/recipes/translations-chaining.mdx
@@ -28,10 +28,10 @@ Then, we can execute the query to fetch a product:
 
 ```graphql
 query {
-  product(slug:"pen") {
+  product(slug: "pen") {
     name
     description
-    translation(languageCode:EN_GB) {
+    translation(languageCode: EN_GB) {
       description
       name
     }
@@ -42,21 +42,22 @@ query {
 As a result, we will see translated fields only if they are filled:
 
 ```json
-  {
-    "product": {
-      "name": "Pen",
-      "description": "{\"time\": 1759301181747, \"blocks\": [{\"id\": \"FbMHH3B_mV\", \"data\": {\"text\": \"It's a pen. No eraser needed!\"}, \"type\": \"paragraph\"}], \"version\": \"2.30.7\"}",
-      "translation": {
-        "description": "{\"time\": 1759301204878, \"blocks\": [{\"id\": \"oW3SCISfmZ\", \"data\": {\"text\": \"It's a pen. No rubber needed!\"}, \"type\": \"paragraph\"}], \"version\": \"2.30.7\"}",
-        "name": null
-      }
+{
+  "product": {
+    "name": "Pen",
+    "description": "{\"time\": 1759301181747, \"blocks\": [{\"id\": \"FbMHH3B_mV\", \"data\": {\"text\": \"It's a pen. No eraser needed!\"}, \"type\": \"paragraph\"}], \"version\": \"2.30.7\"}",
+    "translation": {
+      "description": "{\"time\": 1759301204878, \"blocks\": [{\"id\": \"oW3SCISfmZ\", \"data\": {\"text\": \"It's a pen. No rubber needed!\"}, \"type\": \"paragraph\"}], \"version\": \"2.30.7\"}",
+      "name": null
     }
   }
+}
 ```
 
 Now, the storefront can decide to pick up the translated string and fall back to the main string if it doesn't exist:
 
 ```js
 const productName = product.translation.name ?? product.name;
-const productDescription = product.translation.description ?? product.description;
+const productDescription =
+  product.translation.description ?? product.description;
 ```


### PR DESCRIPTION
Partial apply of #1820 which uses & configures prettier in order to automatically format MDX files to have a consistent style & help with readability. This changeset solely focuses on `./docs/recipes/`, other follow-up PRs will be opened for other directories.



## Checklist

- [x] I have read and followed the [guidelines](../GUIDELINES.md)
