### PR TITLE
Document that PUBLIC_URL must be set on the worker for app installs

### DIFF
--- a/docs/developer/extending/apps/local-app-development.mdx
+++ b/docs/developer/extending/apps/local-app-development.mdx
@@ -127,6 +127,8 @@ If you have following errors you'll need to setup `PUBLIC_URL` env variable:
 
 App logs: `Error: No client has been specified using urql's Provider. please create a client and add a Provider.`
 Saleor logs: `The auth data given during registration request could not be used to fetch app ID.`
+
+The same error occurs if `PUBLIC_URL` is set on the API but not on the worker. App installation runs in the worker, so the variable has to be set there too.
 :::
 
 If you are still having issues with your setup, try setting `DEBUG=app-sdk:*` env variable to see all logs from Saleor App SDK.

--- a/docs/setup/configuration.mdx
+++ b/docs/setup/configuration.mdx
@@ -246,6 +246,10 @@ Controls [Django's `MEDIA_URL`](https://docs.djangoproject.com/en/3.0/ref/settin
 
 Specifies the base URL at which Saleor is hosted, such as `https://api.example.com/`. This setting takes precedence over both [`ENABLE_SSL`](#enable_ssl) and `Shop.domain` (set using the GraphQL API) when generating URLs. Ensure to provide the complete URL, including the protocol: `http://` or `https://`.
 
+:::note
+Set `PUBLIC_URL` on the [worker](/developer/running-saleor/task-queue.mdx) as well as the API. App installation runs as a Celery task in the worker, and the worker uses `PUBLIC_URL` to build the `saleor-api-url` value it sends to the app's registration endpoint. If it is unset there, Django falls back to defaults and the worker sends a localhost URL, so the app cannot call back and the installation fails with `The auth data given during registration request could not be used to fetch app ID`.
+:::
+
 ### `PLAYGROUND_ENABLED`
 
 Controls whether to run [Playground](https://github.com/prisma-labs/graphql-playground) - the interactive GraphQL explorer - when accessing the `/graphql/` URL exposed by Saleor. Defaults to `True`.


### PR DESCRIPTION
Adds a note that `PUBLIC_URL` needs setting on the worker, not just the API.

We lost a good chunk of time to this installing an app against a self-hosted
3.23. App installation runs as a Celery task in the worker, and the worker uses
`PUBLIC_URL` when building the `saleor-api-url` header it sends to the app's
registration endpoint. With it unset on the worker, Django falls back to
defaults and the worker sends `http://localhost:8000/graphql/`. The app then
can't call back, and the install fails with:

> The auth data given during registration request could not be used to fetch app ID

The error is about auth, so it sends you looking at tokens and permissions
rather than at an environment variable on a container you probably weren't
looking at.

Two changes:

- `docs/setup/configuration.mdx` — a note under `PUBLIC_URL`, since that's the
  canonical reference for the variable.
- `docs/developer/extending/apps/local-app-development.mdx` — the existing note
  already lists this exact error but attributes it only to IPv6/localhost
  resolution. This adds the second cause to the same block.

Happy to reword either if you'd rather it sat somewhere else, or if a warning
logged by the worker when `PUBLIC_URL` is unset would be preferable to a docs
note. I'd be glad to take a look at that instead.