### PR TITLE
docs(app-sdk): update for app-sdk 1.15 and recent changes

### DIFF
--- a/docs/developer/extending/apps/architecture/manifest.mdx
+++ b/docs/developer/extending/apps/architecture/manifest.mdx
@@ -73,6 +73,10 @@ Example of a manifest:
 ```
 
 :::info
+From Saleor 3.23.23, each webhook can declare an optional `identifier` — an app-defined string (max 256 characters, unique per app) that lets the app reference one of its webhooks without storing its Saleor ID. It is exposed on the [`Webhook`](/api-reference/webhooks/objects/webhook.mdx) type and typed in `@saleor/app-sdk` 1.13+ as `WebhookManifest.identifier`.
+:::
+
+:::info
 The `tokenTargetUrl` field is optional. When omitted, Saleor will not send the auth token to the app during installation. 
 This is useful for apps that don't need to consume the Saleor protected API, such as static apps that only serve an iframe in the Dashboard.
 :::

--- a/docs/developer/extending/apps/developing-apps/app-sdk/apl.mdx
+++ b/docs/developer/extending/apps/developing-apps/app-sdk/apl.mdx
@@ -280,6 +280,23 @@ Keep in mind that:
 - If you promote the environment, you need to update `saleorApiUrl`
 - If you reinstall the app, you need to repeat the process to receive a new token and ID
 
+#### JWKS caching
+
+Values in `EnvAPL` are read-only, but JWKS is used by the SDK to verify JWT tokens, so from `@saleor/app-sdk` 1.8 `EnvAPL` caches it in memory instead of fetching it on every verification. Other APLs store JWKS in `AuthData` for the same reason.
+
+The TTL defaults to 5 minutes and can be changed with `cacheTtlMs`:
+
+```typescript
+const apl = new EnvAPL({
+  env: {
+    /* ... */
+  },
+  cacheTtlMs: 60_000,
+});
+```
+
+On a long-running server the cache lives for the full TTL. In serverless environments it behaves like a cold cache whenever a new instance is spawned.
+
 
 ### VercelKvApl
 
@@ -384,12 +401,6 @@ const table = new Table<PartitionKey, SortKey>({
 
 Note that this APL exposes `create` factory method, that is easier to use, providing only envs and table instance. There is also `constructor` but it requires more low-level setup, which is not recommended.
 
-
-### SaleorCloudAPL (private & deprecated)
-
-You may see that there is a `SaleorCloudAPL` exported as well. This APL is specific implementation that Saleor Cloud uses when hosting apps on the cloud platform.
-
-It's not available to use and will not be bundled by your app if not imported.
 
 ## Community APL implementations
 

--- a/docs/developer/extending/apps/developing-apps/app-sdk/app-bridge.mdx
+++ b/docs/developer/extending/apps/developing-apps/app-sdk/app-bridge.mdx
@@ -16,11 +16,15 @@ Options object is the following:
 
 ```typescript
 type AppBridgeOptions = {
-  targetDomain?: string;
   saleorApiUrl?: string;
   initialLocale?: LocaleCode;
   autoNotifyReady?: boolean;
   initialTheme?: "dark" | "light";
+  /**
+   * Forward keyboard shortcuts owned by the Dashboard (e.g. Cmd+K) out of the app iframe.
+   * Defaults to true. See "Keyboard shortcuts" below.
+   */
+  forwardKeyboardShortcuts?: boolean | { shouldForward(event: KeyboardEvent): boolean };
 };
 ```
 
@@ -78,6 +82,15 @@ type AppBridgeState = {
    * Permissions of the app itself
    */
   appPermissions?: AppPermission[];
+  /**
+   * Arbitrary payload passed by the `openPopup` action when this app was opened
+   * as a POPUP from one of its own widgets. See "Opening a popup extension".
+   */
+  appParams?: unknown;
+  /**
+   * Internal - used by Dashboard and apps to negotiate inner keyboard shortcuts propagation.
+   */
+  dashboardShortcuts?: DashboardShortcut[];
 };
 ```
 
@@ -162,6 +175,7 @@ appBridge.unsubscribeAll();
 | `theme`         | Fired when Dashboard changes the theme                                       |
 | `localeChanged` | Fired when Dashboard changes locale (and passes locale code in payload)      |
 | `tokenRefresh`  | Fired when Dashboard receives a new auth token and passes it to the app      |
+| `shortcutsChanged` | Internal. Fired when Dashboard changes the set of keyboard shortcuts it owns. Handled automatically by AppBridge |
 
 See [source code for detailed payload](https://github.com/saleor/saleor-app-sdk/blob/5c56cf566d2cc6e4a075c8c619f174fa43aad6c9/src/app-bridge/events.ts)
 
@@ -204,6 +218,33 @@ handleRedirect();
 | `WidgetResize`                | `height` - widget content height in pixels (positive, finite)                                                                                                           | Ask Dashboard to resize the widget iframe to match the app's content height. Only affects `*_DETAILS_WIDGETS` extensions. See [Sizing sidebar widgets](#sizing-sidebar-widgets) for the recommended helpers. |
 | `RefreshEntity` (>=3.23.9)      |                                                                                                                                                                         | Ask Dashboard to refresh the entity active in the current context (e.g. the currently open Order or Product), without a full page reload. Requires `@saleor/app-sdk` 1.11 or newer and Saleor Dashboard 3.23.9 or newer. |
 | `OpenPopup` (>=3.23.19)       | `extensionIdentifier` (string) - app-defined `identifier` of the target `POPUP` extension to open. `params` (optional, JSON-serializable) - arbitrary payload forwarded to the opened popup                              | Ask Dashboard to open one of the **same app's** `POPUP` extensions in full (modal) mode. Intended to be dispatched from a `WIDGET` extension to open a co-located `POPUP`. Requires `@saleor/app-sdk` 1.12 or newer and Saleor 3.23.19 or newer. See [Opening a popup extension](#opening-a-popup-extension). |
+| `RedirectToApp`               | `appIdentifier` (string) - manifest `id` of the target app. `path` (optional string) - path inside the target app                                                        | Ask Dashboard to resolve the URL of another installed app and redirect there. Requires `@saleor/app-sdk` 1.15 or newer. See [Redirecting to another app](#redirecting-to-another-app). |
+
+## Redirecting to another app
+
+Apps often work together — a checkout app may want to hand the user off to the app that owns tax configuration. Instead of hardcoding the other app's URL (which depends on where it is installed), dispatch `actions.RedirectToApp()` with the target app's manifest `id`. The Dashboard resolves that app's URL and navigates to it.
+
+```ts
+import { actions, useAppBridge } from "@saleor/app-sdk/app-bridge";
+
+const { appBridge } = useAppBridge();
+
+const openTaxesApp = async () => {
+  await appBridge.dispatch(
+    actions.RedirectToApp({
+      appIdentifier: "saleor.app.avatax",
+      // Optional: path inside the target app, appended to the resolved URL
+      path: "/configuration",
+    }),
+  );
+};
+```
+
+`appIdentifier` is required and must be a non-empty string — the SDK throws synchronously otherwise. It is the `id` field from the target app's [manifest](../../architecture/manifest.mdx), not its Saleor object ID.
+
+:::info
+Requires `@saleor/app-sdk` 1.15 or newer. The Dashboard must handle the `redirectToApp` action — older Dashboard versions ignore it. The action fails (resolves with `ok: false`) when no app with the given identifier is installed.
+:::
 
 ## Refreshing the active entity
 
@@ -351,18 +392,18 @@ If you are not using React, or you need to report height after a one-off layout 
 
 | Helper | Use when |
 | :----- | :------- |
-| `postWidgetHeight(appBridge, root)` | You have a root element; measure it and dispatch `WidgetResize` in one call |
+| `reportWidgetHeightFromElement(appBridge, root)` | You have a root element; measure it and dispatch `WidgetResize` in one call |
 | `reportWidgetHeight(appBridge, height)` | You already know the height in pixels |
 
 :::warning
-Pass an element that wraps only your widget UI to `postWidgetHeight`. Do not measure `document.body` or `document.documentElement` — they match the iframe size, not your content, so reported heights stay too small and widgets stay clipped. The same applies if you pass a height to `reportWidgetHeight` that you calculated from those nodes.
+Pass an element that wraps only your widget UI to `reportWidgetHeightFromElement`. Do not measure `document.body` or `document.documentElement` — they match the iframe size, not your content, so reported heights stay too small and widgets stay clipped. The same applies if you pass a height to `reportWidgetHeight` that you calculated from those nodes.
 :::
 
-Helpers no-op during SSR. `postWidgetHeight` requires a widget root element.
+Helpers no-op during SSR. `reportWidgetHeightFromElement` requires a widget root element.
 
 ### Protocol
 
-Height is reported through the standard App Bridge channel — `reportWidgetHeight` and `postWidgetHeight` call `appBridge.dispatch(actions.WidgetResize({ height }))`, the same mechanism as redirect, notification, and other actions. If you prefer, you can dispatch it yourself:
+Height is reported through the standard App Bridge channel — `reportWidgetHeight` and `reportWidgetHeightFromElement` call `appBridge.dispatch(actions.WidgetResize({ height }))`, the same mechanism as redirect, notification, and other actions. If you prefer, you can dispatch it yourself:
 
 ```ts
 import { actions } from "@saleor/app-sdk/app-bridge";
@@ -375,3 +416,30 @@ appBridge.dispatch(actions.WidgetResize({ height: 320 })).catch(() => {
 The helpers are the recommended path: they no-op during SSR, skip invalid heights (non-finite or non-positive), and attach a `.catch` so a missing or slow Dashboard response does not surface as an unhandled rejection.
 
 Until the first report, the iframe uses a 200px default height. Reported heights are capped at 5000px.
+
+## Keyboard shortcuts
+
+Dashboard-level shortcuts (such as `Cmd+K`) would otherwise stop working while the app iframe has focus. The Dashboard and AppBridge negotiate this internally with the `shortcutsChanged` event and the `triggerShortcut` action — no code is required in your app, and there is no `actions.TriggerShortcut()` helper.
+
+Pass `forwardKeyboardShortcuts: false` to `new AppBridge()` to opt out, or `{ shouldForward(event) }` to claim a chord back for the app.
+
+:::info
+Available from `@saleor/app-sdk` 1.16.
+:::
+
+## Detaching AppBridge
+
+`appBridge.destroy()` detaches the instance from the window: it stops forwarding keyboard shortcuts, stops receiving Dashboard events, and drops all subscribers. It is safe to call more than once.
+
+You rarely need to call it directly — `AppBridgeProvider` destroys the instance it created when it unmounts. An instance passed via the `appBridgeInstance` prop is left alone, because the caller owns its lifecycle.
+
+```ts
+const appBridge = new AppBridge();
+
+// later, e.g. when tearing down a non-React host
+appBridge.destroy();
+```
+
+:::info
+`destroy()` is available from `@saleor/app-sdk` 1.16.
+:::

--- a/docs/developer/extending/apps/developing-apps/app-sdk/overview.mdx
+++ b/docs/developer/extending/apps/developing-apps/app-sdk/overview.mdx
@@ -40,7 +40,7 @@ Hint: See [migration from 0.x to 1.x](migration-0.x-to-1.x) for more information
 
 ## Requirements
 
-- Saleor support: 3.20 and higher (it may work in older versions, but it's not guaranteed).
+- Saleor support: 3.22 and higher (it may work in older versions, but it's not guaranteed).
 - Next.js support: 14 and higher
 
 ## Peer Dependencies
@@ -60,7 +60,6 @@ The SDK has several optional peer dependencies. Install only what you need based
 | `@saleor/app-sdk/APL/env`                  | -                                                                       |
 | `@saleor/app-sdk/APL/file`                 | -                                                                       |
 | `@saleor/app-sdk/APL/upstash`              | -                                                                       |
-| `@saleor/app-sdk/APL/saleor-cloud`         | -                                                                       |
 | `@saleor/app-sdk/APL/redis`                | `redis`                                                                 |
 | `@saleor/app-sdk/APL/vercel-kv`            | `@vercel/kv`                                                            |
 | `@saleor/app-sdk/APL/dynamodb`             | `@aws-sdk/client-dynamodb`, `@aws-sdk/lib-dynamodb`, `dynamodb-toolbox` |

--- a/docs/developer/extending/apps/extending-dashboard-with-apps.mdx
+++ b/docs/developer/extending/apps/extending-dashboard-with-apps.mdx
@@ -157,6 +157,47 @@ The `HOMEPAGE_WIDGETS` mount lets apps render widgets directly on the Dashboard 
 Requires Dashboard 3.23.12+ and `@saleor/app-sdk` 1.10+.
 
 
+## Command palette actions (from 3.23.21)
+
+The `SEARCH_ACTION` mount surfaces an app action in the Dashboard command palette (`Cmd+K` / `Ctrl+K`), so users can run it by typing instead of hunting for a button.
+
+It supports the `POPUP`, `APP_PAGE` and `NEW_TAB` targets (not `WIDGET`). When the action is run from an entity page, the app receives that entity's context — the same context the entity's "more actions" extensions get.
+
+```json
+{
+  "label": "Recalculate taxes",
+  "mount": "SEARCH_ACTION",
+  "target": "POPUP",
+  "permissions": ["MANAGE_ORDERS"],
+  "url": "/actions/recalculate-taxes",
+  "options": {
+    "views": ["ORDER_DETAILS", "ORDER_LIST"],
+    "aliases": ["taxes", "avatax"]
+  }
+}
+```
+
+### `options.views`
+
+Scopes the action to specific Dashboard views. When omitted, the action is available everywhere. When provided, the list must contain at least one view.
+
+Detail views resolve a single entity id as context; list views are surfaced without an id.
+
+Available views: `PRODUCT_LIST`, `PRODUCT_DETAILS`, `ORDER_LIST`, `ORDER_DETAILS`, `DRAFT_ORDER_LIST`, `DRAFT_ORDER_DETAILS`, `CUSTOMER_LIST`, `CUSTOMER_DETAILS`, `COLLECTION_LIST`, `COLLECTION_DETAILS`, `CATEGORY_LIST`, `CATEGORY_DETAILS`, `GIFT_CARD_LIST`, `GIFT_CARD_DETAILS`, `VOUCHER_LIST`, `VOUCHER_DETAILS`, `DISCOUNT_LIST`, `DISCOUNT_DETAILS`, `PAGE_LIST`, `PAGE_DETAILS`, `PAGE_TYPE_LIST`, `PAGE_TYPE_DETAILS`, `MENU_LIST`, `MENU_DETAILS`, `CHANNEL_DETAILS`.
+
+`CHANNEL_DETAILS` requires Dashboard 3.23.28+; the extension is then opened with `channelId` holding the channel's global id.
+
+### `options.aliases`
+
+Extra terms the command palette matches the action against, for example `["taxes", "avatax"]`. They are searchable but never displayed, which lets users find an action by the vendor or domain name instead of its exact label.
+
+Requires Dashboard 3.23.28+.
+
+:::info
+Manifest typings for `SEARCH_ACTION` are available in `@saleor/app-sdk` 1.13+ (`options.aliases` in 1.14+, `CHANNEL_DETAILS` in 1.15+).
+:::
+
+
 ## Context
 
 Context fields are specific to the mount extension is being attached to. For example, on `CATEGORY_DETAILS_MORE_ACTIONS`, the context field will be `categoryId`.
@@ -207,6 +248,7 @@ Saleor requires extensions to define a mounting place. The table below explains 
 | Mount                             | Description                                             | Supported targets                         | Available from |
 |-----------------------------------|---------------------------------------------------------|-------------------------------------------|----------------|
 | HOMEPAGE_WIDGETS                   | A widget on the Dashboard home page.                    | `WIDGET`                                  | 3.23           |
+| SEARCH_ACTION                     | Dashboard command palette (`Cmd+K`). See [Command palette actions](#command-palette-actions-from-32321). | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.23.21        |
 | CATEGORY_OVERVIEW_CREATE          | Category's list page under the create button.           | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |
 | CATEGORY_OVERVIEW_MORE_ACTIONS    | Category's list page under the more action button.      | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |
 | CATEGORY_DETAILS_MORE_ACTIONS     | Category's detail page under the more action button.    | `POPUP`, `APP_PAGE`, `NEW_TAB`            | 3.22           |


### PR DESCRIPTION
Covers releases 1.8 through 1.15 plus unreleased main:

- RedirectToApp App Bridge action (1.15)
- SEARCH_ACTION extension mount with options.views and options.aliases (Dashboard 3.23.21 / 3.23.28, SDK 1.13-1.15)
- Webhook manifest identifier (Saleor 3.23.23, SDK 1.13)
- EnvAPL in-memory JWKS cache with cacheTtlMs (1.8)
- Keyboard shortcut forwarding, noted as internal, and AppBridge.destroy()

Also corrects docs that drifted from the SDK: postWidgetHeight was renamed to reportWidgetHeightFromElement in 1.10, AppBridgeOptions no longer has targetDomain, SaleorCloudAPL was removed in 1.7, and appParams was missing from the documented AppBridgeState. Minimum supported Saleor is now 3.22.

## Description

<!-- What does this PR do? -->

## Checklist

- [ ] I have read and followed the [guidelines](../GUIDELINES.md)
