### PR TITLE
Document product visibility and purchase availability

### DIFF
--- a/docs/developer/products/api.mdx
+++ b/docs/developer/products/api.mdx
@@ -16,10 +16,10 @@ You can either retrieve a single product or a list of products. You may require 
 Customers can only fetch products from available channels. Because listing channels is only available for staff users, you will need to provide channel slugs to your storefront.
 Besides availability, you can define more parameters on a channel basis using [`ProductChannelListing`](/api-reference/products/objects/product-channel-listing.mdx):
 
-- `publicationDate`
+- `publishedAt`
 - `isPublished`
 - `visibleInListings`
-- `availableForPurchase`
+- `availableForPurchaseAt`
 - `isAvailableForPurchase`
 
 For variants, there's [`ProductVariantChannelListing`](/api-reference/products/objects/product-variant-channel-listing.mdx):
@@ -29,6 +29,19 @@ For variants, there's [`ProductVariantChannelListing`](/api-reference/products/o
 - `margin`
 
 [Learn more about using multiple channels](/developer/channels/overview.mdx).
+
+### Product visibility and purchase availability
+
+Product visibility and purchase availability are configured separately for each channel.
+For storefront users without product permissions, the channel listing fields have the following effects:
+
+| Field | Storefront behavior |
+| --- | --- |
+| `isPublished` and `publishedAt` | Control whether customers can access the product in the channel. The product must be published, its publication time must have passed, and at least one variant must have a price in the channel. |
+| `visibleInListings` | Controls whether the product appears in the `products` query and product variant listings. When set to `false`, customers can still fetch a published product directly by ID or slug. This field does not prevent purchase. |
+| `availableForPurchaseAt` and `isAvailableForPurchase` | Control and report when the product can be purchased. A product can remain visible when `isAvailableForPurchase` is `false`, but customers cannot add it to a checkout. This status does not guarantee that stock is available. |
+
+Users and apps with the `MANAGE_PRODUCTS` permission can query products that are unpublished or hidden from listings. This permission changes product visibility in the API, but it does not override purchase availability in storefront checkouts.
 
 ## Retrieving a list of products
 


### PR DESCRIPTION
## Description

Explains how per-channel product settings affect storefront behavior:

- distinguishes publication, listing visibility, and purchase availability
- clarifies direct product access when `visibleInListings` is disabled
- documents the effect of the `MANAGE_PRODUCTS` permission
- replaces deprecated date field names in the field summary

Closes #884

## Verification

- verified the documented behavior against the current Saleor Core resolvers, models, checkout validation, and tests
- confirmed the MDX file parses successfully with Prettier

## Checklist

- [x] I have read and followed the [guidelines](../GUIDELINES.md)