### PR TITLE
fix(style): format Adyen app docs MDX files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ build/
 !docs/security/**/*.mdx
 !docs/setup/**/*.mdx
 !docs/upgrade-guides/**/*.mdx
+!docs/developer/app-store/apps/adyen/**/*.mdx

--- a/docs/developer/app-store/apps/adyen/architecture.mdx
+++ b/docs/developer/app-store/apps/adyen/architecture.mdx
@@ -44,9 +44,12 @@ If such timeout happens, the created [`TransactionItem`](/api-reference/payments
 ### Refund with line items vs refund with manual amount
 
 :::note
+
 In Saleor Dashboard you can choose between two types of refunds that use different Saleor APIs:
+
 - **"Refund with line items"** - creates [OrderGrantedRefund](/api-reference/orders/objects/order-granted-refund.mdx) and sends a refund to Adyen App using [`transactionRequestRefundForGrantedRefund`](/api-reference/payments/mutations/transaction-request-refund-for-granted-refund.mdx)
 - **"Refund with manual amount"** - sends refund request to Adyen App using [`transactionRequestAction`](/api-reference/payments/mutations/transaction-request-action.mdx)
+
 :::
 
 There are differences in how refunds are handled depending on whether a [`OrderGrantedRefund`](/api-reference/orders/objects/order-granted-refund.mdx) was created in Saleor and a refund via [`transactionRequestRefundForGrantedRefund`](/api-reference/payments/mutations/transaction-request-refund-for-granted-refund.mdx) mutation was requested, or a "manual refund" sent via [`transactionRequestAction`](/api-reference/payments/mutations/transaction-request-action.mdx) mutation was requested. The differences are in how [`lineItems`](https://docs.adyen.com/api-explorer/Checkout/71/post/payments/_paymentPspReference_/refunds#request-lineItems) are reported to Adyen
@@ -73,20 +76,23 @@ App sets metadata on each `TransactionItem` it creates in Saleor. Metadata is se
 Adyen app sets fields on metadata from `NotificationItem.additionalData` object it receives from Adyen. To configure which fields are included by Adyen go to `Developres > Additional data` and select your preferred fields.
 
 :::caution
+
 Remember to always include the following fields for proper notification handling:
+
 - `Authorization amount`
 - `Authorisation amount (dynamic zero authorisation)`
 - `Recurring details`
 - `Merchant reference`
+
 :::
 
 For example, if you want to have data about used payment method, and it's variant choose:
+
 - `Subvariant`
 - `Variant`
 - `Co-brand`
 - `Expiry date`
 - `Card summary`
-
 
 After choosing these settings, you will have the following fields set on your `TransactionItem` metadata:
 
@@ -147,6 +153,7 @@ subscription {
 All payment methods that have "separate capture" feature available (to check availability, refer to [Adyen docs](https://docs.adyen.com/payment-methods/) and look for methods with "Separate captures" listed in the features) are impacted by capture delay setting in merchant account.
 
 Capture is a transfer of previously locked funds to the merchant. In Adyen, you can either:
+
 - capture funds immediately after authorization: `captureDelay: immediate`
 - delay it for a certain period of time: `captureDelay: x hours`
 - disable automatic capture and always do it manually: `captureDelay: manual`

--- a/docs/developer/app-store/apps/adyen/configuration.mdx
+++ b/docs/developer/app-store/apps/adyen/configuration.mdx
@@ -25,6 +25,7 @@ In **Server settings -> Authentication** section generate a new API key.
 In **Client settings -> Authentication** section generate a new client key.
 
 :::caution
+
 The API Key provided inside the configuration must have the following permissions set in the Adyen Dashboard:
 
 - "Management API - Accounts read and write"
@@ -36,6 +37,7 @@ The API Key provided inside the configuration must have the following permission
 - "Merchant Recurring role"
 - "Checkout webservice role"
 - "Merchant PAL Webservice role"
+
 :::
 
 Go back to the Adyen app configuration in the Saleor Dashboard. Provide a configuration name that you will be familiar with. In the **API Key** field provide the key from **Server settings -> Authentication** section. Select **TEST** environment.
@@ -57,6 +59,7 @@ Before you begin configuration, make sure that you have disabled the **Delayed C
 :::
 
 In the Adyen dashboard, first go to **Developers -> Additional data**. Click on the following checkboxes:
+
 - `Card summary`
 - `Expiry date`
 - `Subvariant`
@@ -72,20 +75,20 @@ Your "Response preview" should look like this:
 
 ```json
 {
-    "additionalData": {
-        "cardSummary": "1111",
-        "expiryDate": "8/2018",
-        "paymentMethodVariant": "visadebit",
-        "paymentMethod": "visa",
-        "coBrandedWith": "visa",
-        "bankSummary": "1111",
-        "authorisedAmountCurrency": "EUR",
-        "authorisedAmountValue": "1000",
-        "recurring.contractTypes": "RECURRING,ONECLICK",
-        "recurring.recurringDetailReference": "111111",
-        "recurring.firstPspReference": "111111",
-        "merchantReference": "ref_1234"
-    }
+  "additionalData": {
+    "cardSummary": "1111",
+    "expiryDate": "8/2018",
+    "paymentMethodVariant": "visadebit",
+    "paymentMethod": "visa",
+    "coBrandedWith": "visa",
+    "bankSummary": "1111",
+    "authorisedAmountCurrency": "EUR",
+    "authorisedAmountValue": "1000",
+    "recurring.contractTypes": "RECURRING,ONECLICK",
+    "recurring.recurringDetailReference": "111111",
+    "recurring.firstPspReference": "111111",
+    "merchantReference": "ref_1234"
+  }
 }
 ```
 
@@ -98,22 +101,27 @@ To configure additional fields that will be set when users make payments, go to 
 :::
 
 :::warning
+
 Setting following fields is required for app to send `TransactionItem.paymentMethodDetails`:
+
 - `Card summary`
 - `Expiry date`
 - `Subvariant`
 - `Variant`
 - `Co-brand`
 - `Bank summary`
+
 :::
 
 :::danger
+
 Setting following fields is required for app **to properly process payments**:
+
 - `Authorization amount`
 - `Authorisation amount (dynamic zero authorisation)`
 - `Merchant reference`
-:::
 
+:::
 
 #### Configuring the webhook
 
@@ -131,6 +139,7 @@ In **Events**, make sure that you have selected the following events:
 
 :::tip
 For quick configuration you can just follow these steps:
+
 - deselect events:
   - `ORDER_OPENED`
   - `AUTORESCUE`
@@ -176,9 +185,11 @@ Note that Adyen might add new webhook events or change default selection in the 
 - `VOID_PENDING_REFUND`
 
 In **Additional settings -> Card** select:
+
 - `Include card info for recurring contract events`
 
 In **Additional settings -> Payment** select:
+
 - `Include a success boolean for the payments listed in an ORDER_CLOSED event`
 - `Include Authorised Amount (dynamic zero auth)`
 - `Include Capture Delay Hours`
@@ -187,6 +198,7 @@ In **Additional settings -> Payment** select:
 - `Include zero auth flag`
 
 In **Additional settings -> Risk** select:
+
 - `Add capture reference to dispute event`
 - `Include the originalReference for CHARGEBACK_REVERSED events`
 

--- a/docs/developer/app-store/apps/adyen/migration-guides.mdx
+++ b/docs/developer/app-store/apps/adyen/migration-guides.mdx
@@ -115,10 +115,9 @@ App will now return null as amount if there is none present in Adyen webhook, an
 
 ## v1.1.0
 
-In this release we introduced a *client logs*. Now, some of the operations that are performed by the app (webhooks) will be stored and available to access via the Dashboard.
+In this release we introduced a _client logs_. Now, some of the operations that are performed by the app (webhooks) will be stored and available to access via the Dashboard.
 
 In the future, more events will be stored.
-
 
 ## v0.24.0 (September 2024)
 

--- a/docs/developer/app-store/apps/adyen/overview.mdx
+++ b/docs/developer/app-store/apps/adyen/overview.mdx
@@ -50,36 +50,38 @@ Notifications for payments made without using Adyen app will be ignored. This ha
 
 App supports following notification events from Adyen:
 
-  - [`Authorisation`](https://docs.adyen.com/api-explorer/Webhooks/1/post/AUTHORISATION)
-  - [`AuthorisationAdjustment`](https://docs.adyen.com/api-explorer/Webhooks/1/post/AUTHORISATION_ADJUSTMENT)
-  - [`Cancellation`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CANCELLATION)
-  - [`CancelOrRefund`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CANCEL_OR_REFUND)
-  - [`Capture`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CAPTURE)
-  - [`CaptureFailed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CAPTURE_FAILED)
-  - [`Expire`](https://docs.adyen.com/api-explorer/Webhooks/1/post/EXPIRE)
-  - [`OrderClosed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/ORDER_CLOSED)
-  - [`OfferClosed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/OFFER_CLOSED)
-  - [`Refund`](https://docs.adyen.com/api-explorer/Webhooks/1/post/REFUND)
-  - [`RefundFailed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/REFUND_FAILED)
-  - [`RefundedReversed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/REFUNDED_REVERSED)
-  - [`RefundWithData`](https://docs.adyen.com/api-explorer/Webhooks/1/post/REFUND_WITH_DATA)
-  - [`VoidPendingRefund`](https://docs.adyen.com/api-explorer/Webhooks/1/post/VOID_PENDING_REFUND)
-  - [`Chargeback`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CHARGEBACK)
-  - [`SecondChargeback`](https://docs.adyen.com/api-explorer/Webhooks/1/post/SECOND_CHARGEBACK)
-  - [`ChargebackReversed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CHARGEBACK_REVERSED)
+- [`Authorisation`](https://docs.adyen.com/api-explorer/Webhooks/1/post/AUTHORISATION)
+- [`AuthorisationAdjustment`](https://docs.adyen.com/api-explorer/Webhooks/1/post/AUTHORISATION_ADJUSTMENT)
+- [`Cancellation`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CANCELLATION)
+- [`CancelOrRefund`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CANCEL_OR_REFUND)
+- [`Capture`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CAPTURE)
+- [`CaptureFailed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CAPTURE_FAILED)
+- [`Expire`](https://docs.adyen.com/api-explorer/Webhooks/1/post/EXPIRE)
+- [`OrderClosed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/ORDER_CLOSED)
+- [`OfferClosed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/OFFER_CLOSED)
+- [`Refund`](https://docs.adyen.com/api-explorer/Webhooks/1/post/REFUND)
+- [`RefundFailed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/REFUND_FAILED)
+- [`RefundedReversed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/REFUNDED_REVERSED)
+- [`RefundWithData`](https://docs.adyen.com/api-explorer/Webhooks/1/post/REFUND_WITH_DATA)
+- [`VoidPendingRefund`](https://docs.adyen.com/api-explorer/Webhooks/1/post/VOID_PENDING_REFUND)
+- [`Chargeback`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CHARGEBACK)
+- [`SecondChargeback`](https://docs.adyen.com/api-explorer/Webhooks/1/post/SECOND_CHARGEBACK)
+- [`ChargebackReversed`](https://docs.adyen.com/api-explorer/Webhooks/1/post/CHARGEBACK_REVERSED)
 
 Following events will be mapped to `INFO` event in Saleor, it will not change amounts on `TransactionItem`:
-  - `HandledExternally`
-  - [`PostponedRefund`](https://docs.adyen.com/api-explorer/Webhooks/1/post/POSTPONED_REFUND)
-  - [`NotificationOfFraud`](https://docs.adyen.com/api-explorer/Webhooks/1/post/NOTIFICATION_OF_FRAUD)
-  - [`NotificationOfChargeback`](https://docs.adyen.com/api-explorer/Webhooks/1/post/NOTIFICATION_OF_CHARGEBACK)
-  - [`PrearbitrationLost`](https://docs.adyen.com/api-explorer/Webhooks/1/post/PREARBITRATION_LOST)
-  - [`PrearbitrationWon`](https://docs.adyen.com/api-explorer/Webhooks/1/post/PREARBITRATION_WON)
-  - [`RequestForInformation`](https://docs.adyen.com/api-explorer/Webhooks/1/post/REQUEST_FOR_INFORMATION)
-  - [`ManualReviewAccept`](https://docs.adyen.com/api-explorer/Webhooks/1/post/MANUAL_REVIEW_ACCEPT)
-  - [`ManualReviewReject`](https://docs.adyen.com/api-explorer/Webhooks/1/post/MANUAL_REVIEW_REJECT)
+
+- `HandledExternally`
+- [`PostponedRefund`](https://docs.adyen.com/api-explorer/Webhooks/1/post/POSTPONED_REFUND)
+- [`NotificationOfFraud`](https://docs.adyen.com/api-explorer/Webhooks/1/post/NOTIFICATION_OF_FRAUD)
+- [`NotificationOfChargeback`](https://docs.adyen.com/api-explorer/Webhooks/1/post/NOTIFICATION_OF_CHARGEBACK)
+- [`PrearbitrationLost`](https://docs.adyen.com/api-explorer/Webhooks/1/post/PREARBITRATION_LOST)
+- [`PrearbitrationWon`](https://docs.adyen.com/api-explorer/Webhooks/1/post/PREARBITRATION_WON)
+- [`RequestForInformation`](https://docs.adyen.com/api-explorer/Webhooks/1/post/REQUEST_FOR_INFORMATION)
+- [`ManualReviewAccept`](https://docs.adyen.com/api-explorer/Webhooks/1/post/MANUAL_REVIEW_ACCEPT)
+- [`ManualReviewReject`](https://docs.adyen.com/api-explorer/Webhooks/1/post/MANUAL_REVIEW_REJECT)
 
 These events are currently ignored by the app, left for future implementation:
+
 - [`RecurringContract`](https://docs.adyen.com/api-explorer/Webhooks/1/post/RECURRING_CONTRACT)
 
 ## Assumptions
@@ -118,6 +120,7 @@ Each payment in Adyen stores `channelId` in its metadata, in order to get proper
 If you change the channel to configuration mapping, all enqueued notifications (pending notifications from Adyen) that were related such channel will be not handled properly by the app, causing the request to fail.
 
 Before you change the configuration mapping, make sure that you do one of the following (listed in order of the least intrusive changes):
+
 - **Create new channel in Saleor** and create a new config so that you don't change mappings at all. This way you can gradually accept new orders on new merchant account and keep handling changes related to orders created on old merchant account.
 - **Use the same webhook settings** for the new configuration (HMAC key, username, password).
   - You can re-use old HMAC key in Adyen webhook, by choosing it from the list while creating the webhook.
@@ -144,6 +147,7 @@ Adyen payment -> Notification item -> Metadata channelId -> Channel x configurat
 ```
 
 When signature is invalid, it can mean either that:
+
 - You've changed HMAC key in your Adyen webhook settings, but didn't update it in app settings
 - You've changed HMAC key in your app configuration, but HMAC wasn't changed on Adyen side
 - You've changed a channel to configuration mapping in app, but new configuration has different HMAC key configured
@@ -161,6 +165,7 @@ If number of enqueued webhooks is too high for manual ignore, you can also creat
 #### Missing configuration for channel
 
 As described in [Invalid HMAC signature section](#invalid-hmac-signature-or-username-or-password) notifications are dependent on your channel to configuration mapping. If you do one of the following:
+
 - delete configuration that was assigned to a channel
 - unset channel to configuration mapping
 
@@ -175,10 +180,11 @@ Keep in mind that if you decide to create new configuration and use a new HMAC k
 If you use the same merchant account in Adyen for multiple purposes (e.g. multiple Saleor instances, subscription payments done by other app, in store POS payments) Adyen app might reject these notifications, which will impact delivery of other notifications that were meant for Adyen app.
 
 In order to prevent this from happening you should:
+
 - Treat merchant account used for Adyen app payments as dedicated only to the app, meaning if you want to process other payments, you will create new merchant accounts for any other use case
 - **Only if above cannot be done**: make sure that you do not include any metadata in Adyen payment that could be used to identify it as a Saleor payment. This way Adyen app will not be able to identify it as a Saleor payment and will not reject it. Here are some common fields that are used to identify Saleor payment:
-    - `metadata.channelId`
-    - `metadata.transactionId`
+  - `metadata.channelId`
+  - `metadata.transactionId`
 
 #### Changed `saleorApiUrl`
 
@@ -231,13 +237,17 @@ If you use a server-side proxy to make requests to Saleor on behalf of your cust
 
 If you use a proxy for making requests to Saleor on your customers' behalf, you need to specify the `customerIpAddress` field on your own in the `transactionInitialize` and `transactionProcess` mutation input:
 
-
 `transactionInitialize` mutation:
+
 ```graphql
-mutation TransactionInitialize($checkoutId: ID!, $data: JSON, $customerIpAddress: String!) {
+mutation TransactionInitialize(
+  $checkoutId: ID!
+  $data: JSON
+  $customerIpAddress: String!
+) {
   transactionInitialize(
     id: $checkoutId
-    paymentGateway: {id: "app.saleor.adyen", data: $data}
+    paymentGateway: { id: "app.saleor.adyen", data: $data }
     customerIpAddress: $customerIpAddress # <-- provide customer IP address in your proxy implementation
   ) {
     data
@@ -257,7 +267,11 @@ mutation TransactionInitialize($checkoutId: ID!, $data: JSON, $customerIpAddress
 `transactionProcess` mutation:
 
 ```graphql
-mutation TransactionProcess($transactionId: ID!, $data: JSON, $customerIpAddress: String!) {
+mutation TransactionProcess(
+  $transactionId: ID!
+  $data: JSON
+  $customerIpAddress: String!
+) {
   transactionProcess(
     id: $transactionId
     data: $data
@@ -298,6 +312,7 @@ The app does not process any Cardholder Data ([CHD](https://www.pcisecuritystand
 App stores logs (for 14 days) for debugging purposes. Logs are not used by Saleor employees, but are useful for staff users to debug transactional operations.
 
 Logs contain following data:
+
 - Saleor Checkout ID / Order ID
 - Saleor Transaction ID
 - Saleor Channel ID

--- a/docs/developer/app-store/apps/adyen/pci-dss.mdx
+++ b/docs/developer/app-store/apps/adyen/pci-dss.mdx
@@ -31,7 +31,7 @@ sequenceDiagram
     Adyen API ->> Adyen App: Provide non-sensitive payment data* and encrypted payment data**
     Adyen App ->> Saleor: Pass non-sensitive payment data* and encrypted payment data** from Adyen
     Saleor ->> Saleor database: Update transaction model (non sensitive)
-    Saleor ->> User via storefront: Pass through non-sensitive payment data* and encrypted payment data** 
+    Saleor ->> User via storefront: Pass through non-sensitive payment data* and encrypted payment data**
 
     rect rgba(240,150,150,0.5)
         note right of User via storefront: Sensitive Authentication Data (SAD) Flow
@@ -47,12 +47,11 @@ sequenceDiagram
     Adyen API ->> Adyen App: Provide non-sensitive payment data* and encrypted payment data**
     Adyen App ->> Saleor: Pass non-sensitive payment data* and encrypted payment data** from Adyen
     Saleor ->> Saleor database: Update transaction model (non sensitive)
-    Saleor ->> User via storefront: Pass through non-sensitive payment data* and encrypted payment data** 
+    Saleor ->> User via storefront: Pass through non-sensitive payment data* and encrypted payment data**
 ```
 
-*Passes non-PCI DSS regulated payment information, such as customer IP address, delivery address fields (street, city, state/province, postal code, country), additional data about freight amount, duty amount with total tax amount
+\*Passes non-PCI DSS regulated payment information, such as customer IP address, delivery address fields (street, city, state/province, postal code, country), additional data about freight amount, duty amount with total tax amount
 
-
-**Passes encrypted credit card number and other encrypted information (cardholder data and sensitive authentication data), the decryption key is only accessible by Adyen, data is impossible for Saleor to read.
+\*\*Passes encrypted credit card number and other encrypted information (cardholder data and sensitive authentication data), the decryption key is only accessible by Adyen, data is impossible for Saleor to read.
 
 For more information about Adyen PCI DSS compliance - see their [guide](https://docs.adyen.com/development-resources/pci-dss-compliance-guide/).

--- a/docs/developer/app-store/apps/adyen/storefront.mdx
+++ b/docs/developer/app-store/apps/adyen/storefront.mdx
@@ -511,6 +511,7 @@ To properly implement split payments, you need to correctly pass `amount` to the
 You should calculate what amount is left to pay to avoid overcharges.
 
 For example, take a checkout worth $300. You want to pay:
+
 - $100 with a custom payment method, like loyalty points (using custom gateway)
 - $100 with a gift card (using Adyen)
 - $100 with a credit card (using Adyen)
@@ -524,6 +525,7 @@ To proceed with Adyen split payment, you need to call `paymentGatewayInitialize`
 Last, you need to call `transactionInitializeSession` for the credit card - ensure you provide amount matching the remaining balance, not the checkout/order total, otherwise checkout will be overpaid.
 
 For `paymentGatewayInitialize` Adyen App will:
+
 - Take `amount` field if provided
 - If not, will take `checkout.gross.amount` (or order) as a fallback
 
@@ -561,7 +563,6 @@ The response from that mutation will be:
   }
 }
 ```
-
 
 #### Example
 
@@ -693,12 +694,8 @@ In that case a single `InvalidDataError` error will be included in `errors` arra
               "details": {
                 "formErrors": [],
                 "fieldErrors": {
-                  "orderData": [
-                    "Required"
-                  ],
-                  "pspReference": [
-                    "Required"
-                  ]
+                  "orderData": ["Required"],
+                  "pspReference": ["Required"]
                 }
               }
             }
@@ -715,7 +712,7 @@ In that case a single `InvalidDataError` error will be included in `errors` arra
 
 You may have use cases where you want to create free orders, such as free samples or free digital downloads. This may require skipping the payment step and completing the order without a transaction.
 
-Adyen Drop-in integration does not support handling payments with a total amount of zero. Amount: 0, has a specific meaning in [Adyen](https://docs.adyen.com/get-started-with-adyen/payment-glossary/#zero-value-auth) - it allows payment method tokenization or to obtain other details from the merchant database. 
+Adyen Drop-in integration does not support handling payments with a total amount of zero. Amount: 0, has a specific meaning in [Adyen](https://docs.adyen.com/get-started-with-adyen/payment-glossary/#zero-value-auth) - it allows payment method tokenization or to obtain other details from the merchant database.
 
 ## Storing user cards
 


### PR DESCRIPTION
Formats .mdx files inside the `docs/developer/app-store/apps/adyen/` folder to have a consistent style & help with readability. This changeset solely focuses on `./docs/developer/app-store/apps/adyen/`, other follow-up PRs will be opened for other directories.

This is part of the initiative from #1820.

Note: the folder `docs/developer/**` has a lot of files and lot of unformatted `.mdx` files hence it will be reformatted through many PRs (will require more or less 14 PRs as there are 145 files left to format while aiming for ~10 files per PR)


## Checklist

- [x] I have read and followed the [guidelines](../GUIDELINES.md)
